### PR TITLE
Deduping api

### DIFF
--- a/utils/deduping.go
+++ b/utils/deduping.go
@@ -12,13 +12,13 @@ type Deduper interface {
 }
 
 type localDeduper struct {
-	window time.Duration
-	ttl time.Duration
+	window   time.Duration
+	ttl      time.Duration
 	nBuckets int
 	nCurrent int
 
 	stopEvt *Event
-	m sync.Mutex
+	m       sync.Mutex
 	windows []map[string]struct{}
 }
 
@@ -35,12 +35,12 @@ func NewLocalDeduper(window time.Duration, ttl time.Duration) (Deduper, error) {
 	windows[nCurrent] = make(map[string]struct{})
 
 	d := &localDeduper{
-		window: window,
-		ttl: ttl,
+		window:   window,
+		ttl:      ttl,
 		nBuckets: nBuckets,
 		nCurrent: nCurrent,
-		stopEvt: NewEvent(),
-		windows: windows,
+		stopEvt:  NewEvent(),
+		windows:  windows,
 	}
 
 	go func() {

--- a/utils/deduping.go
+++ b/utils/deduping.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+type Deduper interface {
+	CheckAndAdd(key string) (alreadyExists bool)
+	Close()
+}
+
+type localDeduper struct {
+	window time.Duration
+	ttl time.Duration
+	nBuckets int
+	nCurrent int
+
+	stopEvt *Event
+	m sync.Mutex
+	windows []map[string]struct{}
+}
+
+func NewLocalDeduper(window time.Duration, ttl time.Duration) (Deduper, error) {
+	if window > ttl {
+		return nil, errors.New("window is larger than ttl")
+	}
+	nBuckets := int(ttl / window)
+	if nBuckets < 1 {
+		nBuckets = 1
+	}
+	nCurrent := 0
+	windows := make([]map[string]struct{}, nBuckets)
+	windows[nCurrent] = make(map[string]struct{})
+
+	d := &localDeduper{
+		window: window,
+		ttl: ttl,
+		nBuckets: nBuckets,
+		nCurrent: nCurrent,
+		stopEvt: NewEvent(),
+		windows: windows,
+	}
+
+	go func() {
+		for !d.stopEvt.WaitFor(d.window) {
+			d.m.Lock()
+			d.nCurrent++
+			if d.nCurrent >= d.nBuckets {
+				d.nCurrent = 0
+			}
+			d.windows[d.nCurrent] = make(map[string]struct{})
+			d.m.Unlock()
+		}
+	}()
+
+	return d, nil
+}
+
+func (d *localDeduper) CheckAndAdd(key string) bool {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	// Check all the buckets for the key.
+	for i := 0; i < d.nBuckets; i++ {
+		if len(d.windows[i]) == 0 {
+			continue
+		}
+		if _, ok := d.windows[i][key]; ok {
+			return true
+		}
+	}
+
+	// Add the key to the current bucket.
+	d.windows[d.nCurrent][key] = struct{}{}
+
+	return false
+}
+
+func (d *localDeduper) Close() {
+	d.stopEvt.Set()
+}

--- a/utils/deduping_test.go
+++ b/utils/deduping_test.go
@@ -26,7 +26,7 @@ func TestLocalDeduper_CheckAndAdd(t *testing.T) {
 	if !d.CheckAndAdd("key2") {
 		t.Error("key1 should exist")
 	}
-	time.Sleep(ttl+time.Second)
+	time.Sleep(ttl + time.Second)
 	if d.CheckAndAdd("key1") {
 		t.Error("key1 should not exist after ttl")
 	}

--- a/utils/deduping_test.go
+++ b/utils/deduping_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLocalDeduper_CheckAndAdd(t *testing.T) {
+	window := 100 * time.Millisecond
+	ttl := 500 * time.Millisecond
+
+	d, err := NewLocalDeduper(window, ttl)
+	if err != nil {
+		t.Fatalf("error creating deduper: %v", err)
+	}
+
+	if d.CheckAndAdd("key1") {
+		t.Error("key1 should not exist")
+	}
+	if !d.CheckAndAdd("key1") {
+		t.Error("key1 should exist")
+	}
+	if d.CheckAndAdd("key2") {
+		t.Error("key2 should not exist")
+	}
+	if !d.CheckAndAdd("key2") {
+		t.Error("key1 should exist")
+	}
+	time.Sleep(ttl+time.Second)
+	if d.CheckAndAdd("key1") {
+		t.Error("key1 should not exist after ttl")
+	}
+	if d.CheckAndAdd("key2") {
+		t.Error("key1 should exist after ttl")
+	}
+	if d.CheckAndAdd("key3") {
+		t.Error("key3 should not exist")
+	}
+
+	d.Close()
+}


### PR DESCRIPTION
## Description of the change

Crreating a new interface for deduping and using it in O365. The new interface has a localDeduper built-in that will be used by default, but since it's an interface we will be able to plug in more thorough global deduping mechanisms in the cloud.

The interface takes a single string key to dedupe, it does NOT need to include some kind of partition (like an OID) since it is received per Adapter instance which is already single-tenant.

It uses a CheckAndAdd function so that the check-and-add-if-not-duplicate can be done atomically without further synchronization.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

