### PR TITLE
Switch builder container that changes GLIBC dep.

### DIFF
--- a/containers/general/Dockerfile
+++ b/containers/general/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS builder
+FROM golang:1.20-bullseye AS builder
 
 ADD . .
 ENV GOPATH=/


### PR DESCRIPTION
## Description of the change

The base golang for 1.20 changed its parent container and it introduced a specific GLIBC dep we don't want.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

