### PR TITLE
Don't display config in windows service by default.

### DIFF
--- a/containers/general/win_service.go
+++ b/containers/general/win_service.go
@@ -152,7 +152,7 @@ func (m *serviceInstance) Execute(args []string, r <-chan svc.ChangeRequest, cha
 	chRunnings := make(chan struct{})
 	for _, config := range configsToRun {
 		log("starting adapter: %s", method)
-		client, chRunning, err := runAdapter(method, *config, true)
+		client, chRunning, err := runAdapter(method, *config, false)
 		if err != nil {
 			saveErrorOnDisk(logError("runAdapter(): %v", err))
 			return false, 1


### PR DESCRIPTION
## Description of the change

Don't show config to STDOUT by  default on windows service.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

