### PR TITLE
Prevent error print on normal close.

### DIFF
--- a/azure_event_hub/client.go
+++ b/azure_event_hub/client.go
@@ -82,7 +82,7 @@ func NewEventHubAdapter(conf EventHubConfig) (*EventHubAdapter, chan struct{}, e
 			ch := h.Done()
 			<-ch
 			if err := h.Err(); err != nil && !errors.Is(err, context.Canceled) {
-				a.conf.ClientOptions.OnError(fmt.Errorf("ListenerHandle.Err(): %v", h.Err()))
+				a.conf.ClientOptions.OnError(fmt.Errorf("ListenerHandle.Err(): %v", err))
 			}
 			a.chStopped <- struct{}{}
 		}(listenerHandle)


### PR DESCRIPTION
## Description of the change

Don't emit an error on normal context cancel (stopping) for Azure Event Hub.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

