### PR TITLE
Simplify o365 deduping.

### DIFF
--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -352,7 +352,7 @@ func parseConfigs(args []string) (string, *RuntimeConfig, *GeneralConfigs, error
 func parseConfigsFromFile(filePath string) (*RuntimeConfig, *GeneralConfigs, error) {
 	runtimeConfigs := &RuntimeConfig{}
 	configs := &GeneralConfigs{}
-	
+
 	f, err := os.Open(filePath)
 	if err != nil {
 		printUsage()


### PR DESCRIPTION
## Description of the change

Although I cannot find confirmation of the following in the O365 API documentation, it looks like the ContentID of the bundles represents an immutable set of events.

This allows us to massively simplify the deduping, greatly reducing the memory footprint.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
