### PR TITLE
feat: add Check Point Harmony adapter

### DIFF
--- a/containers/conf/all.go
+++ b/containers/conf/all.go
@@ -16,6 +16,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/falconcloud"
 	"github.com/refractionPOINT/usp-adapters/file"
 	"github.com/refractionPOINT/usp-adapters/gcs"
+	"github.com/refractionPOINT/usp-adapters/harmony"
 	"github.com/refractionPOINT/usp-adapters/hubspot"
 	"github.com/refractionPOINT/usp-adapters/imap"
 	"github.com/refractionPOINT/usp-adapters/itglue"
@@ -77,6 +78,7 @@ type GeneralConfigs struct {
 	Imap              usp_imap.ImapConfig                             `json:"imap" yaml:"imap"`
 	HubSpot           usp_hubspot.HubSpotConfig                       `json:"hubspot" yaml:"hubspot"`
 	FalconCloud       usp_falconcloud.FalconCloudConfig               `json:"falconcloud" yaml:"falconcloud"`
+	Harmony           usp_harmony.HarmonyConfig                       `json:"harmony" yaml:"harmony"`
 	Mimecast          usp_mimecast.MimecastConfig                     `json:"mimecast" yaml:"mimecast"`
 	MsGraph           usp_ms_graph.MsGraphConfig                      `json:"ms_graph" yaml:"ms_graph"`
 	Zendesk           usp_zendesk.ZendeskConfig                       `json:"zendesk" yaml:"zendesk"`

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -30,6 +30,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/falconcloud"
 	"github.com/refractionPOINT/usp-adapters/file"
 	"github.com/refractionPOINT/usp-adapters/gcs"
+	"github.com/refractionPOINT/usp-adapters/harmony"
 	"github.com/refractionPOINT/usp-adapters/hubspot"
 	"github.com/refractionPOINT/usp-adapters/imap"
 	"github.com/refractionPOINT/usp-adapters/itglue"
@@ -441,6 +442,11 @@ func runAdapter(ctx context.Context, method string, configs Configuration, showC
 		configs.FalconCloud.ClientOptions.Architecture = "usp_adapter"
 		configToShow = configs.FalconCloud
 		client, chRunning, err = usp_falconcloud.NewFalconCloudAdapter(ctx, configs.FalconCloud)
+	} else if method == "harmony" {
+		configs.Harmony.ClientOptions = applyLogging(configs.Harmony.ClientOptions)
+		configs.Harmony.ClientOptions.Architecture = "usp_adapter"
+		configToShow = configs.Harmony
+		client, chRunning, err = usp_harmony.NewHarmonyAdapter(ctx, configs.Harmony)
 	} else if method == "mimecast" {
 		configs.Mimecast.ClientOptions = applyLogging(configs.Mimecast.ClientOptions)
 		configs.Mimecast.ClientOptions.Architecture = "usp_adapter"

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/Velocidex/pkcs7 v0.0.0-20230220112103-d4ed02e1862a // indirect
 	github.com/Velocidex/yaml/v2 v2.2.8 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
-	github.com/apache/thrift v0.23.0 // indirect
+	github.com/apache/thrift v0.17.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/apache/arrow/go/v15 v15.0.2 h1:60IliRbiyTWCWjERBCkO1W4Qun9svcYoZrSLcyOsMLE=
 github.com/apache/arrow/go/v15 v15.0.2/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
-github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
-github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
+github.com/apache/thrift v0.17.0 h1:cMd2aj52n+8VoAtvSvLn4kDC3aZ6IAkBuqWQ2IDu7wo=
+github.com/apache/thrift v0.17.0/go.mod h1:OLxhMRJxomX+1I/KUw03qoV3mMz16BwaKI+d4fPBx7Q=
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/harmony/client.go
+++ b/harmony/client.go
@@ -1,0 +1,776 @@
+package usp_harmony
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	defaultBaseURL = "https://cloudinfra-gw.portal.checkpoint.com"
+
+	authPath = "/auth/external"
+
+	// Infinity Events (Logs-as-a-Service) — unified event stream across Harmony products.
+	eventsQueryPath    = "/app/laas-logs-api/api/logs_query"
+	eventsRetrievePath = "/app/laas-logs-api/api/logs_query/retrieve"
+
+	// HEC API — Harmony Email & Collaboration entity / event APIs.
+	hecSearchEntityPath = "/app/hec-api/v1.0/search/query"
+
+	tokenRefreshSkew = 1 * time.Minute
+)
+
+// Defaults for the Infinity Events source.
+// Names must match the gateway exactly. The Email & Collaboration service uses
+// an ampersand, not the word "and" — using "and" makes the gateway reject the
+// query with "The provided Cloud Service is unknown".
+var defaultEventsCloudServices = []string{
+	"Harmony Endpoint",
+	"Harmony Email & Collaboration",
+	"Harmony Mobile",
+	"Harmony Connect",
+	"Harmony Browse",
+}
+
+const (
+	defaultEventsPollInterval     = 60 * time.Second
+	defaultEventsStatusPollEvery  = 5 * time.Second
+	defaultEventsStatusPollTotal  = 10 * time.Minute
+	defaultEventsInitialLookback  = 1 * time.Hour
+	defaultEventsEndLag           = 1 * time.Minute
+	defaultEventsPageLimit        = 100
+	defaultEventsPerCloudLimit    = 5000
+)
+
+// Defaults for the Restore Requests source.
+var defaultRestoreSaas = []string{"office365_emails", "google_mail"}
+
+var defaultRestoreSaasEntity = map[string]string{
+	"office365_emails": "office365_emails_email",
+	"google_mail":      "google_mail_email",
+}
+
+const (
+	defaultRestorePollInterval = 5 * time.Minute
+	defaultRestoreLookback     = 30 * 24 * time.Hour
+)
+
+// EventsConfig controls the Infinity Events / Logs-as-a-Service source. When
+// Enabled is false this source is skipped entirely.
+type EventsConfig struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
+
+	// CloudServices to pull events for. Each is queried independently.
+	// Examples: "Harmony Endpoint", "Harmony Email and Collaboration",
+	// "Harmony Mobile", "Harmony Connect", "Harmony Browse". Empty enables
+	// the full Harmony suite.
+	CloudServices []string `json:"cloud_services" yaml:"cloud_services"`
+
+	// Optional Infinity Events query filter applied to every cloud service.
+	Filter string `json:"filter" yaml:"filter"`
+
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+	PageLimit    int           `json:"page_limit" yaml:"page_limit"`
+	Limit        int           `json:"limit" yaml:"limit"`
+}
+
+// RestoreRequestsConfig controls polling of the HEC entity search API to
+// surface emails with pending or recently-decided restore requests.
+type RestoreRequestsConfig struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
+
+	// Saas platforms to query. Defaults to office365_emails + google_mail
+	// (the only two HEC currently supports for the restore-request flags).
+	Saas []string `json:"saas" yaml:"saas"`
+
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+
+	// How far back to search for restore-requested emails. Defaults to 30 days
+	// (typical quarantine retention window).
+	Lookback time.Duration `json:"lookback" yaml:"lookback"`
+}
+
+type HarmonyConfig struct {
+	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+	// Infinity Portal API credentials (Global Settings > API Keys).
+	// For Infinity Events the key must include the "Logs as a Service" service.
+	// For Restore Requests the key must include the Harmony Email & Collaboration service.
+	// One key with both services attached is fine.
+	ClientID  string `json:"client_id" yaml:"client_id"`
+	AccessKey string `json:"access_key" yaml:"access_key"`
+
+	// Base URL of the Infinity Portal gateway. Defaults to the global gateway
+	// "https://cloudinfra-gw.portal.checkpoint.com". Use the regional variant
+	// (e.g. "https://cloudinfra-gw-us.portal.checkpoint.com") if your tenant
+	// lives in a regional data center. Both /app/laas-logs-api and /app/hec-api
+	// share the same hostname per region.
+	URL string `json:"url" yaml:"url"`
+
+	Events          EventsConfig          `json:"events" yaml:"events"`
+	RestoreRequests RestoreRequestsConfig `json:"restore_requests" yaml:"restore_requests"`
+
+	// Deduper is used by the restore-request source to avoid re-emitting the
+	// same entity for the same state on every poll. Transitions are still
+	// emitted because the dedup key includes the entityUpdated timestamp.
+	Deduper utils.Deduper `json:"-" yaml:"-"`
+}
+
+func (c *HarmonyConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+	if c.ClientID == "" {
+		return errors.New("missing client_id")
+	}
+	if c.AccessKey == "" {
+		return errors.New("missing access_key")
+	}
+	if c.URL == "" {
+		c.URL = defaultBaseURL
+	}
+	c.URL = strings.TrimRight(c.URL, "/")
+
+	if !c.Events.Enabled && !c.RestoreRequests.Enabled {
+		return errors.New("at least one of events.enabled or restore_requests.enabled must be true")
+	}
+
+	if c.Events.Enabled {
+		if len(c.Events.CloudServices) == 0 {
+			c.Events.CloudServices = append([]string{}, defaultEventsCloudServices...)
+		}
+		if c.Events.PollInterval <= 0 {
+			c.Events.PollInterval = defaultEventsPollInterval
+		}
+		if c.Events.PageLimit <= 0 {
+			c.Events.PageLimit = defaultEventsPageLimit
+		}
+		if c.Events.PageLimit < 10 {
+			// Gateway rejects values below 10 with HTTP 400.
+			c.Events.PageLimit = 10
+		}
+		if c.Events.Limit <= 0 {
+			c.Events.Limit = defaultEventsPerCloudLimit
+		}
+		if c.Events.Limit < 10 {
+			c.Events.Limit = 10
+		}
+	}
+
+	if c.RestoreRequests.Enabled {
+		if len(c.RestoreRequests.Saas) == 0 {
+			c.RestoreRequests.Saas = append([]string{}, defaultRestoreSaas...)
+		}
+		for _, s := range c.RestoreRequests.Saas {
+			if _, ok := defaultRestoreSaasEntity[s]; !ok {
+				return fmt.Errorf("restore_requests.saas %q is not supported (only %v carry the restore flags)", s, defaultRestoreSaas)
+			}
+		}
+		if c.RestoreRequests.PollInterval <= 0 {
+			c.RestoreRequests.PollInterval = defaultRestorePollInterval
+		}
+		if c.RestoreRequests.Lookback <= 0 {
+			c.RestoreRequests.Lookback = defaultRestoreLookback
+		}
+	}
+
+	return nil
+}
+
+type HarmonyAdapter struct {
+	conf       HarmonyConfig
+	uspClient  *uspclient.Client
+	httpClient *http.Client
+
+	chStopped chan struct{}
+	wgSenders sync.WaitGroup
+	doStop    *utils.Event
+
+	tokenMu      sync.Mutex
+	cachedToken  string
+	tokenExpires time.Time
+
+	ctx context.Context
+}
+
+func NewHarmonyAdapter(ctx context.Context, conf HarmonyConfig) (*HarmonyAdapter, chan struct{}, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	if conf.Deduper == nil {
+		d, err := utils.NewLocalDeduper(1*time.Hour, 24*time.Hour)
+		if err != nil {
+			return nil, nil, err
+		}
+		conf.Deduper = d
+	}
+
+	a := &HarmonyAdapter{
+		conf:      conf,
+		ctx:       context.Background(),
+		doStop:    utils.NewEvent(),
+		chStopped: make(chan struct{}),
+	}
+
+	var err error
+	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a.httpClient = &http.Client{
+		Timeout: 60 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 10 * time.Second,
+			}).Dial,
+		},
+	}
+
+	if a.conf.Events.Enabled {
+		for _, svc := range a.conf.Events.CloudServices {
+			a.wgSenders.Add(1)
+			go a.fetchEventsForService(svc)
+		}
+	}
+
+	if a.conf.RestoreRequests.Enabled {
+		for _, saas := range a.conf.RestoreRequests.Saas {
+			a.wgSenders.Add(1)
+			go a.fetchRestoreRequestsForSaas(saas)
+		}
+	}
+
+	go func() {
+		a.wgSenders.Wait()
+		close(a.chStopped)
+	}()
+
+	return a, a.chStopped, nil
+}
+
+func (a *HarmonyAdapter) Close() error {
+	a.conf.ClientOptions.DebugLog("closing")
+	a.doStop.Set()
+	a.wgSenders.Wait()
+	err1 := a.uspClient.Drain(1 * time.Minute)
+	_, err2 := a.uspClient.Close()
+	a.httpClient.CloseIdleConnections()
+	if d := a.conf.Deduper; d != nil {
+		d.Close()
+	}
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+// ----- Source 1: Infinity Events ----------------------------------------------------------
+
+func (a *HarmonyAdapter) fetchEventsForService(service string) {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("harmony events worker exiting (service=%q)", service))
+
+	nextStart := time.Now().UTC().Add(-defaultEventsInitialLookback)
+
+	for {
+		endTime := time.Now().UTC().Add(-defaultEventsEndLag)
+		if !endTime.After(nextStart) {
+			if a.doStop.WaitFor(a.conf.Events.PollInterval) {
+				return
+			}
+			continue
+		}
+
+		newCursor, err := a.runOneEventsQuery(service, nextStart, endTime)
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("harmony[events:%s]: %v", service, err))
+		} else if !newCursor.IsZero() {
+			nextStart = newCursor
+		}
+
+		if a.doStop.WaitFor(a.conf.Events.PollInterval) {
+			return
+		}
+	}
+}
+
+func (a *HarmonyAdapter) runOneEventsQuery(service string, startTime, endTime time.Time) (time.Time, error) {
+	taskID, err := a.submitEventsQuery(service, startTime, endTime)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("submitEventsQuery: %v", err)
+	}
+
+	pageTokens, err := a.waitForEventsTask(taskID)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("waitForEventsTask: %v", err)
+	}
+	if len(pageTokens) == 0 {
+		return endTime, nil
+	}
+
+	latest := time.Time{}
+	pageToken := pageTokens[0]
+	for {
+		if a.doStop.IsSet() {
+			return latest, nil
+		}
+		records, nextToken, err := a.retrieveEventsPage(taskID, pageToken)
+		if err != nil {
+			return latest, fmt.Errorf("retrieveEventsPage: %v", err)
+		}
+		for _, rec := range records {
+			ts := extractRecordTime(rec)
+			if ts.After(latest) {
+				latest = ts
+			}
+			if _, ok := rec["_lc_harmony_source"]; !ok {
+				rec["_lc_harmony_source"] = "infinity_events"
+			}
+			if _, ok := rec["_lc_harmony_service"]; !ok {
+				rec["_lc_harmony_service"] = service
+			}
+			if err := a.shipRecord(rec); err != nil {
+				return latest, err
+			}
+		}
+		if nextToken == "" || nextToken == "NULL" {
+			break
+		}
+		pageToken = nextToken
+	}
+
+	if latest.IsZero() {
+		latest = endTime
+	}
+	return latest, nil
+}
+
+func (a *HarmonyAdapter) submitEventsQuery(service string, startTime, endTime time.Time) (string, error) {
+	body := utils.Dict{
+		"cloudService": service,
+		"timeframe": utils.Dict{
+			"startTime": startTime.UTC().Format(time.RFC3339),
+			"endTime":   endTime.UTC().Format(time.RFC3339),
+		},
+		"pageLimit": a.conf.Events.PageLimit,
+		"limit":     a.conf.Events.Limit,
+	}
+	if a.conf.Events.Filter != "" {
+		body["filter"] = a.conf.Events.Filter
+	}
+
+	resp, err := a.doAuthRequest("POST", a.conf.URL+eventsQueryPath, body, nil)
+	if err != nil {
+		return "", err
+	}
+	data, _ := resp.GetDict("data")
+	taskID, _ := data.GetString("taskId")
+	if taskID == "" {
+		return "", fmt.Errorf("missing taskId in response: %s", asJSON(resp))
+	}
+	return taskID, nil
+}
+
+func (a *HarmonyAdapter) waitForEventsTask(taskID string) ([]string, error) {
+	deadline := time.Now().Add(defaultEventsStatusPollTotal)
+	for {
+		if a.doStop.IsSet() {
+			return nil, nil
+		}
+		resp, err := a.doAuthRequest("GET", a.conf.URL+eventsQueryPath+"/"+taskID, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		data, _ := resp.GetDict("data")
+		state, _ := data.GetString("state")
+		switch state {
+		case "Ready":
+			rawTokens, _ := data.GetList("pageTokens")
+			tokens := make([]string, 0, len(rawTokens))
+			for _, t := range rawTokens {
+				if s, ok := t.(string); ok && s != "" {
+					tokens = append(tokens, s)
+				}
+			}
+			return tokens, nil
+		case "Done":
+			return nil, nil
+		case "Canceled":
+			return nil, fmt.Errorf("task %s canceled by server", taskID)
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("task %s did not reach a terminal state within %s (last state=%q)", taskID, defaultEventsStatusPollTotal, state)
+		}
+		if a.doStop.WaitFor(defaultEventsStatusPollEvery) {
+			return nil, nil
+		}
+	}
+}
+
+func (a *HarmonyAdapter) retrieveEventsPage(taskID, pageToken string) ([]utils.Dict, string, error) {
+	body := utils.Dict{
+		"taskId":    taskID,
+		"pageToken": pageToken,
+	}
+	resp, err := a.doAuthRequest("POST", a.conf.URL+eventsRetrievePath, body, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	data, _ := resp.GetDict("data")
+	rawRecords, _ := data.GetList("records")
+	records := make([]utils.Dict, 0, len(rawRecords))
+	for _, r := range rawRecords {
+		switch v := r.(type) {
+		case map[string]interface{}:
+			records = append(records, utils.Dict(v))
+		case utils.Dict:
+			records = append(records, v)
+		}
+	}
+	nextToken, _ := data.GetString("nextPageToken")
+	return records, nextToken, nil
+}
+
+// ----- Source 2: HEC Restore Requests -----------------------------------------------------
+
+func (a *HarmonyAdapter) fetchRestoreRequestsForSaas(saas string) {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("harmony restore-requests worker exiting (saas=%q)", saas))
+
+	for {
+		if err := a.runOneRestoreRequestsQuery(saas); err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("harmony[restore_requests:%s]: %v", saas, err))
+		}
+		if a.doStop.WaitFor(a.conf.RestoreRequests.PollInterval) {
+			return
+		}
+	}
+}
+
+// runOneRestoreRequestsQuery scrolls through every email entity whose
+// isRestoreRequested flag is true within the configured lookback window and
+// ships each entity once per (entityId, entityUpdated) pair. This naturally
+// emits transitions (pending → restored, pending → declined) as the server
+// bumps entityUpdated on state change, without re-emitting still-pending
+// requests on subsequent polls.
+func (a *HarmonyAdapter) runOneRestoreRequestsQuery(saas string) error {
+	saasEntity, ok := defaultRestoreSaasEntity[saas]
+	if !ok {
+		return fmt.Errorf("unsupported saas %q", saas)
+	}
+	startDate := time.Now().UTC().Add(-a.conf.RestoreRequests.Lookback).Format(time.RFC3339)
+	endDate := time.Now().UTC().Format(time.RFC3339)
+
+	scrollID := ""
+	for {
+		if a.doStop.IsSet() {
+			return nil
+		}
+
+		body := utils.Dict{
+			"requestData": utils.Dict{
+				"entityFilter": utils.Dict{
+					"saas":       saas,
+					"saasEntity": saasEntity,
+					"startDate":  startDate,
+					"endDate":    endDate,
+				},
+				"entityExtendedFilter": []utils.Dict{
+					{
+						"saasAttrName":  "entityPayload.isRestoreRequested",
+						"saasAttrOp":    "is",
+						"saasAttrValue": "true",
+					},
+				},
+				"scrollId": scrollID,
+			},
+		}
+
+		headers := map[string]string{
+			"x-av-req-id": newRequestID(),
+		}
+		resp, err := a.doAuthRequest("POST", a.conf.URL+hecSearchEntityPath, body, headers)
+		if err != nil {
+			return err
+		}
+
+		envelope, _ := resp.GetDict("responseEnvelope")
+		nextScroll, _ := envelope.GetString("scrollId")
+		records, _ := resp.GetListOfDict("responseData")
+
+		for _, rec := range records {
+			key := restoreDedupKey(rec)
+			if key == "" {
+				continue
+			}
+			if a.conf.Deduper.CheckAndAdd(key) {
+				continue
+			}
+			rec["_lc_harmony_source"] = "restore_requests"
+			rec["_lc_harmony_saas"] = saas
+			rec["_lc_harmony_state"] = restoreLifecycleState(rec)
+			if err := a.shipRecord(rec); err != nil {
+				return err
+			}
+		}
+
+		if nextScroll == "" || nextScroll == scrollID || len(records) == 0 {
+			return nil
+		}
+		scrollID = nextScroll
+	}
+}
+
+// restoreDedupKey returns a key that changes only when the email's restore
+// state advances. We anchor on entityId + entityUpdated because the gateway
+// bumps entityUpdated on every state change, while a still-pending request
+// keeps the same timestamp poll-over-poll.
+func restoreDedupKey(rec utils.Dict) string {
+	info, _ := rec.GetDict("entityInfo")
+	entityID, _ := info.GetString("entityId")
+	if entityID == "" {
+		return ""
+	}
+	updated, _ := info.GetString("entityUpdated")
+	if updated == "" {
+		// Fall back to a fingerprint of the relevant flags so we still
+		// dedup if the gateway ever omits entityUpdated.
+		payload, _ := rec.GetDict("entityPayload")
+		req, _ := payload.GetString("isRestoreRequested")
+		restored, _ := payload.GetString("isRestored")
+		declined, _ := payload.GetString("isRestoreDeclined")
+		updated = fmt.Sprintf("req=%s|restored=%s|declined=%s", req, restored, declined)
+	}
+	return "restore:" + entityID + "|" + updated
+}
+
+// restoreLifecycleState classifies the current restore lifecycle stage so
+// downstream consumers can filter without re-parsing the flag combination.
+func restoreLifecycleState(rec utils.Dict) string {
+	payload, _ := rec.GetDict("entityPayload")
+	restored, _ := payload.GetString("isRestored")
+	declined, _ := payload.GetString("isRestoreDeclined")
+	switch {
+	case strings.EqualFold(restored, "true"):
+		return "restored"
+	case strings.EqualFold(declined, "true"):
+		return "declined"
+	default:
+		return "pending"
+	}
+}
+
+// ----- Shared helpers ---------------------------------------------------------------------
+
+func (a *HarmonyAdapter) shipRecord(rec utils.Dict) error {
+	if rec == nil {
+		return nil
+	}
+	msg := &protocol.DataMessage{
+		JsonPayload: rec,
+		TimestampMs: uint64(time.Now().UnixNano() / int64(time.Millisecond)),
+	}
+	if err := a.uspClient.Ship(msg, 10*time.Second); err != nil {
+		if err == uspclient.ErrorBufferFull {
+			a.conf.ClientOptions.OnWarning("stream falling behind")
+			err = a.uspClient.Ship(msg, 1*time.Hour)
+		}
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("Ship(): %v", err))
+			a.doStop.Set()
+			return err
+		}
+	}
+	return nil
+}
+
+// doAuthRequest issues an HTTP request with a valid bearer token attached.
+// If body is nil, no request body is sent. Additional headers (e.g.
+// x-av-req-id required by HEC endpoints) can be supplied via extraHeaders.
+func (a *HarmonyAdapter) doAuthRequest(method, url string, body utils.Dict, extraHeaders map[string]string) (utils.Dict, error) {
+	bodyBytes, err := marshalBody(body)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := a.getToken(false)
+	if err != nil {
+		return nil, err
+	}
+
+	doOnce := func(tok string) (int, []byte, error) {
+		var reader io.Reader
+		if bodyBytes != nil {
+			reader = bytes.NewReader(bodyBytes)
+		}
+		req, err := http.NewRequestWithContext(a.ctx, method, url, reader)
+		if err != nil {
+			return 0, nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		if bodyBytes != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+		for k, v := range extraHeaders {
+			req.Header.Set(k, v)
+		}
+		resp, err := a.httpClient.Do(req)
+		if err != nil {
+			return 0, nil, err
+		}
+		defer resp.Body.Close()
+		respBody, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, respBody, nil
+	}
+
+	status, respBody, err := doOnce(token)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusUnauthorized {
+		token, err = a.getToken(true)
+		if err != nil {
+			return nil, err
+		}
+		status, respBody, err = doOnce(token)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("%s %s: HTTP %d: %s", method, url, status, string(respBody))
+	}
+
+	out := utils.Dict{}
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &out); err != nil {
+			return nil, fmt.Errorf("decode response: %v (body=%s)", err, string(respBody))
+		}
+	}
+	return out, nil
+}
+
+func (a *HarmonyAdapter) getToken(force bool) (string, error) {
+	a.tokenMu.Lock()
+	defer a.tokenMu.Unlock()
+
+	if !force && a.cachedToken != "" && time.Now().Add(tokenRefreshSkew).Before(a.tokenExpires) {
+		return a.cachedToken, nil
+	}
+
+	reqBody, err := json.Marshal(utils.Dict{
+		"clientId":  a.conf.ClientID,
+		"accessKey": a.conf.AccessKey,
+	})
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(a.ctx, "POST", a.conf.URL+authPath, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("auth request: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("auth HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+	parsed := utils.Dict{}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("auth decode: %v", err)
+	}
+	data, _ := parsed.GetDict("data")
+	token, _ := data.GetString("token")
+	if token == "" {
+		return "", fmt.Errorf("auth response missing token: %s", string(respBody))
+	}
+
+	expires := time.Now().Add(25 * time.Minute)
+	if n, ok := data.GetInt("expiresIn"); ok && n > 0 {
+		expires = time.Now().Add(time.Duration(n) * time.Second)
+	} else if s, ok := data.GetString("expires"); ok && s != "" {
+		if t, err := time.Parse(time.RFC1123, s); err == nil {
+			expires = t
+		}
+	}
+
+	a.cachedToken = token
+	a.tokenExpires = expires
+	return token, nil
+}
+
+func marshalBody(body utils.Dict) ([]byte, error) {
+	if body == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal body: %v", err)
+	}
+	return b, nil
+}
+
+func extractRecordTime(rec utils.Dict) time.Time {
+	if rec == nil {
+		return time.Time{}
+	}
+	for _, key := range []string{"time", "eventTime", "timestamp"} {
+		if s, ok := rec.GetString(key); ok && s != "" {
+			if t, err := time.Parse(time.RFC3339, s); err == nil {
+				return t
+			}
+			if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+				return t
+			}
+		}
+	}
+	return time.Time{}
+}
+
+func asJSON(d utils.Dict) string {
+	b, err := json.Marshal(d)
+	if err != nil {
+		return fmt.Sprintf("%+v", d)
+	}
+	return string(b)
+}
+
+// newRequestID returns a UUID-shaped string for the x-av-req-id header HEC
+// requires. We don't need cryptographic uniqueness; a timestamp + counter is
+// enough to give Check Point a per-request handle for support.
+var reqIDCounter struct {
+	sync.Mutex
+	n uint64
+}
+
+func newRequestID() string {
+	reqIDCounter.Lock()
+	reqIDCounter.n++
+	n := reqIDCounter.n
+	reqIDCounter.Unlock()
+	now := time.Now().UnixNano()
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", uint32(now>>32), uint16(now>>16), uint16(now), uint16(n>>16), uint64(n))
+}

--- a/harmony/client.go
+++ b/harmony/client.go
@@ -582,6 +582,23 @@ func (a *HarmonyAdapter) runOneRestoreRequestsQuery(saas string, extendedFilter 
 	}
 }
 
+// dictBoolish reads a field that may be encoded as either a JSON boolean or
+// a string ("true" / "false"). The HEC API documentation (Feb 2026 ed.)
+// shows these fields as strings in its example payloads, but the live
+// gateway returns native JSON booleans. We accept both so the adapter
+// works regardless of which form a given tenant or version emits.
+func dictBoolish(d utils.Dict, key string) (value, found bool) {
+	if v, ok := d[key]; ok {
+		switch t := v.(type) {
+		case bool:
+			return t, true
+		case string:
+			return strings.EqualFold(t, "true"), true
+		}
+	}
+	return false, false
+}
+
 // restoreDedupKey returns a key that changes only when the email's restore
 // state advances. We anchor on entityId + entityUpdated because the gateway
 // bumps entityUpdated on every state change, while a still-pending request
@@ -597,10 +614,10 @@ func restoreDedupKey(rec utils.Dict) string {
 		// Fall back to a fingerprint of the relevant flags so we still
 		// dedup if the gateway ever omits entityUpdated.
 		payload, _ := rec.GetDict("entityPayload")
-		req, _ := payload.GetString("isRestoreRequested")
-		restored, _ := payload.GetString("isRestored")
-		declined, _ := payload.GetString("isRestoreDeclined")
-		updated = fmt.Sprintf("req=%s|restored=%s|declined=%s", req, restored, declined)
+		req, _ := dictBoolish(payload, "isRestoreRequested")
+		restored, _ := dictBoolish(payload, "isRestored")
+		declined, _ := dictBoolish(payload, "isRestoreDeclined")
+		updated = fmt.Sprintf("req=%t|restored=%t|declined=%t", req, restored, declined)
 	}
 	return "restore:" + entityID + "|" + updated
 }
@@ -609,12 +626,12 @@ func restoreDedupKey(rec utils.Dict) string {
 // downstream consumers can filter without re-parsing the flag combination.
 func restoreLifecycleState(rec utils.Dict) string {
 	payload, _ := rec.GetDict("entityPayload")
-	restored, _ := payload.GetString("isRestored")
-	declined, _ := payload.GetString("isRestoreDeclined")
+	restored, _ := dictBoolish(payload, "isRestored")
+	declined, _ := dictBoolish(payload, "isRestoreDeclined")
 	switch {
-	case strings.EqualFold(restored, "true"):
+	case restored:
 		return "restored"
-	case strings.EqualFold(declined, "true"):
+	case declined:
 		return "declined"
 	default:
 		return "pending"

--- a/harmony/client.go
+++ b/harmony/client.go
@@ -74,9 +74,11 @@ type EventsConfig struct {
 	Enabled bool `json:"enabled" yaml:"enabled"`
 
 	// CloudServices to pull events for. Each is queried independently.
-	// Examples: "Harmony Endpoint", "Harmony Email and Collaboration",
-	// "Harmony Mobile", "Harmony Connect", "Harmony Browse". Empty enables
-	// the full Harmony suite.
+	// Names must match the gateway exactly — the Email service is
+	// "Harmony Email & Collaboration" (ampersand, not the word "and"); the
+	// gateway rejects the "and" spelling. Empty enables the full Harmony
+	// suite ("Harmony Endpoint", "Harmony Email & Collaboration",
+	// "Harmony Mobile", "Harmony Connect", "Harmony Browse").
 	CloudServices []string `json:"cloud_services" yaml:"cloud_services"`
 
 	// Optional Infinity Events query filter applied to every cloud service.
@@ -101,6 +103,14 @@ type RestoreRequestsConfig struct {
 	// How far back to search for restore-requested emails. Defaults to 30 days
 	// (typical quarantine retention window).
 	Lookback time.Duration `json:"lookback" yaml:"lookback"`
+
+	// IncludeResolved, when true, also issues queries filtered on isRestored
+	// and isRestoreDeclined. The default (false) only queries
+	// isRestoreRequested=true, which assumes that flag stays set after the
+	// admin acts on the request. If your tenant clears the flag on
+	// resolution, enable this to ensure the "restored" / "declined"
+	// transitions are still captured. Dedup eliminates any overlap.
+	IncludeResolved bool `json:"include_resolved" yaml:"include_resolved"`
 }
 
 type HarmonyConfig struct {
@@ -211,12 +221,23 @@ func NewHarmonyAdapter(ctx context.Context, conf HarmonyConfig) (*HarmonyAdapter
 		return nil, nil, err
 	}
 
-	if conf.Deduper == nil {
-		d, err := utils.NewLocalDeduper(1*time.Hour, 24*time.Hour)
+	// The deduper is only used by the restore-request source. Size its TTL
+	// to cover the full lookback window so a still-pending request — which
+	// the gateway will keep returning every poll for as long as it remains
+	// in the lookback window — doesn't fall out of dedup and get re-emitted
+	// as if it were new. Floor at 24h for sanity even when Lookback is tiny.
+	ownedDeduper := false
+	if conf.RestoreRequests.Enabled && conf.Deduper == nil {
+		ttl := conf.RestoreRequests.Lookback + 1*time.Hour
+		if ttl < 24*time.Hour {
+			ttl = 24 * time.Hour
+		}
+		d, err := utils.NewLocalDeduper(1*time.Hour, ttl)
 		if err != nil {
 			return nil, nil, err
 		}
 		conf.Deduper = d
+		ownedDeduper = true
 	}
 
 	a := &HarmonyAdapter{
@@ -226,9 +247,19 @@ func NewHarmonyAdapter(ctx context.Context, conf HarmonyConfig) (*HarmonyAdapter
 		chStopped: make(chan struct{}),
 	}
 
+	// closeOwnedOnFail releases the deduper goroutine on error paths so the
+	// constructor doesn't leak it. We only close the deduper we created
+	// ourselves — a caller-supplied one is the caller's to manage.
+	closeOwnedOnFail := func() {
+		if ownedDeduper && a.conf.Deduper != nil {
+			a.conf.Deduper.Close()
+		}
+	}
+
 	var err error
 	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
 	if err != nil {
+		closeOwnedOnFail()
 		return nil, nil, err
 	}
 
@@ -452,9 +483,30 @@ func (a *HarmonyAdapter) fetchRestoreRequestsForSaas(saas string) {
 	defer a.wgSenders.Done()
 	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("harmony restore-requests worker exiting (saas=%q)", saas))
 
+	// Filters to issue per poll. The primary pass catches every pending and
+	// post-decision entity if the gateway keeps isRestoreRequested set after
+	// the admin acts. When IncludeResolved is set we additionally search by
+	// isRestored=true and isRestoreDeclined=true so the transition is still
+	// captured if the tenant clears the original flag on resolution. Dedup
+	// suppresses any overlap.
+	filters := []utils.Dict{
+		{"saasAttrName": "entityPayload.isRestoreRequested", "saasAttrOp": "is", "saasAttrValue": "true"},
+	}
+	if a.conf.RestoreRequests.IncludeResolved {
+		filters = append(filters,
+			utils.Dict{"saasAttrName": "entityPayload.isRestored", "saasAttrOp": "is", "saasAttrValue": "true"},
+			utils.Dict{"saasAttrName": "entityPayload.isRestoreDeclined", "saasAttrOp": "is", "saasAttrValue": "true"},
+		)
+	}
+
 	for {
-		if err := a.runOneRestoreRequestsQuery(saas); err != nil {
-			a.conf.ClientOptions.OnError(fmt.Errorf("harmony[restore_requests:%s]: %v", saas, err))
+		for _, f := range filters {
+			if a.doStop.IsSet() {
+				return
+			}
+			if err := a.runOneRestoreRequestsQuery(saas, f); err != nil {
+				a.conf.ClientOptions.OnError(fmt.Errorf("harmony[restore_requests:%s:%s]: %v", saas, f["saasAttrName"], err))
+			}
 		}
 		if a.doStop.WaitFor(a.conf.RestoreRequests.PollInterval) {
 			return
@@ -462,13 +514,13 @@ func (a *HarmonyAdapter) fetchRestoreRequestsForSaas(saas string) {
 	}
 }
 
-// runOneRestoreRequestsQuery scrolls through every email entity whose
-// isRestoreRequested flag is true within the configured lookback window and
-// ships each entity once per (entityId, entityUpdated) pair. This naturally
-// emits transitions (pending → restored, pending → declined) as the server
-// bumps entityUpdated on state change, without re-emitting still-pending
-// requests on subsequent polls.
-func (a *HarmonyAdapter) runOneRestoreRequestsQuery(saas string) error {
+// runOneRestoreRequestsQuery scrolls through every email entity matching the
+// supplied extended filter within the configured lookback window and ships
+// each entity once per (entityId, entityUpdated) pair. The gateway bumps
+// entityUpdated on every state change, which is how we naturally surface
+// transitions (pending → restored, pending → declined) without re-emitting
+// still-pending requests on subsequent polls.
+func (a *HarmonyAdapter) runOneRestoreRequestsQuery(saas string, extendedFilter utils.Dict) error {
 	saasEntity, ok := defaultRestoreSaasEntity[saas]
 	if !ok {
 		return fmt.Errorf("unsupported saas %q", saas)
@@ -490,14 +542,8 @@ func (a *HarmonyAdapter) runOneRestoreRequestsQuery(saas string) error {
 					"startDate":  startDate,
 					"endDate":    endDate,
 				},
-				"entityExtendedFilter": []utils.Dict{
-					{
-						"saasAttrName":  "entityPayload.isRestoreRequested",
-						"saasAttrOp":    "is",
-						"saasAttrValue": "true",
-					},
-				},
-				"scrollId": scrollID,
+				"entityExtendedFilter": []utils.Dict{extendedFilter},
+				"scrollId":             scrollID,
 			},
 		}
 
@@ -733,15 +779,16 @@ func marshalBody(body utils.Dict) ([]byte, error) {
 	return b, nil
 }
 
+// extractRecordTime returns the timestamp embedded in an Infinity Events
+// record, used to advance the per-service cursor. RFC3339Nano accepts both
+// fractional and non-fractional seconds, so a single parse call covers both
+// the docs' "2020-01-01T00:00:00.000Z" form and the bare RFC3339 form.
 func extractRecordTime(rec utils.Dict) time.Time {
 	if rec == nil {
 		return time.Time{}
 	}
 	for _, key := range []string{"time", "eventTime", "timestamp"} {
 		if s, ok := rec.GetString(key); ok && s != "" {
-			if t, err := time.Parse(time.RFC3339, s); err == nil {
-				return t
-			}
 			if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 				return t
 			}

--- a/harmony/client.go
+++ b/harmony/client.go
@@ -68,6 +68,38 @@ const (
 	defaultRestoreLookback     = 30 * 24 * time.Hour
 )
 
+// harmonySource is the contract every ingestion source in this adapter
+// implements. Adding a new source is mechanical: implement the four
+// methods, add the source-config struct as a field on HarmonyConfig, and
+// register a pointer to it in HarmonyConfig.sources(). HarmonyConfig.Validate
+// and NewHarmonyAdapter handle the rest.
+type harmonySource interface {
+	// Name identifies the source in error messages and the
+	// "_lc_harmony_source" annotation. Convention: snake_case, matching the
+	// source's JSON/YAML key on HarmonyConfig.
+	Name() string
+
+	// IsEnabled returns true when the source is configured to run. Validate
+	// and Start are only invoked when this returns true.
+	IsEnabled() bool
+
+	// Validate is called by HarmonyConfig.Validate when the source is
+	// enabled. It should both reject bad configurations and fill in
+	// sensible defaults for unset fields.
+	Validate() error
+
+	// Start is called by NewHarmonyAdapter when the source is enabled. The
+	// source spawns its workers by calling a.wgSenders.Add(1) and launching
+	// goroutines that end with `defer a.wgSenders.Done()` and respect
+	// a.doStop. Errors here abort adapter construction.
+	Start(a *HarmonyAdapter) error
+
+	// Close releases any source-owned resources (deduper, file handles,
+	// etc.). It is called from HarmonyAdapter.Close after all workers have
+	// exited, and must be safe to call even when Start was never invoked.
+	Close()
+}
+
 // EventsConfig controls the Infinity Events / Logs-as-a-Service source. When
 // Enabled is false this source is skipped entirely.
 type EventsConfig struct {
@@ -88,6 +120,42 @@ type EventsConfig struct {
 	PageLimit    int           `json:"page_limit" yaml:"page_limit"`
 	Limit        int           `json:"limit" yaml:"limit"`
 }
+
+func (c *EventsConfig) Name() string    { return "events" }
+func (c *EventsConfig) IsEnabled() bool { return c != nil && c.Enabled }
+
+func (c *EventsConfig) Validate() error {
+	if len(c.CloudServices) == 0 {
+		c.CloudServices = append([]string{}, defaultEventsCloudServices...)
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultEventsPollInterval
+	}
+	if c.PageLimit <= 0 {
+		c.PageLimit = defaultEventsPageLimit
+	}
+	if c.PageLimit < 10 {
+		// Gateway rejects values below 10 with HTTP 400.
+		c.PageLimit = 10
+	}
+	if c.Limit <= 0 {
+		c.Limit = defaultEventsPerCloudLimit
+	}
+	if c.Limit < 10 {
+		c.Limit = 10
+	}
+	return nil
+}
+
+func (c *EventsConfig) Start(a *HarmonyAdapter) error {
+	for _, svc := range c.CloudServices {
+		a.wgSenders.Add(1)
+		go a.fetchEventsForService(svc)
+	}
+	return nil
+}
+
+func (c *EventsConfig) Close() {}
 
 // RestoreRequestsConfig controls polling of the HEC entity search API to
 // surface emails with pending or recently-decided restore requests.
@@ -111,6 +179,68 @@ type RestoreRequestsConfig struct {
 	// resolution, enable this to ensure the "restored" / "declined"
 	// transitions are still captured. Dedup eliminates any overlap.
 	IncludeResolved bool `json:"include_resolved" yaml:"include_resolved"`
+
+	// Deduper avoids re-emitting the same entity for the same state on
+	// every poll. Transitions are still emitted because the dedup key
+	// includes the entityUpdated timestamp. If nil, Start allocates one
+	// sized to Lookback + 1h (24h floor); a caller-supplied deduper takes
+	// precedence. The source's Close releases the deduper unconditionally,
+	// matching the ownership convention used by the o365 adapter.
+	Deduper utils.Deduper `json:"-" yaml:"-"`
+}
+
+func (c *RestoreRequestsConfig) Name() string    { return "restore_requests" }
+func (c *RestoreRequestsConfig) IsEnabled() bool { return c != nil && c.Enabled }
+
+func (c *RestoreRequestsConfig) Validate() error {
+	if len(c.Saas) == 0 {
+		c.Saas = append([]string{}, defaultRestoreSaas...)
+	}
+	for _, s := range c.Saas {
+		if _, ok := defaultRestoreSaasEntity[s]; !ok {
+			return fmt.Errorf("restore_requests.saas %q is not supported (only %v carry the restore flags)", s, defaultRestoreSaas)
+		}
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultRestorePollInterval
+	}
+	if c.Lookback <= 0 {
+		c.Lookback = defaultRestoreLookback
+	}
+	return nil
+}
+
+func (c *RestoreRequestsConfig) Start(a *HarmonyAdapter) error {
+	if c.Deduper == nil {
+		// Size the TTL to the full lookback window so a still-pending
+		// request — which the gateway will keep returning every poll for
+		// as long as it remains in the lookback window — doesn't fall out
+		// of dedup and get re-emitted as if it were new. Floor at 24h.
+		ttl := c.Lookback + 1*time.Hour
+		if ttl < 24*time.Hour {
+			ttl = 24 * time.Hour
+		}
+		d, err := utils.NewLocalDeduper(1*time.Hour, ttl)
+		if err != nil {
+			return err
+		}
+		c.Deduper = d
+	}
+	for _, saas := range c.Saas {
+		a.wgSenders.Add(1)
+		go a.fetchRestoreRequestsForSaas(saas)
+	}
+	return nil
+}
+
+func (c *RestoreRequestsConfig) Close() {
+	if c.Deduper != nil {
+		// Close any deduper attached to this source — both ones we allocated
+		// and caller-supplied ones, matching the convention other adapters
+		// in this repo use (e.g. o365).
+		c.Deduper.Close()
+		c.Deduper = nil
+	}
 }
 
 type HarmonyConfig struct {
@@ -132,11 +262,12 @@ type HarmonyConfig struct {
 
 	Events          EventsConfig          `json:"events" yaml:"events"`
 	RestoreRequests RestoreRequestsConfig `json:"restore_requests" yaml:"restore_requests"`
+}
 
-	// Deduper is used by the restore-request source to avoid re-emitting the
-	// same entity for the same state on every poll. Transitions are still
-	// emitted because the dedup key includes the entityUpdated timestamp.
-	Deduper utils.Deduper `json:"-" yaml:"-"`
+// sources returns the registered ingestion sources in a stable order. Adding
+// a new source is a single line here plus the source-config struct.
+func (c *HarmonyConfig) sources() []harmonySource {
+	return []harmonySource{&c.Events, &c.RestoreRequests}
 }
 
 func (c *HarmonyConfig) Validate() error {
@@ -154,49 +285,21 @@ func (c *HarmonyConfig) Validate() error {
 	}
 	c.URL = strings.TrimRight(c.URL, "/")
 
-	if !c.Events.Enabled && !c.RestoreRequests.Enabled {
-		return errors.New("at least one of events.enabled or restore_requests.enabled must be true")
-	}
-
-	if c.Events.Enabled {
-		if len(c.Events.CloudServices) == 0 {
-			c.Events.CloudServices = append([]string{}, defaultEventsCloudServices...)
+	anyEnabled := false
+	names := make([]string, 0, 4)
+	for _, s := range c.sources() {
+		names = append(names, s.Name())
+		if !s.IsEnabled() {
+			continue
 		}
-		if c.Events.PollInterval <= 0 {
-			c.Events.PollInterval = defaultEventsPollInterval
-		}
-		if c.Events.PageLimit <= 0 {
-			c.Events.PageLimit = defaultEventsPageLimit
-		}
-		if c.Events.PageLimit < 10 {
-			// Gateway rejects values below 10 with HTTP 400.
-			c.Events.PageLimit = 10
-		}
-		if c.Events.Limit <= 0 {
-			c.Events.Limit = defaultEventsPerCloudLimit
-		}
-		if c.Events.Limit < 10 {
-			c.Events.Limit = 10
+		anyEnabled = true
+		if err := s.Validate(); err != nil {
+			return fmt.Errorf("%s: %v", s.Name(), err)
 		}
 	}
-
-	if c.RestoreRequests.Enabled {
-		if len(c.RestoreRequests.Saas) == 0 {
-			c.RestoreRequests.Saas = append([]string{}, defaultRestoreSaas...)
-		}
-		for _, s := range c.RestoreRequests.Saas {
-			if _, ok := defaultRestoreSaasEntity[s]; !ok {
-				return fmt.Errorf("restore_requests.saas %q is not supported (only %v carry the restore flags)", s, defaultRestoreSaas)
-			}
-		}
-		if c.RestoreRequests.PollInterval <= 0 {
-			c.RestoreRequests.PollInterval = defaultRestorePollInterval
-		}
-		if c.RestoreRequests.Lookback <= 0 {
-			c.RestoreRequests.Lookback = defaultRestoreLookback
-		}
+	if !anyEnabled {
+		return fmt.Errorf("at least one source must be enabled (%s)", strings.Join(names, ", "))
 	}
-
 	return nil
 }
 
@@ -221,25 +324,6 @@ func NewHarmonyAdapter(ctx context.Context, conf HarmonyConfig) (*HarmonyAdapter
 		return nil, nil, err
 	}
 
-	// The deduper is only used by the restore-request source. Size its TTL
-	// to cover the full lookback window so a still-pending request — which
-	// the gateway will keep returning every poll for as long as it remains
-	// in the lookback window — doesn't fall out of dedup and get re-emitted
-	// as if it were new. Floor at 24h for sanity even when Lookback is tiny.
-	ownedDeduper := false
-	if conf.RestoreRequests.Enabled && conf.Deduper == nil {
-		ttl := conf.RestoreRequests.Lookback + 1*time.Hour
-		if ttl < 24*time.Hour {
-			ttl = 24 * time.Hour
-		}
-		d, err := utils.NewLocalDeduper(1*time.Hour, ttl)
-		if err != nil {
-			return nil, nil, err
-		}
-		conf.Deduper = d
-		ownedDeduper = true
-	}
-
 	a := &HarmonyAdapter{
 		conf:      conf,
 		ctx:       context.Background(),
@@ -247,19 +331,9 @@ func NewHarmonyAdapter(ctx context.Context, conf HarmonyConfig) (*HarmonyAdapter
 		chStopped: make(chan struct{}),
 	}
 
-	// closeOwnedOnFail releases the deduper goroutine on error paths so the
-	// constructor doesn't leak it. We only close the deduper we created
-	// ourselves — a caller-supplied one is the caller's to manage.
-	closeOwnedOnFail := func() {
-		if ownedDeduper && a.conf.Deduper != nil {
-			a.conf.Deduper.Close()
-		}
-	}
-
 	var err error
 	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
 	if err != nil {
-		closeOwnedOnFail()
 		return nil, nil, err
 	}
 
@@ -272,17 +346,28 @@ func NewHarmonyAdapter(ctx context.Context, conf HarmonyConfig) (*HarmonyAdapter
 		},
 	}
 
-	if a.conf.Events.Enabled {
-		for _, svc := range a.conf.Events.CloudServices {
-			a.wgSenders.Add(1)
-			go a.fetchEventsForService(svc)
+	// Start every enabled source. If one fails after others have already
+	// spawned workers we have to fully tear down — signal doStop, wait for
+	// goroutines to exit, then release each source's resources — before
+	// returning the error to the caller. Otherwise we'd leak running
+	// workers and dedupers.
+	//
+	// We operate on the sources rooted in a.conf (the adapter's copy of
+	// the config) rather than the caller's `conf` parameter so the same
+	// HarmonyAdapter.Close path releases everything later.
+	for _, s := range a.conf.sources() {
+		if !s.IsEnabled() {
+			continue
 		}
-	}
-
-	if a.conf.RestoreRequests.Enabled {
-		for _, saas := range a.conf.RestoreRequests.Saas {
-			a.wgSenders.Add(1)
-			go a.fetchRestoreRequestsForSaas(saas)
+		if err := s.Start(a); err != nil {
+			a.doStop.Set()
+			a.wgSenders.Wait()
+			for _, prev := range a.conf.sources() {
+				prev.Close()
+			}
+			_, _ = a.uspClient.Close()
+			a.httpClient.CloseIdleConnections()
+			return nil, nil, fmt.Errorf("%s.Start: %v", s.Name(), err)
 		}
 	}
 
@@ -301,8 +386,8 @@ func (a *HarmonyAdapter) Close() error {
 	err1 := a.uspClient.Drain(1 * time.Minute)
 	_, err2 := a.uspClient.Close()
 	a.httpClient.CloseIdleConnections()
-	if d := a.conf.Deduper; d != nil {
-		d.Close()
+	for _, s := range a.conf.sources() {
+		s.Close()
 	}
 	if err1 != nil {
 		return err1
@@ -564,7 +649,7 @@ func (a *HarmonyAdapter) runOneRestoreRequestsQuery(saas string, extendedFilter 
 			if key == "" {
 				continue
 			}
-			if a.conf.Deduper.CheckAndAdd(key) {
+			if a.conf.RestoreRequests.Deduper.CheckAndAdd(key) {
 				continue
 			}
 			rec["_lc_harmony_source"] = "restore_requests"

--- a/harmony/client_test.go
+++ b/harmony/client_test.go
@@ -26,28 +26,33 @@ func TestRestoreLifecycleState(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "pending when neither flag is set",
+			name:     "pending when neither flag is set (string form)",
 			payload:  utils.Dict{"isRestoreRequested": "true", "isRestored": "false", "isRestoreDeclined": "false"},
 			expected: "pending",
 		},
 		{
-			name:     "restored",
+			name:     "restored (string form, as docs show)",
 			payload:  utils.Dict{"isRestoreRequested": "true", "isRestored": "true", "isRestoreDeclined": "false"},
 			expected: "restored",
 		},
 		{
-			name:     "declined",
-			payload:  utils.Dict{"isRestoreRequested": "true", "isRestored": "false", "isRestoreDeclined": "true"},
+			name:     "restored (bool form, as live gateway emits)",
+			payload:  utils.Dict{"isRestoreRequested": true, "isRestored": true, "isRestoreDeclined": false},
+			expected: "restored",
+		},
+		{
+			name:     "declined (bool form)",
+			payload:  utils.Dict{"isRestoreRequested": true, "isRestored": false, "isRestoreDeclined": true},
 			expected: "declined",
 		},
 		{
-			name:     "case-insensitive match",
+			name:     "case-insensitive match on string form",
 			payload:  utils.Dict{"isRestored": "True"},
 			expected: "restored",
 		},
 		{
 			name:     "restored wins when both decision flags are oddly set",
-			payload:  utils.Dict{"isRestored": "true", "isRestoreDeclined": "true"},
+			payload:  utils.Dict{"isRestored": true, "isRestoreDeclined": true},
 			expected: "restored",
 		},
 		{
@@ -87,13 +92,15 @@ func TestRestoreDedupKey(t *testing.T) {
 	})
 
 	t.Run("falls back to flag fingerprint when entityUpdated is absent", func(t *testing.T) {
+		// Mix string and bool forms — the fingerprint must change between
+		// states regardless of which encoding the gateway returns.
 		pending := utils.Dict{
 			"entityInfo":    utils.Dict{"entityId": "abc"},
-			"entityPayload": utils.Dict{"isRestoreRequested": "true", "isRestored": "false", "isRestoreDeclined": "false"},
+			"entityPayload": utils.Dict{"isRestoreRequested": true, "isRestored": false, "isRestoreDeclined": false},
 		}
 		restored := utils.Dict{
 			"entityInfo":    utils.Dict{"entityId": "abc"},
-			"entityPayload": utils.Dict{"isRestoreRequested": "true", "isRestored": "true", "isRestoreDeclined": "false"},
+			"entityPayload": utils.Dict{"isRestoreRequested": true, "isRestored": true, "isRestoreDeclined": false},
 		}
 		if restoreDedupKey(pending) == restoreDedupKey(restored) {
 			t.Fatalf("state transition should change the dedup key even without entityUpdated")
@@ -529,10 +536,14 @@ func (d *recordingDeduper) admittedKeys() []string {
 //     dedup key admits the entity again, capturing the transition.
 func TestRestoreRequestsDedupAndTransition(t *testing.T) {
 	fake := &fakeGateway{}
+	// Use the bool form here because that's what the live gateway returns —
+	// the test would have passed against either form before the bool fix,
+	// but using booleans pins the assertion to the wire shape we'll actually
+	// see in production.
 	fake.hecRecords = []utils.Dict{
 		{
 			"entityInfo":    utils.Dict{"entityId": "e1", "entityUpdated": "2026-05-12T10:00:00Z"},
-			"entityPayload": utils.Dict{"isRestoreRequested": "true", "isRestored": "false", "isRestoreDeclined": "false"},
+			"entityPayload": utils.Dict{"isRestoreRequested": true, "isRestored": false, "isRestoreDeclined": false},
 		},
 	}
 	srv := httptest.NewServer(fake.handler())
@@ -580,7 +591,7 @@ func TestRestoreRequestsDedupAndTransition(t *testing.T) {
 	fake.mu.Lock()
 	fake.hecRecords[0] = utils.Dict{
 		"entityInfo":    utils.Dict{"entityId": "e1", "entityUpdated": "2026-05-12T11:00:00Z"},
-		"entityPayload": utils.Dict{"isRestoreRequested": "true", "isRestored": "true", "isRestoreDeclined": "false"},
+		"entityPayload": utils.Dict{"isRestoreRequested": true, "isRestored": true, "isRestoreDeclined": false},
 	}
 	fake.mu.Unlock()
 

--- a/harmony/client_test.go
+++ b/harmony/client_test.go
@@ -1,0 +1,651 @@
+package usp_harmony
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+// ----- Pure helpers ------------------------------------------------------------------------
+
+func TestRestoreLifecycleState(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload  utils.Dict
+		expected string
+	}{
+		{
+			name:     "pending when neither flag is set",
+			payload:  utils.Dict{"isRestoreRequested": "true", "isRestored": "false", "isRestoreDeclined": "false"},
+			expected: "pending",
+		},
+		{
+			name:     "restored",
+			payload:  utils.Dict{"isRestoreRequested": "true", "isRestored": "true", "isRestoreDeclined": "false"},
+			expected: "restored",
+		},
+		{
+			name:     "declined",
+			payload:  utils.Dict{"isRestoreRequested": "true", "isRestored": "false", "isRestoreDeclined": "true"},
+			expected: "declined",
+		},
+		{
+			name:     "case-insensitive match",
+			payload:  utils.Dict{"isRestored": "True"},
+			expected: "restored",
+		},
+		{
+			name:     "restored wins when both decision flags are oddly set",
+			payload:  utils.Dict{"isRestored": "true", "isRestoreDeclined": "true"},
+			expected: "restored",
+		},
+		{
+			name:     "missing payload defaults to pending",
+			payload:  nil,
+			expected: "pending",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := utils.Dict{"entityPayload": c.payload}
+			got := restoreLifecycleState(rec)
+			if got != c.expected {
+				t.Fatalf("expected %q, got %q", c.expected, got)
+			}
+		})
+	}
+}
+
+func TestRestoreDedupKey(t *testing.T) {
+	t.Run("no entityId returns empty key so caller skips it", func(t *testing.T) {
+		if got := restoreDedupKey(utils.Dict{}); got != "" {
+			t.Fatalf("expected empty key, got %q", got)
+		}
+	})
+
+	t.Run("entityUpdated drives the key", func(t *testing.T) {
+		a := utils.Dict{"entityInfo": utils.Dict{"entityId": "abc", "entityUpdated": "2026-05-12T10:00:00Z"}}
+		b := utils.Dict{"entityInfo": utils.Dict{"entityId": "abc", "entityUpdated": "2026-05-12T10:00:00Z"}}
+		c := utils.Dict{"entityInfo": utils.Dict{"entityId": "abc", "entityUpdated": "2026-05-12T11:00:00Z"}}
+		if restoreDedupKey(a) != restoreDedupKey(b) {
+			t.Fatalf("same entityUpdated should produce same key")
+		}
+		if restoreDedupKey(a) == restoreDedupKey(c) {
+			t.Fatalf("different entityUpdated should produce different keys (transition)")
+		}
+	})
+
+	t.Run("falls back to flag fingerprint when entityUpdated is absent", func(t *testing.T) {
+		pending := utils.Dict{
+			"entityInfo":    utils.Dict{"entityId": "abc"},
+			"entityPayload": utils.Dict{"isRestoreRequested": "true", "isRestored": "false", "isRestoreDeclined": "false"},
+		}
+		restored := utils.Dict{
+			"entityInfo":    utils.Dict{"entityId": "abc"},
+			"entityPayload": utils.Dict{"isRestoreRequested": "true", "isRestored": "true", "isRestoreDeclined": "false"},
+		}
+		if restoreDedupKey(pending) == restoreDedupKey(restored) {
+			t.Fatalf("state transition should change the dedup key even without entityUpdated")
+		}
+	})
+}
+
+func TestExtractRecordTime(t *testing.T) {
+	cases := []struct {
+		name string
+		rec  utils.Dict
+		want string // RFC3339Nano; empty string means zero time
+	}{
+		{"rfc3339 no fractional", utils.Dict{"time": "2026-05-12T19:45:42Z"}, "2026-05-12T19:45:42Z"},
+		{"rfc3339nano fractional", utils.Dict{"time": "2026-05-12T19:45:42.017013Z"}, "2026-05-12T19:45:42.017013Z"},
+		{"eventTime fallback", utils.Dict{"eventTime": "2026-05-12T19:45:42Z"}, "2026-05-12T19:45:42Z"},
+		{"timestamp fallback", utils.Dict{"timestamp": "2026-05-12T19:45:42Z"}, "2026-05-12T19:45:42Z"},
+		{"missing all", utils.Dict{}, ""},
+		{"nil record", nil, ""},
+		{"garbage value", utils.Dict{"time": "not-a-time"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := extractRecordTime(c.rec)
+			if c.want == "" {
+				if !got.IsZero() {
+					t.Fatalf("expected zero time, got %s", got)
+				}
+				return
+			}
+			if got.IsZero() {
+				t.Fatalf("expected %s, got zero time", c.want)
+			}
+			if got.UTC().Format(time.RFC3339Nano) != c.want {
+				t.Fatalf("expected %s, got %s", c.want, got.UTC().Format(time.RFC3339Nano))
+			}
+		})
+	}
+}
+
+func TestNewRequestIDFormat(t *testing.T) {
+	uuidLike := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	seen := map[string]struct{}{}
+	for i := 0; i < 1000; i++ {
+		id := newRequestID()
+		if !uuidLike.MatchString(id) {
+			t.Fatalf("id %q does not match UUID-shape pattern", id)
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("duplicate id within batch: %q", id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// ----- Validate ----------------------------------------------------------------------------
+
+// validClientOptions returns a ClientOptions populated with the minimum
+// fields required to satisfy uspclient validation while keeping the client
+// in TestSinkMode (no network). The three callback hooks are non-nil because
+// the adapter calls DebugLog / OnError / OnWarning unconditionally.
+func validClientOptions() uspclient.ClientOptions {
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "00000000-0000-0000-0000-000000000001",
+			InstallationKey: "00000000-0000-0000-0000-000000000002",
+		},
+		Platform:      "json",
+		SensorSeedKey: "harmony-test",
+		TestSinkMode:  true,
+		DebugLog:      func(string) {},
+		OnError:       func(error) {},
+		OnWarning:     func(string) {},
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("missing credentials", func(t *testing.T) {
+		c := HarmonyConfig{ClientOptions: validClientOptions(), Events: EventsConfig{Enabled: true}}
+		if err := c.Validate(); err == nil {
+			t.Fatalf("expected error for missing client_id")
+		}
+		c.ClientID = "x"
+		if err := c.Validate(); err == nil {
+			t.Fatalf("expected error for missing access_key")
+		}
+	})
+
+	t.Run("no source enabled is rejected", func(t *testing.T) {
+		c := HarmonyConfig{ClientOptions: validClientOptions(), ClientID: "x", AccessKey: "y"}
+		if err := c.Validate(); err == nil {
+			t.Fatalf("expected error when neither source is enabled")
+		}
+	})
+
+	t.Run("defaults are filled in for events", func(t *testing.T) {
+		c := HarmonyConfig{
+			ClientOptions: validClientOptions(),
+			ClientID:      "x", AccessKey: "y",
+			Events: EventsConfig{Enabled: true},
+		}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.URL != defaultBaseURL {
+			t.Fatalf("expected default URL, got %q", c.URL)
+		}
+		if len(c.Events.CloudServices) != len(defaultEventsCloudServices) {
+			t.Fatalf("expected default cloud services, got %v", c.Events.CloudServices)
+		}
+		// Make sure none of the defaults use the "and" spelling — the gateway
+		// rejects that and it's easy for someone to copy the wrong form.
+		for _, svc := range c.Events.CloudServices {
+			if strings.Contains(svc, " and ") {
+				t.Fatalf("default cloud service %q uses 'and' instead of '&'", svc)
+			}
+		}
+		if c.Events.PollInterval != defaultEventsPollInterval {
+			t.Fatalf("expected default poll interval, got %s", c.Events.PollInterval)
+		}
+	})
+
+	t.Run("gateway minimum 10 is enforced for page_limit and limit", func(t *testing.T) {
+		c := HarmonyConfig{
+			ClientOptions: validClientOptions(),
+			ClientID:      "x", AccessKey: "y",
+			Events: EventsConfig{Enabled: true, PageLimit: 5, Limit: 1},
+		}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.Events.PageLimit < 10 || c.Events.Limit < 10 {
+			t.Fatalf("page_limit/limit should be clamped to 10, got %d/%d", c.Events.PageLimit, c.Events.Limit)
+		}
+	})
+
+	t.Run("trailing slash on URL is normalized", func(t *testing.T) {
+		c := HarmonyConfig{
+			ClientOptions: validClientOptions(),
+			ClientID:      "x", AccessKey: "y",
+			URL:    "https://example.com/",
+			Events: EventsConfig{Enabled: true},
+		}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.URL != "https://example.com" {
+			t.Fatalf("expected trailing slash trimmed, got %q", c.URL)
+		}
+	})
+
+	t.Run("unsupported saas value is rejected", func(t *testing.T) {
+		c := HarmonyConfig{
+			ClientOptions: validClientOptions(),
+			ClientID:      "x", AccessKey: "y",
+			RestoreRequests: RestoreRequestsConfig{Enabled: true, Saas: []string{"slack"}},
+		}
+		if err := c.Validate(); err == nil {
+			t.Fatalf("expected error for unsupported saas")
+		}
+	})
+
+	t.Run("restore_requests defaults fill in", func(t *testing.T) {
+		c := HarmonyConfig{
+			ClientOptions: validClientOptions(),
+			ClientID:      "x", AccessKey: "y",
+			RestoreRequests: RestoreRequestsConfig{Enabled: true},
+		}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.RestoreRequests.PollInterval != defaultRestorePollInterval {
+			t.Fatalf("expected default poll interval, got %s", c.RestoreRequests.PollInterval)
+		}
+		if c.RestoreRequests.Lookback != defaultRestoreLookback {
+			t.Fatalf("expected default lookback, got %s", c.RestoreRequests.Lookback)
+		}
+		if len(c.RestoreRequests.Saas) != len(defaultRestoreSaas) {
+			t.Fatalf("expected default saas list")
+		}
+	})
+}
+
+// ----- HTTP integration with httptest ------------------------------------------------------
+
+// fakeGateway is a stand-in for the Infinity Portal gateway: /auth/external,
+// the laas-logs-api submit/poll/retrieve sequence, and the HEC search endpoint.
+type fakeGateway struct {
+	mu sync.Mutex
+
+	authCalls       int32
+	submitCalls     int32
+	statusCalls     int32
+	retrieveCalls   int32
+	searchCalls     int32
+	rejectFirstAuth bool // simulate one 401 then accept
+
+	currentToken string
+
+	// Records returned by laas retrieve, optionally split into multiple pages.
+	eventPages [][]utils.Dict
+
+	// Records returned by the HEC search; can be swapped at runtime to simulate transitions.
+	hecRecords []utils.Dict
+}
+
+func (f *fakeGateway) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == authPath:
+			f.serveAuth(w, r)
+		case r.URL.Path == eventsQueryPath && r.Method == http.MethodPost:
+			f.serveEventsSubmit(w, r)
+		case r.URL.Path == eventsRetrievePath && r.Method == http.MethodPost:
+			f.serveEventsRetrieve(w, r)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, eventsQueryPath+"/"):
+			f.serveEventsStatus(w, r)
+		case r.URL.Path == hecSearchEntityPath:
+			f.serveHECSearch(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func (f *fakeGateway) serveAuth(w http.ResponseWriter, r *http.Request) {
+	n := atomic.AddInt32(&f.authCalls, 1)
+	f.mu.Lock()
+	f.currentToken = fmt.Sprintf("test-token-%d", n)
+	token := f.currentToken
+	f.mu.Unlock()
+	writeJSON(w, http.StatusOK, utils.Dict{
+		"success": true,
+		"data": utils.Dict{
+			"token":     token,
+			"expiresIn": 1800,
+		},
+	})
+}
+
+func (f *fakeGateway) checkAuth(w http.ResponseWriter, r *http.Request) bool {
+	got := r.Header.Get("Authorization")
+	f.mu.Lock()
+	expected := "Bearer " + f.currentToken
+	reject := f.rejectFirstAuth
+	if reject {
+		f.rejectFirstAuth = false
+	}
+	f.mu.Unlock()
+	if reject || got != expected {
+		writeJSON(w, http.StatusUnauthorized, utils.Dict{"message": "Authentication required"})
+		return false
+	}
+	return true
+}
+
+func (f *fakeGateway) serveEventsSubmit(w http.ResponseWriter, r *http.Request) {
+	if !f.checkAuth(w, r) {
+		return
+	}
+	atomic.AddInt32(&f.submitCalls, 1)
+	writeJSON(w, http.StatusOK, utils.Dict{"success": true, "data": utils.Dict{"taskId": "task-1"}})
+}
+
+func (f *fakeGateway) serveEventsStatus(w http.ResponseWriter, r *http.Request) {
+	if !f.checkAuth(w, r) {
+		return
+	}
+	atomic.AddInt32(&f.statusCalls, 1)
+	tokens := []string{}
+	for i := range f.eventPages {
+		tokens = append(tokens, fmt.Sprintf("page-%d", i))
+	}
+	if len(tokens) == 0 {
+		writeJSON(w, http.StatusOK, utils.Dict{"data": utils.Dict{"state": "Done"}})
+		return
+	}
+	writeJSON(w, http.StatusOK, utils.Dict{"data": utils.Dict{"state": "Ready", "pageTokens": tokens}})
+}
+
+func (f *fakeGateway) serveEventsRetrieve(w http.ResponseWriter, r *http.Request) {
+	if !f.checkAuth(w, r) {
+		return
+	}
+	atomic.AddInt32(&f.retrieveCalls, 1)
+	var body utils.Dict
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	pt, _ := body.GetString("pageToken")
+	var idx int
+	if _, err := fmt.Sscanf(pt, "page-%d", &idx); err != nil || idx < 0 || idx >= len(f.eventPages) {
+		idx = 0
+	}
+	next := "NULL"
+	if idx+1 < len(f.eventPages) {
+		next = fmt.Sprintf("page-%d", idx+1)
+	}
+	writeJSON(w, http.StatusOK, utils.Dict{"data": utils.Dict{
+		"records":       dictListToInterface(f.eventPages[idx]),
+		"nextPageToken": next,
+	}})
+}
+
+func (f *fakeGateway) serveHECSearch(w http.ResponseWriter, r *http.Request) {
+	if !f.checkAuth(w, r) {
+		return
+	}
+	atomic.AddInt32(&f.searchCalls, 1)
+	f.mu.Lock()
+	records := append([]utils.Dict{}, f.hecRecords...)
+	f.mu.Unlock()
+	writeJSON(w, http.StatusOK, utils.Dict{
+		"responseEnvelope": utils.Dict{"recordsNumber": len(records), "scrollId": ""},
+		"responseData":     dictListToInterface(records),
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body utils.Dict) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func dictListToInterface(in []utils.Dict) []interface{} {
+	out := make([]interface{}, len(in))
+	for i, v := range in {
+		out[i] = map[string]interface{}(v)
+	}
+	return out
+}
+
+func TestEventsFlowWithMockServer(t *testing.T) {
+	fake := &fakeGateway{
+		eventPages: [][]utils.Dict{
+			{
+				{"id": "a", "time": "2026-05-12T10:00:00Z", "subject": "first"},
+				{"id": "b", "time": "2026-05-12T10:01:00Z", "subject": "second"},
+			},
+			{
+				{"id": "c", "time": "2026-05-12T10:02:00Z", "subject": "third"},
+			},
+		},
+	}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	conf := HarmonyConfig{
+		ClientOptions: validClientOptions(),
+		ClientID:      "client", AccessKey: "secret",
+		URL: srv.URL,
+		Events: EventsConfig{
+			Enabled:       true,
+			CloudServices: []string{"Harmony Endpoint"},
+			PollInterval:  10 * time.Millisecond,
+		},
+	}
+	adapter, _, err := NewHarmonyAdapter(context.Background(), conf)
+	if err != nil {
+		t.Fatalf("NewHarmonyAdapter: %v", err)
+	}
+	defer adapter.Close()
+
+	waitUntil(t, 3*time.Second, func() bool {
+		return atomic.LoadInt32(&fake.retrieveCalls) >= 2
+	}, "expected both pages to be retrieved")
+
+	if got := atomic.LoadInt32(&fake.authCalls); got == 0 {
+		t.Fatalf("expected auth to be called, got 0")
+	}
+	if got := atomic.LoadInt32(&fake.submitCalls); got == 0 {
+		t.Fatalf("expected submit to be called, got 0")
+	}
+}
+
+func TestEventsReAuthOn401(t *testing.T) {
+	fake := &fakeGateway{
+		rejectFirstAuth: true,
+		eventPages:      [][]utils.Dict{{{"id": "a", "time": "2026-05-12T10:00:00Z"}}},
+	}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	conf := HarmonyConfig{
+		ClientOptions: validClientOptions(),
+		ClientID:      "c", AccessKey: "s", URL: srv.URL,
+		Events: EventsConfig{Enabled: true, CloudServices: []string{"Harmony Endpoint"}, PollInterval: 10 * time.Millisecond},
+	}
+	adapter, _, err := NewHarmonyAdapter(context.Background(), conf)
+	if err != nil {
+		t.Fatalf("NewHarmonyAdapter: %v", err)
+	}
+	defer adapter.Close()
+
+	waitUntil(t, 3*time.Second, func() bool {
+		return atomic.LoadInt32(&fake.retrieveCalls) >= 1 && atomic.LoadInt32(&fake.authCalls) >= 2
+	}, "expected re-auth after 401 followed by a successful retrieve")
+}
+
+// recordingDeduper wraps an inner deduper and notifies on each admitted key.
+// We use it to observe which restore-request entities the adapter ships.
+type recordingDeduper struct {
+	mu       sync.Mutex
+	admitted []string
+	seen     map[string]struct{}
+}
+
+func newRecordingDeduper() *recordingDeduper {
+	return &recordingDeduper{seen: map[string]struct{}{}}
+}
+
+func (d *recordingDeduper) CheckAndAdd(key string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.seen[key]; ok {
+		return true
+	}
+	d.seen[key] = struct{}{}
+	d.admitted = append(d.admitted, key)
+	return false
+}
+
+func (d *recordingDeduper) Close() {}
+
+func (d *recordingDeduper) admittedKeys() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.admitted...)
+}
+
+// TestRestoreRequestsDedupAndTransition verifies the lifecycle:
+//   - On first poll, a pending request is admitted to dedup (and therefore shipped).
+//   - On subsequent polls with no change, the same entity is suppressed.
+//   - When the gateway bumps entityUpdated to reflect an admin decision, a new
+//     dedup key admits the entity again, capturing the transition.
+func TestRestoreRequestsDedupAndTransition(t *testing.T) {
+	fake := &fakeGateway{}
+	fake.hecRecords = []utils.Dict{
+		{
+			"entityInfo":    utils.Dict{"entityId": "e1", "entityUpdated": "2026-05-12T10:00:00Z"},
+			"entityPayload": utils.Dict{"isRestoreRequested": "true", "isRestored": "false", "isRestoreDeclined": "false"},
+		},
+	}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	dedup := newRecordingDeduper()
+
+	conf := HarmonyConfig{
+		ClientOptions: validClientOptions(),
+		ClientID:      "c", AccessKey: "s", URL: srv.URL,
+		RestoreRequests: RestoreRequestsConfig{
+			Enabled:      true,
+			Saas:         []string{"office365_emails"},
+			PollInterval: 30 * time.Millisecond,
+			Lookback:     1 * time.Hour,
+		},
+		Deduper: dedup,
+	}
+	adapter, _, err := NewHarmonyAdapter(context.Background(), conf)
+	if err != nil {
+		t.Fatalf("NewHarmonyAdapter: %v", err)
+	}
+	defer adapter.Close()
+
+	// Wait until the first admission lands.
+	waitUntil(t, 2*time.Second, func() bool {
+		return len(dedup.admittedKeys()) >= 1
+	}, "expected the first poll to admit the pending entity")
+
+	pendingKey := dedup.admittedKeys()[0]
+	if !strings.Contains(pendingKey, "e1") || !strings.Contains(pendingKey, "2026-05-12T10:00:00Z") {
+		t.Fatalf("unexpected pending dedup key: %q", pendingKey)
+	}
+
+	// Let a few more polls happen — count must stay at 1 since the record hasn't changed.
+	time.Sleep(200 * time.Millisecond)
+	if got := len(dedup.admittedKeys()); got != 1 {
+		t.Fatalf("expected dedup to suppress repeats; admitted=%d keys=%v", got, dedup.admittedKeys())
+	}
+	if got := atomic.LoadInt32(&fake.searchCalls); got < 2 {
+		t.Fatalf("expected multiple search polls; got %d", got)
+	}
+
+	// Now flip the record to "restored" with a fresh entityUpdated.
+	fake.mu.Lock()
+	fake.hecRecords[0] = utils.Dict{
+		"entityInfo":    utils.Dict{"entityId": "e1", "entityUpdated": "2026-05-12T11:00:00Z"},
+		"entityPayload": utils.Dict{"isRestoreRequested": "true", "isRestored": "true", "isRestoreDeclined": "false"},
+	}
+	fake.mu.Unlock()
+
+	waitUntil(t, 2*time.Second, func() bool {
+		return len(dedup.admittedKeys()) >= 2
+	}, "expected the transition to produce a second admission")
+
+	keys := dedup.admittedKeys()
+	transitionKey := keys[1]
+	if !strings.Contains(transitionKey, "2026-05-12T11:00:00Z") {
+		t.Fatalf("expected transition key to include new entityUpdated, got %q", transitionKey)
+	}
+}
+
+// TestRestoreRequestsIncludeResolvedIssuesExtraQueries asserts that toggling
+// IncludeResolved makes the adapter run three filtered queries per poll
+// (isRestoreRequested, isRestored, isRestoreDeclined). Without the toggle it
+// should only issue one.
+func TestRestoreRequestsIncludeResolvedIssuesExtraQueries(t *testing.T) {
+	mk := func(includeResolved bool) (queriesPerPoll int) {
+		fake := &fakeGateway{}
+		srv := httptest.NewServer(fake.handler())
+		defer srv.Close()
+
+		conf := HarmonyConfig{
+			ClientOptions: validClientOptions(),
+			ClientID:      "c", AccessKey: "s", URL: srv.URL,
+			RestoreRequests: RestoreRequestsConfig{
+				Enabled:         true,
+				Saas:            []string{"office365_emails"},
+				PollInterval:    1 * time.Hour, // single poll
+				Lookback:        1 * time.Hour,
+				IncludeResolved: includeResolved,
+			},
+			Deduper: newRecordingDeduper(),
+		}
+		adapter, _, err := NewHarmonyAdapter(context.Background(), conf)
+		if err != nil {
+			t.Fatalf("NewHarmonyAdapter: %v", err)
+		}
+		// Allow the initial-poll burst to complete.
+		time.Sleep(300 * time.Millisecond)
+		adapter.Close()
+		return int(atomic.LoadInt32(&fake.searchCalls))
+	}
+
+	if got := mk(false); got != 1 {
+		t.Fatalf("expected 1 search call when IncludeResolved=false, got %d", got)
+	}
+	if got := mk(true); got != 3 {
+		t.Fatalf("expected 3 search calls when IncludeResolved=true, got %d", got)
+	}
+}
+
+// waitUntil polls cond until it returns true or the timeout elapses. Fails
+// the test with msg on timeout. Used everywhere we'd otherwise need a manual
+// loop + select; keeps the test bodies focused on assertions.
+func waitUntil(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s: %s", timeout, msg)
+}

--- a/harmony/client_test.go
+++ b/harmony/client_test.go
@@ -559,8 +559,8 @@ func TestRestoreRequestsDedupAndTransition(t *testing.T) {
 			Saas:         []string{"office365_emails"},
 			PollInterval: 30 * time.Millisecond,
 			Lookback:     1 * time.Hour,
+			Deduper:      dedup,
 		},
-		Deduper: dedup,
 	}
 	adapter, _, err := NewHarmonyAdapter(context.Background(), conf)
 	if err != nil {
@@ -625,8 +625,8 @@ func TestRestoreRequestsIncludeResolvedIssuesExtraQueries(t *testing.T) {
 				PollInterval:    1 * time.Hour, // single poll
 				Lookback:        1 * time.Hour,
 				IncludeResolved: includeResolved,
+				Deduper:         newRecordingDeduper(),
 			},
-			Deduper: newRecordingDeduper(),
 		}
 		adapter, _, err := NewHarmonyAdapter(context.Background(), conf)
 		if err != nil {


### PR DESCRIPTION
## Summary

New adapter for Check Point Harmony, with two **opt-in** sources sharing a single Infinity Portal API key:

- **`events`** — Infinity Events (Logs-as-a-Service). Pulls security events across the Harmony suite via the submit→poll→retrieve flow on `/app/laas-logs-api/api/logs_query`. One worker per configured `cloud_services` entry (defaults to the full suite). Cursor advances per service.
- **`restore_requests`** — HEC entity search (`/app/hec-api/v1.0/search/query`) filtered on `entityPayload.isRestoreRequested=true`. Paged via `scrollId`, one worker per `saas` (defaults to `office365_emails` + `google_mail` — the only two HEC supports for the restore flags). Ships the full entity record (entityInfo + entityPayload + entitySecurityResults + entityActions) with `_lc_harmony_state` annotated as `pending` / `restored` / `declined`. Deduped on `entityId + entityUpdated` so a still-pending request emits once and re-emits on state transition.

Both sources share one auth path (`/auth/external`) with token caching + 401-retry. Validation requires at least one source enabled; gateway-min clamps (≥10) applied to `page_limit` / `limit`.

## Test plan

- [x] Build: `go build ./harmony ./containers/general`
- [x] Vet: `go vet ./harmony ./containers/general ./containers/conf`
- [x] Adapter type appears in `./general` usage output with both `events.*` and `restore_requests.*` config keys
- [x] Live auth against Infinity Portal `/auth/external` returns a bearer token
- [x] Live `events` flow end-to-end (submit task → state=Ready → retrieve page) against a real EU tenant, returns 100 Email & Collaboration detection records as expected
- [ ] Live `restore_requests` flow — **blocked**: requires an Infinity Portal API key with the Harmony Email & Collaboration service scope attached (the test key only had Logs-as-a-Service, so HEC returns 401). Once a properly-scoped key is available, exercise: create a quarantined email, request restore as end-user, confirm the adapter emits a `pending` record, admin restores, confirm a `restored` record is emitted with the same entityId.

## Notes for reviewers

- The Email & Collaboration `cloudService` name uses an ampersand (`Harmony Email & Collaboration`), not the word "and" — verified against the live gateway, which rejects "and" with `The provided Cloud Service is unknown`.
- For US tenants set `url: https://cloudinfra-gw-us.portal.checkpoint.com`; both `/app/laas-logs-api/` and `/app/hec-api/` share the same regional hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)