### PR TITLE
Simulator with timing replay.

### DIFF
--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -20,6 +20,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/o365"
 	"github.com/refractionPOINT/usp-adapters/pubsub"
 	"github.com/refractionPOINT/usp-adapters/s3"
+	"github.com/refractionPOINT/usp-adapters/simulator"
 	"github.com/refractionPOINT/usp-adapters/slack"
 	"github.com/refractionPOINT/usp-adapters/sqs"
 	"github.com/refractionPOINT/usp-adapters/stdin"
@@ -53,6 +54,7 @@ type GeneralConfigs struct {
 	Gcs           usp_gcs.GCSConfig                  `json:"gcs" yaml:"gcs"`
 	Slack         usp_slack.SlackConfig              `json:"slack" yaml:"slack"`
 	Sqs           usp_sqs.SQSConfig                  `json:"sqs" yaml:"sqs"`
+	Simulator     usp_simulator.SimulatorConfig      `json:"simulator" yaml:"simulator"`
 }
 
 type AdapterStats struct {
@@ -240,6 +242,11 @@ func main() {
 		configs.Sqs.ClientOptions.Architecture = "usp_adapter"
 		printConfig(adapterType, configs.Sqs)
 		client, chRunning, err = usp_sqs.NewSQSAdapter(configs.Sqs)
+	} else if adapterType == "simulator" {
+		configs.Simulator.ClientOptions = applyLogging(configs.Simulator.ClientOptions)
+		configs.Simulator.ClientOptions.Architecture = "usp_adapter"
+		printConfig(adapterType, configs.Simulator)
+		client, chRunning, err = usp_simulator.NewSimulatorAdapter(configs.Simulator)
 	} else {
 		logError("unknown adapter_type: %s", adapterType)
 		os.Exit(1)

--- a/simulator/client.go
+++ b/simulator/client.go
@@ -1,0 +1,164 @@
+package usp_simulator
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	defaultWriteTimeout = 60 * 10
+)
+
+type SimulatorAdapter struct {
+	conf         SimulatorConfig
+	wg           sync.WaitGroup
+	isRunning    uint32
+	uspClient    *uspclient.Client
+	writeTimeout time.Duration
+	dataReader   io.ReadCloser
+
+	lastEventTime int64
+	lastSentTime  int64
+}
+
+type SimulatorConfig struct {
+	ClientOptions  uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+	Reader         io.ReadCloser           `json:"-" yaml:"-"`
+	FilePath       string                  `json:"file_path" yaml:"file_path"`
+	IsReplayTiming bool                    `json:"is_replay_timing" yaml:"is_replay_timing"`
+}
+
+type basicLCEvent struct {
+	Routing struct {
+		EventTime int64 `json:"event_time"`
+	} `json:"routing"`
+}
+
+func (c *SimulatorConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+	return nil
+}
+
+func NewSimulatorAdapter(conf SimulatorConfig) (*SimulatorAdapter, chan struct{}, error) {
+	a := &SimulatorAdapter{
+		conf:      conf,
+		isRunning: 1,
+	}
+
+	a.writeTimeout = defaultWriteTimeout
+
+	if conf.FilePath != "" {
+		f, err := os.Open(conf.FilePath)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.dataReader = f
+	}
+
+	var err error
+	a.uspClient, err = uspclient.NewClient(conf.ClientOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	chStopped := make(chan struct{})
+	a.wg.Add(1)
+	go func() {
+		defer a.wg.Done()
+		defer close(chStopped)
+		a.handleInput()
+	}()
+
+	return a, chStopped, nil
+}
+
+func (a *SimulatorAdapter) Close() error {
+	a.conf.ClientOptions.DebugLog("closing")
+	atomic.StoreUint32(&a.isRunning, 0)
+	a.dataReader.Close()
+	err1 := a.uspClient.Drain(1 * time.Minute)
+	_, err2 := a.uspClient.Close()
+
+	if err1 != nil {
+		return err1
+	}
+
+	return err2
+}
+
+func (a *SimulatorAdapter) handleInput() {
+	readBufferSize := 1024 * 16
+	st := utils.StreamTokenizer{
+		ExpectedSize: readBufferSize * 2,
+		Token:        0x0a,
+	}
+
+	readBuffer := make([]byte, readBufferSize)
+	for atomic.LoadUint32(&a.isRunning) == 1 {
+		sizeRead, err := a.dataReader.Read(readBuffer[:])
+		if err != nil {
+			if err != io.EOF {
+				a.conf.ClientOptions.OnError(fmt.Errorf("os.File.Read(): %v", err))
+			}
+			return
+		}
+
+		data := readBuffer[:sizeRead]
+
+		chunks, err := st.Add(data)
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("tokenizer: %v", err))
+		}
+		for _, chunk := range chunks {
+			a.handleLine(chunk)
+		}
+	}
+}
+
+func (a *SimulatorAdapter) handleLine(line []byte) {
+	if len(line) == 0 {
+		return
+	}
+
+	// If Replay Timing is enabled, parse the line
+	// and look at replaying it based on the routing.
+	if a.conf.IsReplayTiming {
+		evt := basicLCEvent{}
+		if err := json.Unmarshal(line, &evt); err == nil {
+			if a.lastEventTime <= evt.Routing.EventTime {
+				evtDelta := evt.Routing.EventTime - a.lastEventTime
+				now := time.Now().UnixMilli()
+				clockDelta := now - a.lastSentTime
+				if clockDelta < evtDelta {
+					time.Sleep(time.Duration(evtDelta-clockDelta) * time.Millisecond)
+				}
+				a.lastEventTime = evt.Routing.EventTime
+				a.lastSentTime = now
+			}
+		}
+	}
+
+	msg := &protocol.DataMessage{
+		TextPayload: string(line),
+		TimestampMs: uint64(time.Now().UnixNano() / int64(time.Millisecond)),
+	}
+	err := a.uspClient.Ship(msg, a.writeTimeout)
+	if err == uspclient.ErrorBufferFull {
+		a.conf.ClientOptions.OnWarning("stream falling behind")
+		err = a.uspClient.Ship(msg, 0)
+	}
+	if err != nil {
+		a.conf.ClientOptions.OnError(fmt.Errorf("Ship(): %v", err))
+	}
+}


### PR DESCRIPTION
## Description of the change

This is the draft for the mechanical component of USP Adapters to eventually run Demo Sensors.
It will replay a flat file of JSON LC traffic via USP, optionally respecting the timing of events (to replay in real-time).

This will need to be coupled with a parser in the Endpoint or USP-Proxy that will normalize the inbound LC events into mostly-similar LC events (just changing OIDs and stuff like that).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
