### PR TITLE
Fix Office 365 OAuth2 for GCC High and DoD environments

### DIFF
--- a/o365/client.go
+++ b/o365/client.go
@@ -329,13 +329,26 @@ func (a *Office365Adapter) updateBearerToken() error {
 		resourceScope = "https://manage.office.com"
 	}
 
-	conf := &clientcredentials.Config{
-		ClientID:     a.conf.ClientID,
-		ClientSecret: a.conf.ClientSecret,
-		TokenURL:     tokenURL,
-		EndpointParams: url.Values{
-			"resource": []string{resourceScope},
-		},
+	var conf *clientcredentials.Config
+	
+	// GCC High and DoD use v2.0 endpoints which require 'scope' parameter instead of 'resource'
+	if a.endpointType == "gcc-high-gov" || a.endpointType == "dod-gov" {
+		conf = &clientcredentials.Config{
+			ClientID:     a.conf.ClientID,
+			ClientSecret: a.conf.ClientSecret,
+			TokenURL:     tokenURL,
+			Scopes:       []string{resourceScope + "/.default"},
+		}
+	} else {
+		// Enterprise and regular GCC use v1.0 endpoints with 'resource' parameter
+		conf = &clientcredentials.Config{
+			ClientID:     a.conf.ClientID,
+			ClientSecret: a.conf.ClientSecret,
+			TokenURL:     tokenURL,
+			EndpointParams: url.Values{
+				"resource": []string{resourceScope},
+			},
+		}
 	}
 
 	a.httpClient = conf.Client(context.Background())


### PR DESCRIPTION
## Summary
- Fixes error for GCC High and DoD O365 adapter users
- Updates OAuth2 authentication to use correct parameters for v2.0 endpoints
- Maintains full backwards compatibility for Enterprise and regular GCC users

## Problem
The Office 365 adapter was using the `resource` parameter for all OAuth2 token requests. However, GCC High and DoD environments use v2.0 OAuth endpoints which require the `scope` parameter instead of `resource`. This was causing authentication failures with error: The 'resource' request parameter is not supported.`

## Solution
Added conditional logic in the `updateBearerToken()` function to:
- Use `scope` parameter with `/.default` suffix for GCC High/DoD (v2.0 endpoints)
- Continue using `resource` parameter for Enterprise/GCC (v1.0 endpoints)

## Test plan
- [ ] Test with existing Enterprise deployment - should continue working unchanged
- [ ] Test with existing GCC deployment - should continue working unchanged  
- [ ] Test with GCC High deployment - should now authenticate successfully
- [ ] Test with DoD deployment - should now authenticate successfully

🤖 Generated with [Claude Code](https://claude.ai/code)