### PR TITLE
Fix case where o365 dedupe could reset across 3 windows.

### DIFF
--- a/o365/client.go
+++ b/o365/client.go
@@ -225,6 +225,7 @@ func (a *Office365Adapter) fetchEvents(url string) {
 		for _, item := range items {
 			if _, ok := contentSeen[item.ContentID]; ok {
 				nSkipped++
+				newContentSeen[item.ContentID] = struct{}{}
 				continue
 			}
 			if _, ok := newContentSeen[item.ContentID]; ok {
@@ -248,6 +249,7 @@ func (a *Office365Adapter) fetchEvents(url string) {
 				if ID != "" {
 					if _, ok := contentSeen[ID]; ok {
 						nSkipped++
+						newContentSeen[ID] = struct{}{}
 						return true
 					}
 					if _, ok := newContentSeen[ID]; ok {


### PR DESCRIPTION
## Description of the change

I think this is the last case where we could not ignore duped events.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
