### PR TITLE
add a new option to backfill data seeking information from the beginning of the file

### DIFF
--- a/file/client.go
+++ b/file/client.go
@@ -169,12 +169,17 @@ func (a *FileAdapter) pollFiles() {
 					continue
 				}
 
+				location := &tail.SeekInfo{Offset: 0, Whence: io.SeekEnd} // start to ingest at the end for new files
+				if a.conf.Backfill {
+					location = &tail.SeekInfo{Offset: 0, Whence: io.SeekStart} // start to ingest at the beginning of files
+				}
+
 				t, err := tail.TailFile(match, tail.Config{
 					ReOpen:        !a.conf.NoFollow,
 					MustExist:     true,
 					Follow:        !a.conf.NoFollow,
 					CompleteLines: true,
-					Location:      &tail.SeekInfo{Offset: 0, Whence: io.SeekEnd}, // start to ingest at the end for new files
+					Location:      location,
 				})
 				if err != nil {
 					a.conf.ClientOptions.OnError(fmt.Errorf("tail error: %v", err))

--- a/file/conf.go
+++ b/file/conf.go
@@ -11,4 +11,5 @@ type FileConfig struct {
 	NoFollow              bool                    `json:"no_follow" yaml:"no_follow"`
 	InactivityThreshold   int                     `json:"inactivity_threshold" yaml:"inactivity_threshold"`
 	ReactivationThreshold int                     `json:"reactivation_threshold" yaml:"reactivation_threshold"`
+	Backfill              bool                    `json:"backfill" yaml:"backfill"`
 }


### PR DESCRIPTION
## Description of the change

Allow to configure if you're backfilling information to read from the beginning of the file

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix refractionPOINT/tracking#1
