### PR TITLE
fix(harmony): treat events task Canceled as a soft failure

### DIFF
--- a/harmony/client.go
+++ b/harmony/client.go
@@ -413,9 +413,22 @@ func (a *HarmonyAdapter) fetchEventsForService(service string) {
 		}
 
 		newCursor, err := a.runOneEventsQuery(service, nextStart, endTime)
-		if err != nil {
+		var canceled *taskCanceledError
+		switch {
+		case errors.As(err, &canceled):
+			// Soft failure: the gateway accepted the query but couldn't
+			// fulfill it for this service (commonly: the service isn't
+			// provisioned for the tenant). Warn once per poll with the
+			// gateway's error detail, advance the cursor so we don't keep
+			// re-querying the same window, and let the next poll try
+			// again — most non-provisioned services stay non-provisioned,
+			// so the operator should remove them from cloud_services if
+			// they want the warnings to stop.
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf("harmony[events:%s]: %v — skipping window", service, canceled))
+			nextStart = endTime
+		case err != nil:
 			a.conf.ClientOptions.OnError(fmt.Errorf("harmony[events:%s]: %v", service, err))
-		} else if !newCursor.IsZero() {
+		case !newCursor.IsZero():
 			nextStart = newCursor
 		}
 
@@ -433,7 +446,8 @@ func (a *HarmonyAdapter) runOneEventsQuery(service string, startTime, endTime ti
 
 	pageTokens, err := a.waitForEventsTask(taskID)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("waitForEventsTask: %v", err)
+		// Wrap with %w so callers can errors.As to detect taskCanceledError.
+		return time.Time{}, fmt.Errorf("waitForEventsTask: %w", err)
 	}
 	if len(pageTokens) == 0 {
 		return endTime, nil
@@ -502,6 +516,25 @@ func (a *HarmonyAdapter) submitEventsQuery(service string, startTime, endTime ti
 	return taskID, nil
 }
 
+// taskCanceledError is returned when the gateway terminates a logs_query
+// task with state "Canceled". This is the gateway's response when it can't
+// fulfill the query (e.g. a cloud service that's listed in our default set
+// but not provisioned for the tenant), and it surfaces as HTTP 200 with the
+// "Canceled" state field — not as a transport error. We carry the gateway's
+// error details on the type so the worker can emit a meaningful warning,
+// and so callers can errors.As for soft-fail handling.
+type taskCanceledError struct {
+	TaskID  string
+	Details []string
+}
+
+func (e *taskCanceledError) Error() string {
+	if len(e.Details) == 0 {
+		return fmt.Sprintf("task %s canceled by server", e.TaskID)
+	}
+	return fmt.Sprintf("task %s canceled by server: %s", e.TaskID, strings.Join(e.Details, "; "))
+}
+
 func (a *HarmonyAdapter) waitForEventsTask(taskID string) ([]string, error) {
 	deadline := time.Now().Add(defaultEventsStatusPollTotal)
 	for {
@@ -527,7 +560,15 @@ func (a *HarmonyAdapter) waitForEventsTask(taskID string) ([]string, error) {
 		case "Done":
 			return nil, nil
 		case "Canceled":
-			return nil, fmt.Errorf("task %s canceled by server", taskID)
+			details := []string{}
+			if rawErrs, ok := data.GetList("errors"); ok {
+				for _, e := range rawErrs {
+					if s, ok := e.(string); ok {
+						details = append(details, s)
+					}
+				}
+			}
+			return nil, &taskCanceledError{TaskID: taskID, Details: details}
 		}
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("task %s did not reach a terminal state within %s (last state=%q)", taskID, defaultEventsStatusPollTotal, state)

--- a/harmony/client.go
+++ b/harmony/client.go
@@ -563,8 +563,15 @@ func (a *HarmonyAdapter) waitForEventsTask(taskID string) ([]string, error) {
 			details := []string{}
 			if rawErrs, ok := data.GetList("errors"); ok {
 				for _, e := range rawErrs {
+					// Today the gateway emits plain strings here. JSON-marshal
+					// anything else so the warning still carries the detail if
+					// Check Point ever switches to structured error objects.
 					if s, ok := e.(string); ok {
 						details = append(details, s)
+						continue
+					}
+					if b, err := json.Marshal(e); err == nil {
+						details = append(details, string(b))
 					}
 				}
 			}

--- a/harmony/client_test.go
+++ b/harmony/client_test.go
@@ -303,6 +303,12 @@ type fakeGateway struct {
 	// Records returned by laas retrieve, optionally split into multiple pages.
 	eventPages [][]utils.Dict
 
+	// When non-nil, every laas status poll returns state "Canceled" with
+	// these strings as the gateway's error detail — used to exercise the
+	// soft-fail path the adapter takes when a service can't be fulfilled
+	// for the tenant (e.g. not-provisioned products).
+	cancelEventsTaskWith []string
+
 	// Records returned by the HEC search; can be swapped at runtime to simulate transitions.
 	hecRecords []utils.Dict
 }
@@ -370,6 +376,14 @@ func (f *fakeGateway) serveEventsStatus(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	atomic.AddInt32(&f.statusCalls, 1)
+	if f.cancelEventsTaskWith != nil {
+		errs := make([]interface{}, len(f.cancelEventsTaskWith))
+		for i, s := range f.cancelEventsTaskWith {
+			errs[i] = s
+		}
+		writeJSON(w, http.StatusOK, utils.Dict{"data": utils.Dict{"state": "Canceled", "errors": errs}})
+		return
+	}
 	tokens := []string{}
 	for i := range f.eventPages {
 		tokens = append(tokens, fmt.Sprintf("page-%d", i))
@@ -496,6 +510,69 @@ func TestEventsReAuthOn401(t *testing.T) {
 	waitUntil(t, 3*time.Second, func() bool {
 		return atomic.LoadInt32(&fake.retrieveCalls) >= 1 && atomic.LoadInt32(&fake.authCalls) >= 2
 	}, "expected re-auth after 401 followed by a successful retrieve")
+}
+
+// TestEventsCanceledIsSoftFailure asserts that a logs_query task ending in
+// state "Canceled" is treated as a per-service soft failure: OnWarning fires
+// with the gateway's error detail, OnError stays silent, and the worker
+// keeps polling instead of either bubbling the error up or wedging.
+//
+// This is the failure mode the gateway returns when a cloud service is
+// listed in cloud_services but isn't actually provisioned for the tenant
+// (e.g. "Harmony Connect" on a tenant that only has Email/Endpoint/Mobile).
+// Bubbling it as OnError would spam the operator's error stream every
+// poll_interval for every non-provisioned product in the default list.
+func TestEventsCanceledIsSoftFailure(t *testing.T) {
+	fake := &fakeGateway{cancelEventsTaskWith: []string{"Couldn't process request"}}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	var warnings []string
+	var errors []string
+	var mu sync.Mutex
+	opts := validClientOptions()
+	opts.OnWarning = func(msg string) {
+		mu.Lock()
+		warnings = append(warnings, msg)
+		mu.Unlock()
+	}
+	opts.OnError = func(err error) {
+		mu.Lock()
+		errors = append(errors, err.Error())
+		mu.Unlock()
+	}
+
+	conf := HarmonyConfig{
+		ClientOptions: opts,
+		ClientID:      "c", AccessKey: "s", URL: srv.URL,
+		Events: EventsConfig{Enabled: true, CloudServices: []string{"Harmony Connect"}, PollInterval: 10 * time.Millisecond},
+	}
+	adapter, _, err := NewHarmonyAdapter(context.Background(), conf)
+	if err != nil {
+		t.Fatalf("NewHarmonyAdapter: %v", err)
+	}
+	defer adapter.Close()
+
+	// Wait until we've seen at least two cancellations — proves the worker
+	// keeps polling instead of wedging on the first one.
+	waitUntil(t, 3*time.Second, func() bool {
+		return atomic.LoadInt32(&fake.statusCalls) >= 2
+	}, "expected the worker to keep polling after a Canceled status")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(errors) != 0 {
+		t.Fatalf("Canceled should not surface as OnError; got %d errors: %v", len(errors), errors)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected at least one OnWarning for the Canceled status")
+	}
+	if !strings.Contains(warnings[0], "Harmony Connect") {
+		t.Fatalf("warning should name the offending service; got %q", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "Couldn't process request") {
+		t.Fatalf("warning should include the gateway's error detail; got %q", warnings[0])
+	}
 }
 
 // recordingDeduper wraps an inner deduper and notifies on each admitted key.

--- a/harmony/client_test.go
+++ b/harmony/client_test.go
@@ -303,11 +303,18 @@ type fakeGateway struct {
 	// Records returned by laas retrieve, optionally split into multiple pages.
 	eventPages [][]utils.Dict
 
-	// When non-nil, every laas status poll returns state "Canceled" with
-	// these strings as the gateway's error detail — used to exercise the
-	// soft-fail path the adapter takes when a service can't be fulfilled
-	// for the tenant (e.g. not-provisioned products).
-	cancelEventsTaskWith []string
+	// cancelEventsErrors is the errors[] payload returned alongside a
+	// Canceled status. The gateway emits strings today; cancelEventsErrorsAny
+	// lets a test stick non-string values in there to exercise the JSON
+	// marshal fallback path.
+	cancelEventsErrors    []string
+	cancelEventsErrorsAny []interface{}
+
+	// cancelEventsTimes controls how many status polls return Canceled
+	// before the gateway reverts to normal Ready/Done behavior. Negative
+	// values mean "always cancel" (used to model a not-provisioned cloud
+	// service that never recovers).
+	cancelEventsTimes int
 
 	// Records returned by the HEC search; can be swapped at runtime to simulate transitions.
 	hecRecords []utils.Dict
@@ -376,14 +383,26 @@ func (f *fakeGateway) serveEventsStatus(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	atomic.AddInt32(&f.statusCalls, 1)
-	if f.cancelEventsTaskWith != nil {
-		errs := make([]interface{}, len(f.cancelEventsTaskWith))
-		for i, s := range f.cancelEventsTaskWith {
-			errs[i] = s
+
+	f.mu.Lock()
+	shouldCancel := f.cancelEventsTimes != 0
+	if f.cancelEventsTimes > 0 {
+		f.cancelEventsTimes--
+	}
+	stringErrs := append([]string(nil), f.cancelEventsErrors...)
+	anyErrs := append([]interface{}(nil), f.cancelEventsErrorsAny...)
+	f.mu.Unlock()
+
+	if shouldCancel {
+		errs := make([]interface{}, 0, len(stringErrs)+len(anyErrs))
+		for _, s := range stringErrs {
+			errs = append(errs, s)
 		}
+		errs = append(errs, anyErrs...)
 		writeJSON(w, http.StatusOK, utils.Dict{"data": utils.Dict{"state": "Canceled", "errors": errs}})
 		return
 	}
+
 	tokens := []string{}
 	for i := range f.eventPages {
 		tokens = append(tokens, fmt.Sprintf("page-%d", i))
@@ -523,7 +542,10 @@ func TestEventsReAuthOn401(t *testing.T) {
 // Bubbling it as OnError would spam the operator's error stream every
 // poll_interval for every non-provisioned product in the default list.
 func TestEventsCanceledIsSoftFailure(t *testing.T) {
-	fake := &fakeGateway{cancelEventsTaskWith: []string{"Couldn't process request"}}
+	fake := &fakeGateway{
+		cancelEventsErrors: []string{"Couldn't process request"},
+		cancelEventsTimes:  -1, // persistently canceled, never recovers
+	}
 	srv := httptest.NewServer(fake.handler())
 	defer srv.Close()
 
@@ -572,6 +594,113 @@ func TestEventsCanceledIsSoftFailure(t *testing.T) {
 	}
 	if !strings.Contains(warnings[0], "Couldn't process request") {
 		t.Fatalf("warning should include the gateway's error detail; got %q", warnings[0])
+	}
+}
+
+// TestEventsCanceledTransientRecovery covers the recovery case: the gateway
+// cancels exactly one task and then resumes normal Ready/Done responses. The
+// worker must surface a single OnWarning, no OnError, and eventually issue a
+// retrieve once the gateway recovers — proving the cursor wasn't wedged and
+// that the soft-fail path lets normal traffic resume on the next poll.
+func TestEventsCanceledTransientRecovery(t *testing.T) {
+	fake := &fakeGateway{
+		cancelEventsErrors: []string{"Transient gateway hiccup"},
+		cancelEventsTimes:  1, // cancel exactly once, then recover
+		eventPages: [][]utils.Dict{
+			{{"id": "post-recovery", "time": "2026-05-14T22:00:00Z"}},
+		},
+	}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	var warnings, errs []string
+	var mu sync.Mutex
+	opts := validClientOptions()
+	opts.OnWarning = func(msg string) {
+		mu.Lock()
+		warnings = append(warnings, msg)
+		mu.Unlock()
+	}
+	opts.OnError = func(err error) {
+		mu.Lock()
+		errs = append(errs, err.Error())
+		mu.Unlock()
+	}
+
+	conf := HarmonyConfig{
+		ClientOptions: opts,
+		ClientID:      "c", AccessKey: "s", URL: srv.URL,
+		Events: EventsConfig{Enabled: true, CloudServices: []string{"Harmony Endpoint"}, PollInterval: 10 * time.Millisecond},
+	}
+	adapter, _, err := NewHarmonyAdapter(context.Background(), conf)
+	if err != nil {
+		t.Fatalf("NewHarmonyAdapter: %v", err)
+	}
+	defer adapter.Close()
+
+	// A successful retrieve only happens after the gateway recovers, so this
+	// is the cleanest proof of "post-cancellation traffic flows again".
+	waitUntil(t, 3*time.Second, func() bool {
+		return atomic.LoadInt32(&fake.retrieveCalls) >= 1
+	}, "expected a retrieve to succeed after the transient cancel")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(errs) != 0 {
+		t.Fatalf("transient Canceled should not surface as OnError; got %d errors: %v", len(errs), errs)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected exactly one OnWarning for the transient cancel")
+	}
+}
+
+// TestEventsCanceledMarshalsStructuredErrorDetail pins the JSON-marshal
+// fallback for non-string errors[] entries. Today Check Point returns
+// strings; if it ever switches to objects we want the warning to still
+// carry the detail rather than silently dropping it.
+func TestEventsCanceledMarshalsStructuredErrorDetail(t *testing.T) {
+	fake := &fakeGateway{
+		cancelEventsErrorsAny: []interface{}{
+			map[string]interface{}{"code": 5042, "message": "Service not provisioned"},
+		},
+		cancelEventsTimes: -1,
+	}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	var warnings []string
+	var mu sync.Mutex
+	opts := validClientOptions()
+	opts.OnWarning = func(msg string) {
+		mu.Lock()
+		warnings = append(warnings, msg)
+		mu.Unlock()
+	}
+	opts.OnError = func(error) {}
+
+	conf := HarmonyConfig{
+		ClientOptions: opts,
+		ClientID:      "c", AccessKey: "s", URL: srv.URL,
+		Events: EventsConfig{Enabled: true, CloudServices: []string{"Harmony Endpoint"}, PollInterval: 10 * time.Millisecond},
+	}
+	adapter, _, err := NewHarmonyAdapter(context.Background(), conf)
+	if err != nil {
+		t.Fatalf("NewHarmonyAdapter: %v", err)
+	}
+	defer adapter.Close()
+
+	waitUntil(t, 3*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(warnings) >= 1
+	}, "expected a warning for the canceled task")
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Both fields from the object should appear somewhere in the warning,
+	// proving the marshal fallback ran and kept the detail.
+	if !strings.Contains(warnings[0], "5042") || !strings.Contains(warnings[0], "Service not provisioned") {
+		t.Fatalf("warning should carry the structured error detail via JSON marshal; got %q", warnings[0])
 	}
 }
 


### PR DESCRIPTION
## Problem

When the gateway terminates a `logs_query` task with `state: "Canceled"` and `errors: ["Couldn't process request"]`, the adapter was bubbling that up via `OnError`. This happens once per `events.poll_interval` for every cloud_service the gateway can't fulfill — most commonly products listed in the default `cloud_services` set that aren't actually provisioned for the tenant (e.g. \"Harmony Connect\" on an Email/Endpoint/Mobile-only tenant). Net effect: the operator's error stream gets one message per minute per non-provisioned product, indefinitely.

Reproduced empirically: with the default `cloud_services` list against a tenant without Harmony Connect, the submit returns `200 {"data":{"taskId":"..."}}` normally, but the very first status poll returns `200 {"data":{"state":"Canceled","errors":["Couldn't process request"]}}`.

## Fix

Treat `Canceled` as a per-service soft failure:

- New typed `taskCanceledError` carries the gateway's `errors[]` detail.
- `waitForEventsTask` returns it on state=Canceled; `runOneEventsQuery` wraps with `%w` so callers can `errors.As` it.
- The events worker `errors.As`-checks, emits **OnWarning** (not OnError) with the offending service name and the gateway's reason, and advances the cursor past the failed window so we don't keep re-querying the same range. Recovery if the service later becomes provisioned still works on the next poll.
- Other services in the same `cloud_services` list are unaffected — each runs in its own goroutine.

## Test plan

- [x] Build: `go build ./...`
- [x] Race: `CGO_ENABLED=1 go test ./harmony -race -timeout 60s`
- [x] New `TestEventsCanceledIsSoftFailure` that points the worker at a `fakeGateway` returning `Canceled` and asserts: `OnError` fires zero times, `OnWarning` fires at least once with both the service name and the gateway's error detail in the message, and the worker keeps polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)