### PR TITLE
O365 collection should start Now().

### DIFF
--- a/o365/client.go
+++ b/o365/client.go
@@ -202,7 +202,7 @@ func (a *Office365Adapter) fetchEvents(url string) {
 			now := time.Now().UTC()
 			start := a.conf.StartTime
 			if !isFirstRun || start == "" {
-				start = now.Add(-3 * time.Hour).Format("2006-01-02T15:04:05")
+				start = now.Format("2006-01-02T15:04:05")
 			}
 			end := now.Format("2006-01-02T15:04:05")
 			nextPage = fmt.Sprintf("%s&startTime=%s&endTime=%s", url, start, end)


### PR DESCRIPTION
## Description of the change

Start collection of o365 at Now() to avoid a restarting adapter having overlap.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


