### PR TITLE
s/createdDateTime/activityDateTime

### DIFF
--- a/entraid/client.go
+++ b/entraid/client.go
@@ -268,13 +268,13 @@ func (a *EntraIDAdapter) makeOneListRequest(eventsUrl string, since string, last
 			eventId = id
 
 			if id != lastEventId {
-				createdDateTime, ok := detectMap["createdDateTime"].(string)
+				activityDateTime, ok := detectMap["activityDateTime"].(string)
 				if !ok {
-					a.conf.ClientOptions.DebugLog("Error parsing createdDateTime from detectMap JSON")
+					a.conf.ClientOptions.DebugLog("Error parsing activityDateTime from detectMap JSON")
 					continue
 				}
 
-				lastDetectionTime = createdDateTime
+				lastDetectionTime = activityDateTime
 				alerts = append(alerts, detectMap)
 
 			}


### PR DESCRIPTION
## Description of the change

s/createdDateTime/activityDateTime -- data coming back from MS API has a field rename which wasn't allowing detections to be parsed/ingested

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
