### PR TITLE
feat: Add configurable NotBefore parameter to FalconCloud adapter

### DIFF
--- a/falconcloud/client.go
+++ b/falconcloud/client.go
@@ -29,6 +29,7 @@ type FalconCloudConfig struct {
 	ClientSecret    string                  `json:"client_secret" yaml:"client_secret"`
 	IsUsingOffset   bool                    `json:"is_using_offset" yaml:"is_using_offset"`
 	Offset          uint64                  `json:"offset" yaml:"offset"`
+	NotBefore       *time.Time              `json:"not_before,omitempty" yaml:"not_before,omitempty"`
 }
 
 func (c *FalconCloudConfig) Validate() error {
@@ -180,7 +181,12 @@ func (a *FalconCloudAdapter) handleStream(client *client.CrowdStrikeAPISpecifica
 	if a.conf.IsUsingOffset {
 		offset = a.conf.Offset
 	} else {
-		notBefore = time.Now()
+		// If NotBefore is configured, use it; otherwise use current time
+		if a.conf.NotBefore != nil && !a.conf.NotBefore.IsZero() {
+			notBefore = *a.conf.NotBefore
+		} else {
+			notBefore = time.Now()
+		}
 	}
 	streamHandle, err := falcon.NewStream(a.ctx, client, appName, streamInfo, offset)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds optional `NotBefore` timestamp configuration to FalconCloud adapter
- Prevents ingestion of old alerts when adapter starts fresh
- Addresses issue about historical detections being processed when adapter is first connected

## Problem
When the FalconCloud adapter starts fresh (without an offset) or when credentials are updated, it currently processes all events from the past 30 days due to CrowdStrike's API design. While the adapter filters these events by timestamp, it still has to consume the entire stream, and old alerts can be inadvertently ingested into SOAR systems.

## Solution
Added a configurable `not_before` parameter that allows users to specify a cutoff timestamp for historical events. When configured, the adapter will drop any events with timestamps before this cutoff, preventing old alerts from being processed.

### Configuration Example
```yaml
falconcloud:
  not_before: "2025-01-01T00:00:00Z"
  client_id: "xxx"
  client_secret: "xxx"
  # ... other config
```

## Changes
- Added `NotBefore` field to `FalconCloudConfig` struct with proper JSON/YAML tags
- Updated `handleStream` logic to use configured `NotBefore` value when `IsUsingOffset` is false
- Maintains full backward compatibility - defaults to current time if not configured

## Testing
- [x] Code compiles successfully
- [x] Existing functionality preserved (backward compatible)
- [ ] Manual testing with configured `NotBefore` parameter

🤖 Generated with [Claude Code](https://claude.ai/code)