### PR TITLE
falconcloud timestamp filter bug

### DIFF
--- a/falconcloud/client.go
+++ b/falconcloud/client.go
@@ -197,7 +197,7 @@ func (a *FalconCloudAdapter) handleStream(client *client.CrowdStrikeAPISpecifica
 			a.conf.ClientOptions.OnError(fmt.Errorf("stream error: %v", err))
 			return
 		case event := <-streamHandle.Events:
-			if !notBefore.IsZero() && !notBefore.After(time.UnixMilli(int64(event.Metadata.EventCreationTime))) {
+			if !notBefore.IsZero() && notBefore.After(time.UnixMilli(int64(event.Metadata.EventCreationTime))) {
 				// This is a very ugly hack for what is a bad API design.
 				// It implies we HAVE to consume the entire 30 days of events
 				// retained by Crowdstrike every time the adapter starts.


### PR DESCRIPTION
## FalconCloud Timestamp Filter Bug

> The not_before filtering logic contains an inverted condition that causes it to filter out events occurring after the specified timestamp rather than before it.
> The issue stems from the incorrect negation of the After() method:
> ```
> // Current (buggy) code
> if !notBefore.IsZero() && !notBefore.After(time.UnixMilli(int64(event.Metadata.EventCreationTime))) {
>    continue  // Skip this event
> }
> ```
>
> According to the Go documentation:
>
>> func (t Time) After(u Time) bool
>> After reports whether the time instant t is after u.
>
> Therefore, notBefore.After(EventCreationTime) returns true when notBefore is chronologically after EventCreationTime. > The negation !notBefore.After(EventCreationTime) evaluates to true when notBefore is before or equal to EventCreationTime.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
refractionPOINT/usp-adapters/#229