### PR TITLE
Fix the parsing of the bool flag is_usp.

### DIFF
--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -141,7 +141,7 @@ func main() {
 	configs.PubSub.ClientOptions.BufferOptions.OnBackPressure = func() {
 		log("experiencing back pressure")
 	}
-	configs.Syslog.ClientOptions.BufferOptions.OnAck = func() {
+	configs.PubSub.ClientOptions.BufferOptions.OnAck = func() {
 		log("received data ack from limacharlie")
 	}
 
@@ -153,9 +153,6 @@ func main() {
 	configs.S3.ClientOptions.BufferOptions.OnBackPressure = func() {
 		log("experiencing back pressure")
 	}
-	configs.Syslog.ClientOptions.BufferOptions.OnAck = func() {
-		log("received data ack from limacharlie")
-	}
 
 	// Stdin
 	configs.Stdin.ClientOptions.DebugLog = func(msg string) {
@@ -165,7 +162,7 @@ func main() {
 	configs.Stdin.ClientOptions.BufferOptions.OnBackPressure = func() {
 		log("experiencing back pressure")
 	}
-	configs.Syslog.ClientOptions.BufferOptions.OnAck = func() {
+	configs.Stdin.ClientOptions.BufferOptions.OnAck = func() {
 		log("received data ack from limacharlie")
 	}
 


### PR DESCRIPTION
## Description of the change

The is_usp flag is bool so it needs a small compat layer to be parsable from the CLI.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


