### PR TITLE
Handle odd IMAP response.

### DIFF
--- a/imap/client.go
+++ b/imap/client.go
@@ -251,6 +251,12 @@ func (a *IMAPAdapter) handleConnection() {
 					continue
 				default:
 				}
+				// Sometimes the server returns an old out of bounds UID for some reason, so
+				// just ignore those cases.
+				if msg.Uid < lastUID {
+
+					continue
+				}
 				if err := a.processEvent(a.ctx, msg); err != nil {
 					a.conf.ClientOptions.OnError(fmt.Errorf("processEvent(): %v", err))
 					hadError = true

--- a/imap/client.go
+++ b/imap/client.go
@@ -253,7 +253,7 @@ func (a *IMAPAdapter) handleConnection() {
 				}
 				// Sometimes the server returns an old out of bounds UID for some reason, so
 				// just ignore those cases.
-				if msg.Uid < lastUID {
+				if msg.Uid <= lastUID {
 
 					continue
 				}


### PR DESCRIPTION
## Description of the change

Apparently some IMAP servers have race conditions and odd caching issues that can result in UIDs being returned even though they were out of the query bounds. We're seeing that with gmail. We can only skip those messages for now.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

