### PR TITLE
ci: stagger Arrow-heavy adapter cross-compiles to avoid OOM

### DIFF
--- a/cloudbuild_general.yaml
+++ b/cloudbuild_general.yaml
@@ -1,72 +1,96 @@
 steps:
 # Adapters
+#
+# The adapter pulls in github.com/apache/arrow/go/v15 for Parquet support
+# (see utils/parquet_supported.go). Compiling arrow/compute/internal/kernels
+# alone needs ~3-4 GB of RAM, and the N1_HIGHCPU_32 worker only has ~28.8 GB.
+# We cap Arrow-heavy compiles to 4 concurrent by chaining them into waves via
+# waitFor. The AIX build uses the parquet_unsupported.go stub and is not
+# Arrow-heavy, so it stays in wave 1.
   - name: 'golang:1.25-bookworm'
     id: run-tests
     args: ['go', 'test', './...', '-v']
+
+  # Wave 1: 3 Arrow-heavy cross-compiles + AIX stub
   - name: 'golang:1.25-bookworm'
+    id: build-linux64
     args: ['go', 'build', '-v', '-o', 'lc_adapter_linux_64', './containers/general']
     waitFor: ['run-tests']
   - name: 'golang:1.25-bookworm'
+    id: build-win64
     args: ['go', 'build', '-v', '-o', 'lc_adapter_windows_64.exe', './containers/general']
     env:
       - 'GOOS=windows'
       - 'GOARCH=amd64'
     waitFor: ['run-tests']
   - name: 'golang:1.25-bookworm'
+    id: build-macos64
     args: ['go', 'build', '-v', '-o', 'lc_adapter_macos_64', './containers/general']
     env:
       - 'GOOS=darwin'
       - 'GOARCH=amd64'
     waitFor: ['run-tests']
   - name: 'golang:1.25-bookworm'
-    args: ['go', 'build', '-v', '-o', 'lc_adapter_macos_arm64', './containers/general']
-    env:
-      - 'GOOS=darwin'
-      - 'GOARCH=arm64'
-    waitFor: ['run-tests']
-  - name: 'golang:1.25-bookworm'
-    args: ['go', 'build', '-v', '-o', 'lc_adapter_linux_arm', './containers/general']
-    env:
-      - 'GOOS=linux'
-      - 'GOARCH=arm'
-      - 'GOARM=5'
-    waitFor: ['run-tests']
-  - name: 'golang:1.25-bookworm'
-    args: ['go', 'build', '-v', '-o', 'lc_adapter_linux_arm64', './containers/general']
-    env:
-      - 'GOOS=linux'
-      - 'GOARCH=arm64'
-    waitFor: ['run-tests']
-  - name: 'golang:1.25-bookworm'
-    args: ['go', 'build', '-v', '-o', 'lc_adapter_solaris_amd64', './containers/general']
-    env:
-      - 'GOOS=solaris'
-      - 'GOARCH=amd64'
-    waitFor: ['run-tests']
-  - name: 'golang:1.25-bookworm'
+    id: build-aixppc64
     args: ['go', 'build', '-v', '-o', 'lc_adapter_aix_ppc64', './containers/general']
     env:
       - 'GOOS=aix'
       - 'GOARCH=ppc64'
     waitFor: ['run-tests']
+
+  # Wave 2: 4 Arrow-heavy cross-compiles, after wave 1
   - name: 'golang:1.25-bookworm'
+    id: build-macosarm64
+    args: ['go', 'build', '-v', '-o', 'lc_adapter_macos_arm64', './containers/general']
+    env:
+      - 'GOOS=darwin'
+      - 'GOARCH=arm64'
+    waitFor: ['build-linux64', 'build-win64', 'build-macos64']
+  - name: 'golang:1.25-bookworm'
+    id: build-linuxarm
+    args: ['go', 'build', '-v', '-o', 'lc_adapter_linux_arm', './containers/general']
+    env:
+      - 'GOOS=linux'
+      - 'GOARCH=arm'
+      - 'GOARM=5'
+    waitFor: ['build-linux64', 'build-win64', 'build-macos64']
+  - name: 'golang:1.25-bookworm'
+    id: build-linuxarm64
+    args: ['go', 'build', '-v', '-o', 'lc_adapter_linux_arm64', './containers/general']
+    env:
+      - 'GOOS=linux'
+      - 'GOARCH=arm64'
+    waitFor: ['build-linux64', 'build-win64', 'build-macos64']
+  - name: 'golang:1.25-bookworm'
+    id: build-solarisamd64
+    args: ['go', 'build', '-v', '-o', 'lc_adapter_solaris_amd64', './containers/general']
+    env:
+      - 'GOOS=solaris'
+      - 'GOARCH=amd64'
+    waitFor: ['build-linux64', 'build-win64', 'build-macos64']
+
+  # Wave 3: 3 Arrow-heavy cross-compiles, after wave 2
+  - name: 'golang:1.25-bookworm'
+    id: build-freebsdamd64
     args: ['go', 'build', '-v', '-o', 'lc_adapter_freebsd_64', './containers/general']
     env:
       - 'GOOS=freebsd'
       - 'GOARCH=amd64'
-    waitFor: ['run-tests']
+    waitFor: ['build-macosarm64', 'build-linuxarm', 'build-linuxarm64', 'build-solarisamd64']
   - name: 'golang:1.25-bookworm'
+    id: build-netbsdamd64
     args: ['go', 'build', '-v', '-o', 'lc_adapter_netbsd_64', './containers/general']
     env:
       - 'GOOS=netbsd'
       - 'GOARCH=amd64'
-    waitFor: ['run-tests']
+    waitFor: ['build-macosarm64', 'build-linuxarm', 'build-linuxarm64', 'build-solarisamd64']
   - name: 'golang:1.25-bookworm'
+    id: build-openbsdamd64
     args: ['go', 'build', '-v', '-o', 'lc_adapter_openbsd_64', './containers/general']
     env:
       - 'GOOS=openbsd'
       - 'GOARCH=amd64'
-    waitFor: ['run-tests']
+    waitFor: ['build-macosarm64', 'build-linuxarm', 'build-linuxarm64', 'build-solarisamd64']
 
 
 # Connectivity Tester
@@ -136,4 +160,4 @@ steps:
     waitFor: ['run-tests']
 options:
   machineType: 'N1_HIGHCPU_32'
-timeout: 30m
+timeout: 45m

--- a/cloudbuild_release.yaml
+++ b/cloudbuild_release.yaml
@@ -26,6 +26,15 @@ steps:
   waitFor: ['get-github-keys']
 
 # Adapters
+#
+# The adapter pulls in github.com/apache/arrow/go/v15 for Parquet support
+# (see utils/parquet_supported.go). Compiling arrow/compute/internal/kernels
+# alone needs ~3-4 GB of RAM, and the N1_HIGHCPU_32 worker only has ~28.8 GB.
+# We cap Arrow-heavy compiles to 4 concurrent by chaining them into waves via
+# waitFor. The AIX build uses the parquet_unsupported.go stub and is not
+# Arrow-heavy, so it stays in wave 1.
+
+# Wave 1: docker-general + 3 cross-compiles (4 Arrow-heavy)
 - name: 'golang:1.25-bookworm'
   id: build-linux64
   args: ['go', 'build', '-v', '-o', 'lc_adapter_linux_64_$TAG_NAME', './containers/general']
@@ -45,12 +54,21 @@ steps:
     - 'GOARCH=amd64'
   waitFor: ['get-github-keys']
 - name: 'golang:1.25-bookworm'
+  id: build-aixppc64
+  args: ['go', 'build', '-v', '-o', 'lc_adapter_aix_ppc64_$TAG_NAME', './containers/general']
+  env:
+    - 'GOOS=aix'
+    - 'GOARCH=ppc64'
+  waitFor: ['get-github-keys']
+
+# Wave 2: 4 Arrow-heavy cross-compiles, after wave 1
+- name: 'golang:1.25-bookworm'
   id: build-macosarm64
   args: ['go', 'build', '-v', '-o', 'lc_adapter_macos_arm64_$TAG_NAME', './containers/general']
   env:
     - 'GOOS=darwin'
     - 'GOARCH=arm64'
-  waitFor: ['get-github-keys']
+  waitFor: ['build-linux64', 'build-win64', 'build-macos64', 'build-docker-general']
 - name: 'golang:1.25-bookworm'
   id: build-linuxarm
   args: ['go', 'build', '-v', '-o', 'lc_adapter_linux_arm_$TAG_NAME', './containers/general']
@@ -58,49 +76,44 @@ steps:
     - 'GOOS=linux'
     - 'GOARCH=arm'
     - 'GOARM=5'
-  waitFor: ['get-github-keys']
+  waitFor: ['build-linux64', 'build-win64', 'build-macos64', 'build-docker-general']
 - name: 'golang:1.25-bookworm'
   id: build-linuxarm64
   args: ['go', 'build', '-v', '-o', 'lc_adapter_linux_arm64_$TAG_NAME', './containers/general']
   env:
     - 'GOOS=linux'
     - 'GOARCH=arm64'
-  waitFor: ['get-github-keys']
+  waitFor: ['build-linux64', 'build-win64', 'build-macos64', 'build-docker-general']
 - name: 'golang:1.25-bookworm'
   id: build-solarisamd64
   args: ['go', 'build', '-v', '-o', 'lc_adapter_solaris_amd64_$TAG_NAME', './containers/general']
   env:
     - 'GOOS=solaris'
     - 'GOARCH=amd64'
-  waitFor: ['get-github-keys']
-- name: 'golang:1.25-bookworm'
-  id: build-aixppc64
-  args: ['go', 'build', '-v', '-o', 'lc_adapter_aix_ppc64_$TAG_NAME', './containers/general']
-  env:
-    - 'GOOS=aix'
-    - 'GOARCH=ppc64'
-  waitFor: ['get-github-keys']
+  waitFor: ['build-linux64', 'build-win64', 'build-macos64', 'build-docker-general']
+
+# Wave 3: 3 Arrow-heavy cross-compiles, after wave 2
 - name: 'golang:1.25-bookworm'
   id: 'build-freebsdamd64'
   args: ['go', 'build', '-v', '-o', 'lc_adapter_freebsd_64_$TAG_NAME', './containers/general']
   env:
     - 'GOOS=freebsd'
     - 'GOARCH=amd64'
-  waitFor: ['get-github-keys']
+  waitFor: ['build-macosarm64', 'build-linuxarm', 'build-linuxarm64', 'build-solarisamd64']
 - name: 'golang:1.25-bookworm'
   id: 'build-netbsdamd64'
   args: ['go', 'build', '-v', '-o', 'lc_adapter_netbsd_64_$TAG_NAME', './containers/general']
   env:
     - 'GOOS=netbsd'
     - 'GOARCH=amd64'
-  waitFor: ['get-github-keys']
+  waitFor: ['build-macosarm64', 'build-linuxarm', 'build-linuxarm64', 'build-solarisamd64']
 - name: 'golang:1.25-bookworm'
   id: 'build-openbsdamd64'
   args: ['go', 'build', '-v', '-o', 'lc_adapter_openbsd_64_$TAG_NAME', './containers/general']
   env:
     - 'GOOS=openbsd'
     - 'GOARCH=amd64'
-  waitFor: ['get-github-keys']
+  waitFor: ['build-macosarm64', 'build-linuxarm', 'build-linuxarm64', 'build-solarisamd64']
 
 # Connectivity Tester
 - name: 'golang:1.25-bookworm'
@@ -224,4 +237,4 @@ availableSecrets:
     env: 'SSH_KEY'
 options:
   machineType: 'N1_HIGHCPU_32'
-timeout: 30m
+timeout: 45m


### PR DESCRIPTION
## Summary

- Release build [ec4f5953](https://console.cloud.google.com/cloud-build/builds;region=global/ec4f5953-08b7-4e41-bf53-71b9ded3d112?project=legion-212720) for v1.32.18 failed: the Go compiler was OOM-killed while building `github.com/apache/arrow/go/v15/arrow/compute/internal/kernels`.
- Apache Arrow (introduced in #273 for Parquet support) needs ~3-4 GB of RAM to compile that one package. The release pipeline fans out 11 cross-platform adapter builds + the docker general build in parallel on a single N1_HIGHCPU_32 worker (~28.8 GB), and the kernel OOM-killed one of them.
- Split the Arrow-heavy builds into three waves of at most 4 concurrent via `waitFor`. Non-Arrow steps (11 connectivity binaries, the AIX adapter stub, zeek/zeek_extract/k8s_pods docker images) keep their original parallelism.
- Mirrored the same wave structure in `cloudbuild_general.yaml` (CI on every commit), which has the same OOM risk.
- Bumped timeout from 30m to 45m for headroom across the serialized waves.

## Test plan

- [ ] Re-tag v1.32.18 (or cut a new patch) and confirm the Cloud Build release pipeline completes without OOM.
- [ ] Confirm a regular CI build on a PR using the new general pipeline finishes within the 45m timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)