### PR TITLE
Fix parsing of Mapping rename_only field.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20210908184532-d51651c5f02d // indirect
-	github.com/refractionPOINT/go-uspclient v0.0.0-20211104034151-c680065b4371
+	github.com/refractionPOINT/go-uspclient v0.0.0-20211110003224-12b2b5856cd9
 	github.com/rs/zerolog v1.25.0 // indirect
 	golang.org/x/net v0.0.0-20211011170408-caeb26a5c8c0 // indirect
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20210901012122-480388145bf4/go.mod h1:5mF9lmWN1FdIcr6x9isB/09Ch76txHQF+KAOrgTJo8s=
 github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20210908184532-d51651c5f02d h1:AGgrdxrS7s9vKJ9vRriichizQNsUm97PfyNN/esNQtM=
 github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20210908184532-d51651c5f02d/go.mod h1:5mF9lmWN1FdIcr6x9isB/09Ch76txHQF+KAOrgTJo8s=
-github.com/refractionPOINT/go-uspclient v0.0.0-20211104034151-c680065b4371 h1:alg8OupgrYFn/+ii90Wbe+4ea7e1jCMUjSMof1axEa4=
-github.com/refractionPOINT/go-uspclient v0.0.0-20211104034151-c680065b4371/go.mod h1:vGJoESXbXW5pMznB8puMP2sbhE8D+7YgSW58Tov8RXI=
+github.com/refractionPOINT/go-uspclient v0.0.0-20211110003224-12b2b5856cd9 h1:5D9hZWKSa++8BHu1cFAygyZ7HX8UD1u9XglvL/y8o4Y=
+github.com/refractionPOINT/go-uspclient v0.0.0-20211110003224-12b2b5856cd9/go.mod h1:vGJoESXbXW5pMznB8puMP2sbhE8D+7YgSW58Tov8RXI=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=

--- a/utils/env_parse_test.go
+++ b/utils/env_parse_test.go
@@ -2,13 +2,16 @@ package utils
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 )
 
 type testStruct1 struct {
 	A1 string      `json:"a1"`
 	A2 testStruct2 `json:"b"`
+	A3 bool        `json:"a3"`
 }
+type tmpTestStruct1 testStruct1
 
 type testStruct2 struct {
 	B1 string        `json:"b1"`
@@ -19,6 +22,31 @@ type testStruct2 struct {
 type testStruct3 struct {
 	C1 string `json:"c1"`
 	C2 string `json:"c2"`
+}
+
+// Demonstrating the use of a custom Unmarshaler
+// to support string versions of bools.
+func (ts *testStruct1) UnmarshalJSON(dat []byte) error {
+	d := map[string]interface{}{}
+	if err := json.Unmarshal(dat, &d); err != nil {
+		return err
+	}
+	var err error
+	if a3, ok := d["a3"]; ok {
+		if d["a3"], err = strconv.ParseBool(a3.(string)); err != nil {
+			return err
+		}
+	}
+	t, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+	tts := tmpTestStruct1{}
+	if err := json.Unmarshal(t, &tts); err != nil {
+		return err
+	}
+	*ts = testStruct1(tts)
+	return nil
 }
 
 func TestParseCLI(t *testing.T) {
@@ -38,6 +66,7 @@ func TestParseCLI(t *testing.T) {
 				},
 			},
 		},
+		A3: true,
 	}
 	testData := []string{
 		"a1=aaa",
@@ -47,6 +76,7 @@ func TestParseCLI(t *testing.T) {
 		"b.b3[0].c2=ttt",
 		"b.b3[1].c1=yyy",
 		"b.b3[1].c2=ooo",
+		"a3=true",
 	}
 	actualData := testStruct1{}
 


### PR DESCRIPTION
## Description of the change

Fix the parsing of the rename_only field from CLI and Env.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
