### PR TITLE
Ensure adapter stop on partial failure.

### DIFF
--- a/o365/client.go
+++ b/o365/client.go
@@ -197,7 +197,7 @@ func (a *Office365Adapter) fetchEvents(url string) {
 
 	nextPage := ""
 	isFirstRun := true
-	for isFirstRun || nextPage != "" || !a.doStop.WaitFor(5*time.Minute) {
+	for isFirstRun || (nextPage != "" && !a.doStop.IsSet()) || !a.doStop.WaitFor(5*time.Minute) {
 		if nextPage == "" {
 			now := time.Now().UTC()
 			start := a.conf.StartTime


### PR DESCRIPTION
## Description of the change

Fix bug in o365 where a partial failure could result in a stop() that never ended because the other fetches still had data. It's a logic that works for other single-threaded adapters that do not have never-ending cursors but not here.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
