### PR TITLE
Add generic ThreatLocker adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,13 @@ journalctl -f -q | netcat 127.0.0.1 4444
 ```
 ./adapter stdin client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=text "client_options.mapping.parsing_re=(?P<date>... \d\d \d\d:\d\d:\d\d) (?P<host>.+) (?P<exe>.+?)\[(?P<pid>\d+)\]: (?P<msg>.*)" client_options.sensor_seed_key=testclient3 client_options.mapping.event_type_path=exe
 ```
+
+### ThreatLocker
+
+Pulls events from the ThreatLocker Portal API. By default it collects pending
+Application Control approval requests; additional ThreatLocker event types can
+be added purely through configuration. See [threatlocker/README.md](./threatlocker/README.md).
+
+```
+./general threatlocker client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=threatlocker api_key=$THREATLOCKER_API_TOKEN instance=g
+```

--- a/containers/conf/all.go
+++ b/containers/conf/all.go
@@ -39,6 +39,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/stdin"
 	"github.com/refractionPOINT/usp-adapters/sublime"
 	"github.com/refractionPOINT/usp-adapters/syslog"
+	"github.com/refractionPOINT/usp-adapters/threatlocker"
 	"github.com/refractionPOINT/usp-adapters/trendmicro"
 	"github.com/refractionPOINT/usp-adapters/wel"
 	"github.com/refractionPOINT/usp-adapters/wiz"
@@ -87,6 +88,7 @@ type GeneralConfigs struct {
 	Box               usp_box.BoxConfig                               `json:"box" yaml:"box"`
 	Sublime           usp_sublime.SublimeConfig                       `json:"sublime" yaml:"sublime"`
 	SentinelOne       usp_sentinelone.SentinelOneConfig               `json:"sentinel_one" yaml:"sentinel_one"`
+	ThreatLocker      usp_threatlocker.ThreatLockerConfig             `json:"threatlocker" yaml:"threatlocker"`
 	TrendMicro        usp_trendmicro.TrendMicroConfig                 `json:"trendmicro" yaml:"trendmicro"`
 	Wiz               usp_wiz.WizConfig                               `json:"wiz" yaml:"wiz"`
 }

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -53,6 +53,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/stdin"
 	"github.com/refractionPOINT/usp-adapters/sublime"
 	"github.com/refractionPOINT/usp-adapters/syslog"
+	"github.com/refractionPOINT/usp-adapters/threatlocker"
 	"github.com/refractionPOINT/usp-adapters/trendmicro"
 	"github.com/refractionPOINT/usp-adapters/wel"
 	"github.com/refractionPOINT/usp-adapters/wiz"
@@ -492,6 +493,11 @@ func runAdapter(ctx context.Context, method string, configs Configuration, showC
 		configs.TrendMicro.ClientOptions.Architecture = "usp_adapter"
 		configToShow = configs.TrendMicro
 		client, chRunning, err = usp_trendmicro.NewTrendMicroAdapter(ctx, configs.TrendMicro)
+	} else if method == "threatlocker" {
+		configs.ThreatLocker.ClientOptions = applyLogging(configs.ThreatLocker.ClientOptions)
+		configs.ThreatLocker.ClientOptions.Architecture = "usp_adapter"
+		configToShow = configs.ThreatLocker
+		client, chRunning, err = usp_threatlocker.NewThreatLockerAdapter(ctx, configs.ThreatLocker)
 	} else {
 		return nil, nil, errors.New(logError("unknown adapter_type: %s", method))
 	}

--- a/threatlocker/README.md
+++ b/threatlocker/README.md
@@ -12,10 +12,23 @@ event type is purely a configuration change — no code change required.
 
 ## Out of the box
 
-With no `feeds` configured, the adapter polls a single feed: **pending
-Application Control approval requests** (`statusId = 1`). Each pending request
-is shipped exactly once, which is well suited to triggering automated
-investigations in LimaCharlie.
+With no `feeds` configured, the adapter polls three feeds that together cover
+ThreatLocker's primary telemetry surfaces:
+
+| Default feed | ThreatLocker endpoint | What it carries |
+|---|---|---|
+| `approval_request` | `ApprovalRequest/ApprovalRequestGetByParameters` (`statusId = 1`) | Pending Application Control whitelist requests — one event per new request, shipped exactly once. Well suited to triggering automated investigations in LimaCharlie. |
+| `unified_audit` | `ActionLog/ActionLogGetByParametersV2` | The **Unified Audit** — ThreatLocker's combined event stream of `execute` / `install` / `network` / `registry` / `read` / `write` / `move` / `delete` / `baseline` / `powershell` / `elevate` / web activity across every module. Polled on a 5-minute rolling window. |
+| `system_audit` | `SystemAudit/SystemAuditGetByParameters` | Portal / administrator activity — logins, policy edits, approval decisions, organization changes. Polled on a 5-minute rolling window. |
+
+`unified_audit` and `system_audit` both *require* a `startDate`/`endDate` filter
+on every request; the adapter rewrites those fields automatically (see the
+`window` feed setting below). At-least-once delivery is preserved by the
+per-feed deduper.
+
+Override `feeds` in your config to add custom feeds (e.g. denied approval
+requests, child-organization-scoped queries) or to replace the defaults
+entirely.
 
 ## Authentication
 
@@ -49,7 +62,7 @@ Access** (e.g. `ThreatLocker Access (C)` → `instance: c`).
 | `instance` | yes* | ThreatLocker instance identifier (e.g. `g`). *Required unless `base_url` is set. |
 | `base_url` | no | Full API root override, e.g. `https://portalapi.g.threatlocker.com/portalapi`. |
 | `managed_organization_id` | no | Scopes every request to that organization via the `managedOrganizationId` header. |
-| `feeds` | no | List of feeds to poll. Defaults to pending approval requests. |
+| `feeds` | no | List of feeds to poll. Defaults to the three feeds listed under [Out of the box](#out-of-the-box). |
 | `page_size` | no | Records per page. Default `100` (max `1000`). |
 | `poll_interval` | no | Wait between polls, as a Go duration in nanoseconds. Default `60000000000` (1 minute). |
 | `dedupe_ttl` | no | How long a record id is remembered to suppress re-shipping. Default 7 days. |
@@ -67,6 +80,8 @@ Access** (e.g. `ThreatLocker Access (C)` → `instance: c`).
 | `timestamp_field` | no | Path to the record's event time (supports `/`-separated nested paths). Default `dateTime`. |
 | `id_field` | no | Path to the record's stable identifier, used for deduplication. Falls back to common id fields, then a content hash. |
 | `max_pages` | no | Caps pages fetched per poll. Default `100`. |
+| `window` | no | When set (e.g. `5m`), rewrites `startDate` / `endDate` on every poll to a rolling `[now-window-poll_interval, now]` range. Required for endpoints that mandate a date range (`ActionLog`, `SystemAudit`). The overlap with the previous poll is absorbed by the deduper. |
+| `start_date_field` / `end_date_field` | no | Override the request-body field names used by `window`. Defaults: `startDate` / `endDate`. |
 
 ## How polling works
 
@@ -102,7 +117,8 @@ Default (pending approval requests), via the CLI:
   instance=g
 ```
 
-Multiple feeds, via a YAML config file:
+Adding a custom feed (e.g. ship *denied* approval requests too) on top of the
+defaults, via a YAML config file:
 
 ```yaml
 threatlocker:
@@ -115,17 +131,36 @@ threatlocker:
   api_key: $THREATLOCKER_API_TOKEN
   instance: g
   feeds:
+    # Re-declare the three defaults explicitly so this list fully replaces them,
+    # then append the custom feed.
     - name: approval_request
       url: ApprovalRequest/ApprovalRequestGetByParameters
       parameters:
         statusId: 1            # pending
         showChildOrganizations: false
-      timestamp_field: dateTime
       id_field: approvalRequestId
     - name: unified_audit
       url: ActionLog/ActionLogGetByParametersV2
+      window: 5m
       parameters:
-        # endpoint-specific filters (e.g. a date range) go here
-      timestamp_field: dateTime
-      # id_field: set to the record's stable identifier for reliable dedup
+        paramsFieldsDto: []
+        groupBys: []
+        exportMode: false
+        showTotalCount: false
+        showChildOrganizations: false
+        onlyTrueDenies: false
+        simulateDeny: false
+      id_field: actionLogId
+    - name: system_audit
+      url: SystemAudit/SystemAuditGetByParameters
+      window: 5m
+      parameters:
+        viewChildOrganizations: false
+      id_field: systemAuditId
+    - name: approval_request_denied
+      url: ApprovalRequest/ApprovalRequestGetByParameters
+      parameters:
+        statusId: 3            # denied
+        showChildOrganizations: false
+      id_field: approvalRequestId
 ```

--- a/threatlocker/README.md
+++ b/threatlocker/README.md
@@ -1,0 +1,109 @@
+# ThreatLocker Adapter
+
+Pulls events from the [ThreatLocker](https://www.threatlocker.com/) Portal API
+into LimaCharlie. Events are forwarded in their original ThreatLocker JSON form
+— the adapter does not reshape payloads.
+
+The adapter is intentionally generic. The ThreatLocker Portal API is uniform:
+every queryable resource exposes a `<Resource>GetByParameters` endpoint that
+takes a `POST` with a JSON body describing the filter, sort order and
+pagination. The adapter models each such endpoint as a **feed**, so adding a new
+event type is purely a configuration change — no code change required.
+
+## Out of the box
+
+With no `feeds` configured, the adapter polls a single feed: **pending
+Application Control approval requests** (`statusId = 1`). Each pending request
+is shipped exactly once, which is well suited to triggering automated
+investigations in LimaCharlie.
+
+## Authentication
+
+Create an API token under **Portal → Administration → API Users** in the
+ThreatLocker portal. The token is sent verbatim in the `Authorization` header.
+
+The API root is `https://portalapi.<instance>.threatlocker.com/portalapi`, where
+`<instance>` is your ThreatLocker instance. Provide it via `instance`, or set
+`base_url` to override the whole root.
+
+## Configuration
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `client_options` | yes | Standard USP adapter options (see the repo README). |
+| `api_key` | yes | ThreatLocker API token. |
+| `instance` | yes* | ThreatLocker instance identifier (e.g. `g`). *Required unless `base_url` is set. |
+| `base_url` | no | Full API root override, e.g. `https://portalapi.g.threatlocker.com/portalapi`. |
+| `managed_organization_id` | no | Scopes every request to that organization via the `managedOrganizationId` header. |
+| `feeds` | no | List of feeds to poll. Defaults to pending approval requests. |
+| `page_size` | no | Records per page. Default `100` (max `1000`). |
+| `poll_interval` | no | Wait between polls, as a Go duration in nanoseconds. Default `60000000000` (1 minute). |
+| `dedupe_ttl` | no | How long a record id is remembered to suppress re-shipping. Default 7 days. |
+| `retry_base_delay` / `max_retry_delay` / `max_retry_attempts` | no | Transient-failure retry tuning. |
+
+### Feed fields
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `name` | yes | Labels the feed and becomes the `EventType` of every shipped event. |
+| `url` | yes | API path of the `*GetByParameters` endpoint, relative to the API root. |
+| `parameters` | no | JSON object merged into the request body (resource-specific filters). |
+| `order_by` | no | Sort field. Default `dateTime`. |
+| `items_path` | no | Key holding the records array when the response is an object envelope. Auto-detected (`data`, `pageItems`, ...) when empty. |
+| `timestamp_field` | no | Path to the record's event time (supports `/`-separated nested paths). Default `dateTime`. |
+| `id_field` | no | Path to the record's stable identifier, used for deduplication. Falls back to common id fields, then a content hash. |
+| `max_pages` | no | Caps pages fetched per poll. Default `100`. |
+
+## How polling works
+
+For each feed the adapter walks pages **newest-first** and stops as soon as
+either a short page is returned, or a page contains no records it has not
+already shipped. Because new records always land on the first page, this makes
+each poll cheap once caught up. An in-memory deduper (keyed per feed) guarantees
+each record is shipped once. Transient API failures (HTTP 5xx, 429, network
+errors) are retried with exponential backoff; an authentication failure
+(401/403) stops the adapter.
+
+> Feeds must be sorted newest-first (`isAscending = false`, the default) for the
+> incremental polling and early-stop to behave correctly.
+
+## Examples
+
+Default (pending approval requests), via the CLI:
+
+```
+./general threatlocker \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=json \
+  client_options.sensor_seed_key=threatlocker \
+  api_key=$THREATLOCKER_API_TOKEN \
+  instance=g
+```
+
+Multiple feeds, via a YAML config file:
+
+```yaml
+threatlocker:
+  client_options:
+    identity:
+      oid: $OID
+      installation_key: $INSTALLATION_KEY
+    platform: json
+    sensor_seed_key: threatlocker
+  api_key: $THREATLOCKER_API_TOKEN
+  instance: g
+  feeds:
+    - name: approval_request
+      url: ApprovalRequest/ApprovalRequestGetByParameters
+      parameters:
+        statusId: 1            # pending
+        showChildOrganizations: false
+      timestamp_field: dateTime
+      id_field: approvalRequestId
+    - name: unified_audit
+      url: ActionLog/ActionLogGetByParametersV2
+      parameters:
+        # endpoint-specific filters go here
+      timestamp_field: dateTime
+```

--- a/threatlocker/README.md
+++ b/threatlocker/README.md
@@ -56,16 +56,23 @@ The API root is `https://portalapi.<instance>.threatlocker.com/portalapi`, where
 
 ## How polling works
 
-For each feed the adapter walks pages **newest-first** and stops as soon as
-either a short page is returned, or a page contains no records it has not
-already shipped. Because new records always land on the first page, this makes
-each poll cheap once caught up. An in-memory deduper (keyed per feed) guarantees
-each record is shipped once. Transient API failures (HTTP 5xx, 429, network
-errors) are retried with exponential backoff; an authentication failure
-(401/403) stops the adapter.
+On every poll the adapter walks a feed's pages (`pageNumber`/`pageSize`) until
+the result set is exhausted (a short or empty page) or the feed's `max_pages`
+cap is reached. An in-memory deduper, keyed per feed, guarantees each record is
+shipped to LimaCharlie exactly once even though pages are re-fetched on every
+poll. Transient API failures (HTTP 5xx, 429, network errors) are retried with
+exponential backoff; an authentication failure (401/403) stops the adapter.
 
-> Feeds must be sorted newest-first (`isAscending = false`, the default) for the
-> incremental polling and early-stop to behave correctly.
+The adapter deliberately re-walks every page rather than stopping early at the
+first page of already-seen records: the API paginates by offset over a live,
+mutable list, so a record can shift across a page boundary between two page
+fetches and an early stop could skip it permanently. Re-walking costs more
+requests but is correct.
+
+For a large or high-churn feed, bound each poll's work with the feed's
+`parameters` (e.g. a date-range filter) and a `max_pages` that comfortably
+exceeds the feed's expected size. Querying newest-first (`isAscending = false`,
+the default) keeps the most recent records when `max_pages` truncates.
 
 ## Examples
 
@@ -104,6 +111,7 @@ threatlocker:
     - name: unified_audit
       url: ActionLog/ActionLogGetByParametersV2
       parameters:
-        # endpoint-specific filters go here
+        # endpoint-specific filters (e.g. a date range) go here
       timestamp_field: dateTime
+      # id_field: set to the record's stable identifier for reliable dedup
 ```

--- a/threatlocker/README.md
+++ b/threatlocker/README.md
@@ -26,6 +26,20 @@ The API root is `https://portalapi.<instance>.threatlocker.com/portalapi`, where
 `<instance>` is your ThreatLocker instance. Provide it via `instance`, or set
 `base_url` to override the whole root.
 
+### Finding your instance
+
+ThreatLocker hosts each tenant on one of several lettered instances (`b`, `c`,
+`d`, …) and API tokens are scoped to the instance that minted them. To find
+yours, open the ThreatLocker Portal, click the **Help** button in the top-right
+corner of any page, and read the letter in parentheses next to **ThreatLocker
+Access** (e.g. `ThreatLocker Access (C)` → `instance: c`).
+
+> ⚠️ **A token from one instance returns `403 TOKEN_REVOKED` on every other
+> instance** — the API does not distinguish "wrong instance" from a genuinely
+> revoked token. If you are confident the token is active and still see
+> `TOKEN_REVOKED`, double-check the instance before assuming the token was
+> revoked.
+
 ## Configuration
 
 | Key | Required | Description |

--- a/threatlocker/api.go
+++ b/threatlocker/api.go
@@ -1,0 +1,154 @@
+package usp_threatlocker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// HTTPError represents a non-2xx response from the ThreatLocker API. It carries
+// the status code so callers can classify the error (retry vs. give up) without
+// having to parse error strings.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	body := e.Body
+	if len(body) > 512 {
+		body = body[:512] + "..."
+	}
+	return fmt.Sprintf("unexpected status code %d for %q: %s", e.StatusCode, e.URL, body)
+}
+
+// isTransientError reports whether an error is worth retrying.
+//
+// Transient (retry):
+//   - HTTP 5xx server errors
+//   - HTTP 429 Too Many Requests (rate limiting)
+//   - network errors (timeouts, connection refused, DNS failures, ...)
+//
+// Permanent (do not retry):
+//   - HTTP 4xx other than 429 (bad request, auth failure, not found, ...)
+//   - context cancellation (intentional shutdown)
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 500 && httpErr.StatusCode <= 599 {
+			return true
+		}
+		if httpErr.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+		return false
+	}
+
+	// Context cancellation is an intentional shutdown, not a transient blip.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Anything that failed before we got a response (DNS, dial, timeout, ...)
+	// is reported by Do() and wrapped with this prefix; treat it as transient.
+	if strings.Contains(err.Error(), "failed to execute request") {
+		return true
+	}
+
+	return false
+}
+
+// ThreatLockerClient is a thin wrapper around the ThreatLocker Portal API.
+//
+// The Portal API is uniform: every queryable resource exposes a
+// "<Resource>GetByParameters" endpoint that accepts a POST with a JSON body
+// describing the filter, sort and pagination. This client therefore only needs
+// a single generic POST helper, which keeps the adapter trivial to extend to
+// new resources.
+type ThreatLockerClient struct {
+	baseURL      string
+	apiKey       string
+	managedOrgID string
+	httpClient   *http.Client
+}
+
+// NewThreatLockerClient builds a client. baseURL is the API root, e.g.
+// "https://portalapi.<instance>.threatlocker.com/portalapi".
+func NewThreatLockerClient(baseURL, apiKey, managedOrgID string) *ThreatLockerClient {
+	return &ThreatLockerClient{
+		baseURL:      strings.TrimRight(baseURL, "/"),
+		apiKey:       apiKey,
+		managedOrgID: managedOrgID,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout: 10 * time.Second,
+				}).Dial,
+			},
+		},
+	}
+}
+
+// Post issues a POST to the given API path with a JSON body and returns the raw
+// response body. A non-200 response is returned as an *HTTPError.
+func (c *ThreatLockerClient) Post(ctx context.Context, path string, body interface{}) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %v", err)
+	}
+
+	url := c.baseURL + "/" + strings.TrimPrefix(path, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request %q: %v", url, err)
+	}
+
+	// ThreatLocker authenticates with an API token passed verbatim in the
+	// Authorization header (tokens are minted under Portal > API Users).
+	req.Header.Set("Authorization", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	// Optional: scope the request to a specific (often a child) organization.
+	if c.managedOrgID != "" {
+		req.Header.Set("managedOrganizationId", c.managedOrgID)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request %q: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response %q: %v", url, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPError{
+			StatusCode: resp.StatusCode,
+			URL:        url,
+			Body:       string(respBody),
+		}
+	}
+
+	return respBody, nil
+}
+
+// Close releases idle connections held by the underlying transport.
+func (c *ThreatLockerClient) Close() {
+	c.httpClient.CloseIdleConnections()
+}

--- a/threatlocker/client.go
+++ b/threatlocker/client.go
@@ -458,6 +458,17 @@ func (a *ThreatLockerAdapter) fetchPage(feed ThreatLockerFeed, pageNumber int) (
 			var httpErr *HTTPError
 			if errors.As(err, &httpErr) &&
 				(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
+				// ThreatLocker returns the same TOKEN_REVOKED response for a
+				// genuinely revoked token and for a token presented to the
+				// wrong instance. Surface that ambiguity so an operator does
+				// not chase a token rotation when the real fix is to flip
+				// `instance` to the letter their portal shows next to
+				// "ThreatLocker Access" under the Help menu.
+				a.conf.ClientOptions.OnError(fmt.Errorf(
+					"threatlocker: HTTP %d -- token rejected. If the token is known to be active, "+
+						"verify `instance` matches the letter shown in the ThreatLocker Portal "+
+						"(Help > 'ThreatLocker Access (X)'); a token from a different instance "+
+						"is reported as TOKEN_REVOKED.", httpErr.StatusCode))
 				a.doStop.Set()
 			}
 			return nil, false

--- a/threatlocker/client.go
+++ b/threatlocker/client.go
@@ -145,6 +145,11 @@ type ThreatLockerConfig struct {
 	RetryBaseDelay   time.Duration `json:"retry_base_delay" yaml:"retry_base_delay"`
 	MaxRetryDelay    time.Duration `json:"max_retry_delay" yaml:"max_retry_delay"`
 	MaxRetryAttempts int           `json:"max_retry_attempts" yaml:"max_retry_attempts"`
+
+	// Deduper, when set, replaces the built-in in-memory deduper. It is not
+	// settable through a config file; it exists as a seam for tests and for
+	// embedders that want to supply a shared deduper.
+	Deduper utils.Deduper `json:"-" yaml:"-"`
 }
 
 // defaultFeeds returns the out-of-the-box feed set: pending Application Control
@@ -238,14 +243,18 @@ func (c *ThreatLockerConfig) Validate() error {
 // ThreatLockerAdapter polls one or more ThreatLocker feeds and ships their
 // records to LimaCharlie.
 type ThreatLockerAdapter struct {
-	conf      ThreatLockerConfig
-	uspClient *uspclient.Client
-	client    *ThreatLockerClient
-	deduper   utils.Deduper
+	conf        ThreatLockerConfig
+	uspClient   *uspclient.Client
+	client      *ThreatLockerClient
+	deduper     utils.Deduper
+	ownsDeduper bool
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
 	doStop    *utils.Event
+
+	closeOnce sync.Once
+	closeErr  error
 
 	ctx context.Context
 }
@@ -261,23 +270,31 @@ func NewThreatLockerAdapter(ctx context.Context, conf ThreatLockerConfig) (*Thre
 		doStop: utils.NewEvent(),
 	}
 
-	// The same pending record reappears on every poll until it is resolved, so
-	// a deduper is required to ship each record exactly once.
-	window := dedupeBucketWindow
-	if window > conf.DedupeTTL {
-		window = conf.DedupeTTL
+	// Every page is re-fetched on every poll, so a deduper is required to ship
+	// each record exactly once. A deduper may be supplied via the config;
+	// otherwise an in-memory one is created (and owned/closed by the adapter).
+	a.deduper = conf.Deduper
+	if a.deduper == nil {
+		window := dedupeBucketWindow
+		if window > conf.DedupeTTL {
+			window = conf.DedupeTTL
+		}
+		deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("threatlocker: deduper: %v", err)
+		}
+		a.deduper = deduper
+		a.ownsDeduper = true
 	}
-	deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
-	if err != nil {
-		return nil, nil, fmt.Errorf("threatlocker: deduper: %v", err)
-	}
-	a.deduper = deduper
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
+	uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
 	if err != nil {
-		a.deduper.Close()
+		if a.ownsDeduper {
+			a.deduper.Close()
+		}
 		return nil, nil, err
 	}
+	a.uspClient = uspClient
 
 	a.client = NewThreatLockerClient(resolveBaseURL(conf), conf.APIKey, conf.ManagedOrganizationID)
 	a.chStopped = make(chan struct{})
@@ -296,19 +313,26 @@ func NewThreatLockerAdapter(ctx context.Context, conf ThreatLockerConfig) (*Thre
 	return a, a.chStopped, nil
 }
 
+// Close stops the adapter. It is idempotent: repeated calls are no-ops and
+// return the result of the first call.
 func (a *ThreatLockerAdapter) Close() error {
-	a.conf.ClientOptions.DebugLog("threatlocker: closing")
-	a.doStop.Set()
-	a.wgSenders.Wait()
-	err1 := a.uspClient.Drain(1 * time.Minute)
-	_, err2 := a.uspClient.Close()
-	a.client.Close()
-	a.deduper.Close()
-
-	if err1 != nil {
-		return err1
-	}
-	return err2
+	a.closeOnce.Do(func() {
+		a.conf.ClientOptions.DebugLog("threatlocker: closing")
+		a.doStop.Set()
+		a.wgSenders.Wait()
+		err1 := a.uspClient.Drain(1 * time.Minute)
+		_, err2 := a.uspClient.Close()
+		a.client.Close()
+		if a.ownsDeduper {
+			a.deduper.Close()
+		}
+		if err1 != nil {
+			a.closeErr = err1
+		} else {
+			a.closeErr = err2
+		}
+	})
+	return a.closeErr
 }
 
 // resolveBaseURL computes the ThreatLocker API root from the config.
@@ -332,22 +356,26 @@ func (a *ThreatLockerAdapter) runFeed(feed ThreatLockerFeed) {
 	}
 }
 
-// pollFeed fetches one feed once, walking pages newest-first.
+// pollFeed fetches one feed once. It walks pages until the result set is
+// exhausted (a short or empty page) or the feed's MaxPages cap is reached.
 //
-// Pagination stops as soon as either:
-//   - a short page is returned (fewer records than the page size => last page);
-//   - a page contains no records the adapter has not already shipped. Because
-//     feeds are queried newest-first, a brand new record always lands on the
-//     first page, so the first fully-seen page means everything below is older
-//     and already shipped.
+// Every page is fetched on every poll; the deduper -- not an early exit -- is
+// what keeps a record from being shipped more than once. This is deliberate:
+// the ThreatLocker API paginates by offset over a live, mutable list, so a
+// record can shift across a page boundary between two page fetches. Stopping
+// early on a page of already-seen records would let such a shifted record be
+// skipped permanently. Re-walking every page each poll costs more requests but
+// is correct; bound it per feed with MaxPages and the feed's parameters.
 func (a *ThreatLockerAdapter) pollFeed(feed ThreatLockerFeed) {
 	nSeen := 0
 	nShipped := 0
 
 	for pageNumber := 1; !a.doStop.IsSet(); pageNumber++ {
-		if feed.MaxPages > 0 && pageNumber > feed.MaxPages {
+		if pageNumber > feed.MaxPages {
 			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
-				"threatlocker: feed %q reached max_pages=%d, ending this poll early", feed.Name, feed.MaxPages))
+				"threatlocker: feed %q hit max_pages=%d; records past that are not "+
+					"collected this poll -- raise max_pages or narrow the feed's parameters",
+				feed.Name, feed.MaxPages))
 			break
 		}
 
@@ -361,23 +389,19 @@ func (a *ThreatLockerAdapter) pollFeed(feed ThreatLockerFeed) {
 			break
 		}
 
-		nNew := 0
 		for _, item := range items {
 			nSeen++
 			if a.deduper.CheckAndAdd(a.dedupeKey(feed, item)) {
 				continue
 			}
-			nNew++
 			if !a.ship(feed, item) {
 				return
 			}
 			nShipped++
 		}
 
+		// A short page is the end of the result set.
 		if len(items) < a.conf.PageSize {
-			break
-		}
-		if nNew == 0 {
 			break
 		}
 	}
@@ -537,8 +561,11 @@ func fieldAsString(item utils.Dict, path string) string {
 	if s := item.FindOneString(path); s != "" {
 		return s
 	}
-	if n := item.FindOneInt(path); n != 0 {
-		return strconv.FormatUint(n, 10)
+	// FindInt returns every match at the path; a non-empty result means the
+	// field is present -- including a legitimate value of 0, which FindOneInt
+	// cannot distinguish from "absent".
+	if ints := item.FindInt(path); len(ints) > 0 {
+		return strconv.FormatUint(ints[0], 10)
 	}
 	return ""
 }
@@ -558,7 +585,7 @@ func extractItems(raw []byte, itemsPath string) ([]utils.Dict, error) {
 		if err := json.Unmarshal([]byte(trimmed), &arr); err != nil {
 			return nil, fmt.Errorf("invalid JSON array: %v", err)
 		}
-		return rawMessagesToDicts(arr)
+		return rawMessagesToDicts(arr), nil
 
 	case '{':
 		var obj map[string]json.RawMessage
@@ -586,7 +613,7 @@ func extractItems(raw []byte, itemsPath string) ([]utils.Dict, error) {
 		if err := json.Unmarshal(arrRaw, &arr); err != nil {
 			return nil, fmt.Errorf("response field is not an array: %v", err)
 		}
-		return rawMessagesToDicts(arr)
+		return rawMessagesToDicts(arr), nil
 
 	default:
 		return nil, errors.New("response is neither a JSON array nor a JSON object")
@@ -595,17 +622,19 @@ func extractItems(raw []byte, itemsPath string) ([]utils.Dict, error) {
 
 // rawMessagesToDicts decodes each record with utils.UnmarshalCleanJSON, which
 // preserves integer precision (no float coercion) so payloads round-trip
-// faithfully.
-func rawMessagesToDicts(raw []json.RawMessage) ([]utils.Dict, error) {
+// faithfully. A record that is not a non-empty JSON object (a scalar, an array,
+// null, or {}) is skipped rather than failing the whole page -- one anomalous
+// element should not block every other record.
+func rawMessagesToDicts(raw []json.RawMessage) []utils.Dict {
 	items := make([]utils.Dict, 0, len(raw))
-	for i, r := range raw {
+	for _, r := range raw {
 		m, err := utils.UnmarshalCleanJSON(string(r))
-		if err != nil {
-			return nil, fmt.Errorf("record %d is not a JSON object: %v", i, err)
+		if err != nil || len(m) == 0 {
+			continue
 		}
 		items = append(items, utils.Dict(m))
 	}
-	return items, nil
+	return items
 }
 
 func keysOf(m map[string]json.RawMessage) []string {

--- a/threatlocker/client.go
+++ b/threatlocker/client.go
@@ -42,8 +42,16 @@ const (
 	defaultMaxRetryAttempts = 3
 	defaultRetryBaseDelay   = 5 * time.Second
 	defaultMaxRetryDelay    = 30 * time.Second
+	defaultStartDateField   = "startDate"
+	defaultEndDateField     = "endDate"
+	defaultWindow           = 5 * time.Minute
 
 	shipTimeout = 10 * time.Second
+
+	// windowTimestampLayout is the time format the adapter uses to render
+	// rolling-window dates into ThreatLocker request bodies. ThreatLocker's API
+	// accepts RFC 3339 with a Z suffix and millisecond precision.
+	windowTimestampLayout = "2006-01-02T15:04:05.000Z"
 )
 
 // itemsArrayKeys are the keys the adapter probes, in order, to locate the list
@@ -105,6 +113,20 @@ type ThreatLockerFeed struct {
 	// MaxPages caps how many pages are fetched per poll, bounding the work of
 	// a first poll against a large historical data set. Defaults to 100.
 	MaxPages int `json:"max_pages" yaml:"max_pages"`
+
+	// Window, when > 0, enables rolling time-range filtering on each poll. On
+	// each call the adapter sets StartDateField to now-Window-PollInterval and
+	// EndDateField to now. The +PollInterval ensures consecutive polls overlap
+	// (so a slipped or delayed poll cycle does not leave a gap); the deduper
+	// suppresses re-shipping records that fall into the overlap. Endpoints
+	// like ActionLog and SystemAudit reject requests that omit a date range.
+	Window time.Duration `json:"window" yaml:"window"`
+
+	// StartDateField / EndDateField name the request-body fields that carry
+	// the rolling-window endpoints. Defaults: "startDate" / "endDate". Only
+	// consulted when Window > 0.
+	StartDateField string `json:"start_date_field" yaml:"start_date_field"`
+	EndDateField   string `json:"end_date_field" yaml:"end_date_field"`
 }
 
 // ThreatLockerConfig is the adapter configuration.
@@ -152,9 +174,22 @@ type ThreatLockerConfig struct {
 	Deduper utils.Deduper `json:"-" yaml:"-"`
 }
 
-// defaultFeeds returns the out-of-the-box feed set: pending Application Control
-// approval requests, which is the primary use case (driving automated
-// investigations in LimaCharlie).
+// defaultFeeds returns the out-of-the-box feed set. The three feeds together
+// cover the three main telemetry surfaces ThreatLocker exposes:
+//
+//   - approval_request: pending Application Control whitelist requests
+//     (statusId=1). Each request is shipped exactly once, well suited to
+//     triggering automated investigations in LimaCharlie.
+//   - unified_audit: the ActionLog -- ThreatLocker's combined event stream of
+//     execute/install/network/registry/file/web/powershell/elevate activity
+//     across all modules. Polled on a 5-minute rolling window.
+//   - system_audit: portal/administrator activity (logins, policy edits,
+//     approval decisions, ...). Polled on a 5-minute rolling window.
+//
+// ActionLog and SystemAudit both *require* a date range in every request;
+// the adapter's Window mechanism rewrites startDate/endDate on each poll, and
+// the deduper suppresses re-shipping records that fall into successive
+// overlapping windows.
 func defaultFeeds() []ThreatLockerFeed {
 	return []ThreatLockerFeed{
 		{
@@ -169,6 +204,38 @@ func defaultFeeds() []ThreatLockerFeed {
 			OrderBy:        defaultOrderBy,
 			TimestampField: defaultTimestampField,
 			IDField:        "approvalRequestId",
+		},
+		{
+			Name: "unified_audit",
+			URL:  "ActionLog/ActionLogGetByParametersV2",
+			// These body fields are documented as optional in the OpenAPI
+			// spec but ThreatLocker's own Postman example sends every one --
+			// omitting them yields opaque HTTP 500 responses against some
+			// tenants. Keep them populated with their identity defaults.
+			Parameters: utils.Dict{
+				"paramsFieldsDto":        []any{},
+				"groupBys":               []any{},
+				"exportMode":             false,
+				"showTotalCount":         false,
+				"showChildOrganizations": false,
+				"onlyTrueDenies":         false,
+				"simulateDeny":           false,
+			},
+			OrderBy:        defaultOrderBy,
+			TimestampField: defaultTimestampField,
+			IDField:        "actionLogId",
+			Window:         defaultWindow,
+		},
+		{
+			Name: "system_audit",
+			URL:  "SystemAudit/SystemAuditGetByParameters",
+			Parameters: utils.Dict{
+				"viewChildOrganizations": false,
+			},
+			OrderBy:        defaultOrderBy,
+			TimestampField: defaultTimestampField,
+			IDField:        "systemAuditId",
+			Window:         defaultWindow,
 		},
 	}
 }
@@ -235,6 +302,14 @@ func (c *ThreatLockerConfig) Validate() error {
 		}
 		if f.MaxPages <= 0 {
 			f.MaxPages = defaultMaxPages
+		}
+		if f.Window > 0 {
+			if f.StartDateField == "" {
+				f.StartDateField = defaultStartDateField
+			}
+			if f.EndDateField == "" {
+				f.EndDateField = defaultEndDateField
+			}
 		}
 	}
 	return nil
@@ -504,7 +579,10 @@ func (a *ThreatLockerAdapter) fetchPage(feed ThreatLockerFeed, pageNumber int) (
 
 // buildRequestBody assembles the JSON body for a "*GetByParameters" call. The
 // adapter always controls pagination; sorting is taken from the feed unless the
-// feed's Parameters override it.
+// feed's Parameters override it. When the feed has Window > 0, the rolling
+// window's start/end timestamps are injected too, so a poll always covers
+// [now-Window-PollInterval, now] -- the small overlap with the prior poll is
+// absorbed by the deduper.
 func (a *ThreatLockerAdapter) buildRequestBody(feed ThreatLockerFeed, pageNumber int) utils.Dict {
 	body := utils.Dict{}
 	for k, v := range feed.Parameters {
@@ -517,6 +595,12 @@ func (a *ThreatLockerAdapter) buildRequestBody(feed ThreatLockerFeed, pageNumber
 	}
 	if _, ok := body["isAscending"]; !ok {
 		body["isAscending"] = false
+	}
+	if feed.Window > 0 {
+		end := time.Now().UTC()
+		start := end.Add(-feed.Window - a.conf.PollInterval)
+		body[feed.StartDateField] = start.Format(windowTimestampLayout)
+		body[feed.EndDateField] = end.Format(windowTimestampLayout)
 	}
 	return body
 }

--- a/threatlocker/client.go
+++ b/threatlocker/client.go
@@ -1,0 +1,630 @@
+// Package usp_threatlocker implements a generic USP adapter for the ThreatLocker
+// Portal API (https://portalapi.<instance>.threatlocker.com/portalapi).
+//
+// The ThreatLocker Portal API is uniform: every queryable resource exposes a
+// "<Resource>GetByParameters" endpoint that takes a POST with a JSON body
+// describing the filter, sort order and pagination, and returns the matching
+// records. The adapter models a "feed" as one such endpoint plus its request
+// parameters, so supporting a new ThreatLocker event type is purely a matter of
+// configuration -- no code change required.
+//
+// Events are forwarded to LimaCharlie in their original ThreatLocker JSON form;
+// the adapter does not reshape payloads.
+package usp_threatlocker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	defaultPageSize         = 100
+	maxPageSize             = 1000
+	defaultPollInterval     = 1 * time.Minute
+	defaultDedupeTTL        = 7 * 24 * time.Hour
+	dedupeBucketWindow      = 1 * time.Hour
+	defaultMaxPages         = 100
+	defaultOrderBy          = "dateTime"
+	defaultTimestampField   = "dateTime"
+	defaultMaxRetryAttempts = 3
+	defaultRetryBaseDelay   = 5 * time.Second
+	defaultMaxRetryDelay    = 30 * time.Second
+
+	shipTimeout = 10 * time.Second
+)
+
+// itemsArrayKeys are the keys the adapter probes, in order, to locate the list
+// of records when a ThreatLocker endpoint wraps its results in an object
+// instead of returning a bare JSON array. A feed may override this via its
+// ItemsPath setting.
+var itemsArrayKeys = []string{"data", "pageItems", "items", "value", "result", "results", "records"}
+
+// commonIDFields are the fields the adapter probes, in order, for a stable
+// per-record identifier used for deduplication when a feed does not specify an
+// IDField explicitly.
+var commonIDFields = []string{"approvalRequestId", "actionId", "auditId", "id", "Id", "guid", "uniqueId"}
+
+// timestampLayouts are the time formats accepted for a record's timestamp
+// field. ThreatLocker emits ISO-8601, occasionally without a zone or with
+// sub-second precision.
+var timestampLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05.999999999",
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+}
+
+// ThreatLockerFeed describes a single ThreatLocker "*GetByParameters" endpoint
+// to poll. New event types are added by appending feeds -- no code change.
+type ThreatLockerFeed struct {
+	// Name labels the feed and becomes the EventType of every shipped event.
+	Name string `json:"name" yaml:"name"`
+
+	// URL is the API path (relative to the API root) of the GetByParameters
+	// endpoint, e.g. "ApprovalRequest/ApprovalRequestGetByParameters".
+	URL string `json:"url" yaml:"url"`
+
+	// Parameters are merged into the request body sent to the endpoint. Use it
+	// for resource-specific filters, e.g. {"statusId": 1} for pending approval
+	// requests. The adapter always sets pageNumber/pageSize itself, and sets
+	// orderBy/isAscending unless they are provided here.
+	Parameters utils.Dict `json:"parameters" yaml:"parameters"`
+
+	// OrderBy is the field the endpoint sorts on. The adapter relies on a
+	// newest-first ordering (isAscending=false) for incremental polling.
+	OrderBy string `json:"order_by" yaml:"order_by"`
+
+	// ItemsPath is the key under which the records array lives when the
+	// endpoint returns an object envelope. Empty means: response is a bare
+	// array, or auto-detect a common key.
+	ItemsPath string `json:"items_path" yaml:"items_path"`
+
+	// TimestampField is the path to the record's event time (a "/" separated
+	// path is supported for nested fields). Defaults to "dateTime".
+	TimestampField string `json:"timestamp_field" yaml:"timestamp_field"`
+
+	// IDField is the path to the record's stable identifier, used for
+	// deduplication. Empty means: probe a set of common id fields, and fall
+	// back to a content hash.
+	IDField string `json:"id_field" yaml:"id_field"`
+
+	// MaxPages caps how many pages are fetched per poll, bounding the work of
+	// a first poll against a large historical data set. Defaults to 100.
+	MaxPages int `json:"max_pages" yaml:"max_pages"`
+}
+
+// ThreatLockerConfig is the adapter configuration.
+type ThreatLockerConfig struct {
+	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+	// APIKey is a ThreatLocker API token (Portal > API Users).
+	APIKey string `json:"api_key" yaml:"api_key"`
+
+	// Instance is the ThreatLocker instance identifier used to build the API
+	// root: https://portalapi.<instance>.threatlocker.com/portalapi
+	Instance string `json:"instance" yaml:"instance"`
+
+	// BaseURL fully overrides the API root. When set, Instance is ignored.
+	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// ManagedOrganizationID, when set, scopes every request to that
+	// organization via the managedOrganizationId header (useful for parent
+	// organizations querying a specific child).
+	ManagedOrganizationID string `json:"managed_organization_id" yaml:"managed_organization_id"`
+
+	// Feeds is the set of ThreatLocker endpoints to poll. When empty, the
+	// adapter defaults to a single feed of pending Application Control
+	// approval requests.
+	Feeds []ThreatLockerFeed `json:"feeds" yaml:"feeds"`
+
+	// PageSize is the number of records requested per page. Default 100.
+	PageSize int `json:"page_size" yaml:"page_size"`
+
+	// PollInterval is the wait between polls of a feed. Default 1 minute.
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+
+	// DedupeTTL is how long a record's identifier is remembered to suppress
+	// re-shipping it on subsequent polls. Default 7 days.
+	DedupeTTL time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
+
+	// Retry tuning for transient API failures.
+	RetryBaseDelay   time.Duration `json:"retry_base_delay" yaml:"retry_base_delay"`
+	MaxRetryDelay    time.Duration `json:"max_retry_delay" yaml:"max_retry_delay"`
+	MaxRetryAttempts int           `json:"max_retry_attempts" yaml:"max_retry_attempts"`
+}
+
+// defaultFeeds returns the out-of-the-box feed set: pending Application Control
+// approval requests, which is the primary use case (driving automated
+// investigations in LimaCharlie).
+func defaultFeeds() []ThreatLockerFeed {
+	return []ThreatLockerFeed{
+		{
+			Name: "approval_request",
+			URL:  "ApprovalRequest/ApprovalRequestGetByParameters",
+			Parameters: utils.Dict{
+				// statusId 1 == pending (awaiting an approve/deny decision).
+				"statusId":               1,
+				"showChildOrganizations": false,
+				"showCurrentTierOnly":    false,
+			},
+			OrderBy:        defaultOrderBy,
+			TimestampField: defaultTimestampField,
+			IDField:        "approvalRequestId",
+		},
+	}
+}
+
+func (c *ThreatLockerConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+	if c.APIKey == "" {
+		return errors.New("missing api_key")
+	}
+
+	c.BaseURL = strings.TrimSpace(c.BaseURL)
+	c.Instance = strings.TrimSpace(c.Instance)
+	if c.BaseURL == "" && c.Instance == "" {
+		return errors.New("missing instance (or base_url)")
+	}
+
+	if c.PageSize <= 0 {
+		c.PageSize = defaultPageSize
+	}
+	if c.PageSize > maxPageSize {
+		c.PageSize = maxPageSize
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
+	if c.DedupeTTL <= 0 {
+		c.DedupeTTL = defaultDedupeTTL
+	}
+	if c.RetryBaseDelay <= 0 {
+		c.RetryBaseDelay = defaultRetryBaseDelay
+	}
+	if c.MaxRetryDelay <= 0 {
+		c.MaxRetryDelay = defaultMaxRetryDelay
+	}
+	if c.MaxRetryAttempts <= 0 {
+		c.MaxRetryAttempts = defaultMaxRetryAttempts
+	}
+
+	if len(c.Feeds) == 0 {
+		c.Feeds = defaultFeeds()
+	}
+	seenNames := make(map[string]struct{}, len(c.Feeds))
+	for i := range c.Feeds {
+		f := &c.Feeds[i]
+		f.Name = strings.TrimSpace(f.Name)
+		f.URL = strings.TrimSpace(strings.TrimPrefix(f.URL, "/"))
+		if f.URL == "" {
+			return fmt.Errorf("feed %d: missing url", i)
+		}
+		if f.Name == "" {
+			return fmt.Errorf("feed %q: missing name", f.URL)
+		}
+		if _, ok := seenNames[f.Name]; ok {
+			return fmt.Errorf("feed %q: duplicate name", f.Name)
+		}
+		seenNames[f.Name] = struct{}{}
+		if f.OrderBy == "" {
+			f.OrderBy = defaultOrderBy
+		}
+		if f.TimestampField == "" {
+			f.TimestampField = defaultTimestampField
+		}
+		if f.MaxPages <= 0 {
+			f.MaxPages = defaultMaxPages
+		}
+	}
+	return nil
+}
+
+// ThreatLockerAdapter polls one or more ThreatLocker feeds and ships their
+// records to LimaCharlie.
+type ThreatLockerAdapter struct {
+	conf      ThreatLockerConfig
+	uspClient *uspclient.Client
+	client    *ThreatLockerClient
+	deduper   utils.Deduper
+
+	chStopped chan struct{}
+	wgSenders sync.WaitGroup
+	doStop    *utils.Event
+
+	ctx context.Context
+}
+
+func NewThreatLockerAdapter(ctx context.Context, conf ThreatLockerConfig) (*ThreatLockerAdapter, chan struct{}, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	a := &ThreatLockerAdapter{
+		conf:   conf,
+		ctx:    ctx,
+		doStop: utils.NewEvent(),
+	}
+
+	// The same pending record reappears on every poll until it is resolved, so
+	// a deduper is required to ship each record exactly once.
+	window := dedupeBucketWindow
+	if window > conf.DedupeTTL {
+		window = conf.DedupeTTL
+	}
+	deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("threatlocker: deduper: %v", err)
+	}
+	a.deduper = deduper
+
+	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
+	if err != nil {
+		a.deduper.Close()
+		return nil, nil, err
+	}
+
+	a.client = NewThreatLockerClient(resolveBaseURL(conf), conf.APIKey, conf.ManagedOrganizationID)
+	a.chStopped = make(chan struct{})
+
+	for _, feed := range conf.Feeds {
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf("threatlocker: starting feed %q -> %s", feed.Name, feed.URL))
+		a.wgSenders.Add(1)
+		go a.runFeed(feed)
+	}
+
+	go func() {
+		a.wgSenders.Wait()
+		close(a.chStopped)
+	}()
+
+	return a, a.chStopped, nil
+}
+
+func (a *ThreatLockerAdapter) Close() error {
+	a.conf.ClientOptions.DebugLog("threatlocker: closing")
+	a.doStop.Set()
+	a.wgSenders.Wait()
+	err1 := a.uspClient.Drain(1 * time.Minute)
+	_, err2 := a.uspClient.Close()
+	a.client.Close()
+	a.deduper.Close()
+
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+// resolveBaseURL computes the ThreatLocker API root from the config.
+func resolveBaseURL(conf ThreatLockerConfig) string {
+	if conf.BaseURL != "" {
+		return strings.TrimRight(conf.BaseURL, "/")
+	}
+	instance := strings.Trim(conf.Instance, "/")
+	return fmt.Sprintf("https://portalapi.%s.threatlocker.com/portalapi", instance)
+}
+
+// runFeed polls a single feed forever, until the adapter is asked to stop.
+func (a *ThreatLockerAdapter) runFeed(feed ThreatLockerFeed) {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("threatlocker: feed %q stopped", feed.Name))
+
+	isFirstRun := true
+	for isFirstRun || !a.doStop.WaitFor(a.conf.PollInterval) {
+		isFirstRun = false
+		a.pollFeed(feed)
+	}
+}
+
+// pollFeed fetches one feed once, walking pages newest-first.
+//
+// Pagination stops as soon as either:
+//   - a short page is returned (fewer records than the page size => last page);
+//   - a page contains no records the adapter has not already shipped. Because
+//     feeds are queried newest-first, a brand new record always lands on the
+//     first page, so the first fully-seen page means everything below is older
+//     and already shipped.
+func (a *ThreatLockerAdapter) pollFeed(feed ThreatLockerFeed) {
+	nSeen := 0
+	nShipped := 0
+
+	for pageNumber := 1; !a.doStop.IsSet(); pageNumber++ {
+		if feed.MaxPages > 0 && pageNumber > feed.MaxPages {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"threatlocker: feed %q reached max_pages=%d, ending this poll early", feed.Name, feed.MaxPages))
+			break
+		}
+
+		items, ok := a.fetchPage(feed, pageNumber)
+		if !ok {
+			// The error has already been reported; abandon this poll and try
+			// again on the next interval.
+			return
+		}
+		if len(items) == 0 {
+			break
+		}
+
+		nNew := 0
+		for _, item := range items {
+			nSeen++
+			if a.deduper.CheckAndAdd(a.dedupeKey(feed, item)) {
+				continue
+			}
+			nNew++
+			if !a.ship(feed, item) {
+				return
+			}
+			nShipped++
+		}
+
+		if len(items) < a.conf.PageSize {
+			break
+		}
+		if nNew == 0 {
+			break
+		}
+	}
+
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"threatlocker: feed %q poll complete (seen=%d shipped=%d)", feed.Name, nSeen, nShipped))
+}
+
+// fetchPage requests one page of a feed, retrying transient failures with
+// exponential backoff. The bool result is false when the poll should be
+// abandoned (a permanent error, or the adapter is stopping).
+func (a *ThreatLockerAdapter) fetchPage(feed ThreatLockerFeed, pageNumber int) ([]utils.Dict, bool) {
+	body := a.buildRequestBody(feed, pageNumber)
+
+	var raw []byte
+	var err error
+	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
+		if a.doStop.IsSet() {
+			return nil, false
+		}
+
+		raw, err = a.client.Post(a.ctx, feed.URL, body)
+		if err == nil {
+			break
+		}
+
+		if !isTransientError(err) {
+			a.conf.ClientOptions.OnError(fmt.Errorf("threatlocker: feed %q request failed: %v", feed.Name, err))
+			// An authentication/authorization failure affects every feed, so
+			// stop the whole adapter rather than spin uselessly. Other
+			// permanent errors (e.g. a misconfigured feed URL) are isolated to
+			// this feed: abandon the poll but keep the adapter alive.
+			var httpErr *HTTPError
+			if errors.As(err, &httpErr) &&
+				(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
+				a.doStop.Set()
+			}
+			return nil, false
+		}
+
+		if attempt+1 >= a.conf.MaxRetryAttempts {
+			break
+		}
+		delay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
+		if delay > a.conf.MaxRetryDelay {
+			delay = a.conf.MaxRetryDelay
+		}
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"threatlocker: feed %q transient error (attempt %d/%d), retrying in %v: %v",
+			feed.Name, attempt+1, a.conf.MaxRetryAttempts, delay, err))
+		if a.doStop.WaitFor(delay) {
+			return nil, false
+		}
+	}
+	if err != nil {
+		a.conf.ClientOptions.OnError(fmt.Errorf(
+			"threatlocker: feed %q failed after %d attempts: %v", feed.Name, a.conf.MaxRetryAttempts, err))
+		return nil, false
+	}
+
+	items, err := extractItems(raw, feed.ItemsPath)
+	if err != nil {
+		a.conf.ClientOptions.OnError(fmt.Errorf("threatlocker: feed %q response parse error: %v", feed.Name, err))
+		return nil, false
+	}
+	return items, true
+}
+
+// buildRequestBody assembles the JSON body for a "*GetByParameters" call. The
+// adapter always controls pagination; sorting is taken from the feed unless the
+// feed's Parameters override it.
+func (a *ThreatLockerAdapter) buildRequestBody(feed ThreatLockerFeed, pageNumber int) utils.Dict {
+	body := utils.Dict{}
+	for k, v := range feed.Parameters {
+		body[k] = v
+	}
+	body["pageNumber"] = pageNumber
+	body["pageSize"] = a.conf.PageSize
+	if _, ok := body["orderBy"]; !ok && feed.OrderBy != "" {
+		body["orderBy"] = feed.OrderBy
+	}
+	if _, ok := body["isAscending"]; !ok {
+		body["isAscending"] = false
+	}
+	return body
+}
+
+// ship forwards a single record to LimaCharlie. It returns false if the adapter
+// should stop (an unrecoverable shipping error).
+func (a *ThreatLockerAdapter) ship(feed ThreatLockerFeed, item utils.Dict) bool {
+	msg := &protocol.DataMessage{
+		JsonPayload: item,
+		EventType:   feed.Name,
+		TimestampMs: a.eventTime(feed, item),
+	}
+	if err := a.uspClient.Ship(msg, shipTimeout); err != nil {
+		if err == uspclient.ErrorBufferFull {
+			a.conf.ClientOptions.OnWarning("threatlocker: stream falling behind")
+			err = a.uspClient.Ship(msg, 1*time.Hour)
+		}
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("threatlocker: Ship(): %v", err))
+			a.doStop.Set()
+			return false
+		}
+	}
+	return true
+}
+
+// eventTime extracts the record's event time, falling back to now when the
+// configured timestamp field is absent or unparseable.
+func (a *ThreatLockerAdapter) eventTime(feed ThreatLockerFeed, item utils.Dict) uint64 {
+	field := feed.TimestampField
+	if field == "" {
+		field = defaultTimestampField
+	}
+	if raw := item.FindOneString(field); raw != "" {
+		if t, ok := parseTimestamp(raw); ok {
+			return uint64(t.UnixMilli())
+		}
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+			"threatlocker: feed %q unparseable timestamp %q at field %q", feed.Name, raw, field))
+	}
+	return uint64(time.Now().UnixMilli())
+}
+
+// dedupeKey returns a stable deduplication key for a record, namespaced by feed
+// so identifiers cannot collide across feeds.
+func (a *ThreatLockerAdapter) dedupeKey(feed ThreatLockerFeed, item utils.Dict) string {
+	return feed.Name + "|" + recordID(feed, item)
+}
+
+// recordID resolves a record's identifier: the feed's IDField if set, otherwise
+// a probe of common id fields, otherwise a content hash so deduplication still
+// works for records with no recognizable identifier.
+func recordID(feed ThreatLockerFeed, item utils.Dict) string {
+	if feed.IDField != "" {
+		if id := fieldAsString(item, feed.IDField); id != "" {
+			return id
+		}
+	}
+	for _, k := range commonIDFields {
+		if id := fieldAsString(item, k); id != "" {
+			return id
+		}
+	}
+	if b, err := json.Marshal(item); err == nil {
+		sum := sha256.Sum256(b)
+		return "sha256:" + hex.EncodeToString(sum[:])
+	}
+	return ""
+}
+
+// fieldAsString reads a field as a string, accepting numeric values too (ids
+// are sometimes integers).
+func fieldAsString(item utils.Dict, path string) string {
+	if s := item.FindOneString(path); s != "" {
+		return s
+	}
+	if n := item.FindOneInt(path); n != 0 {
+		return strconv.FormatUint(n, 10)
+	}
+	return ""
+}
+
+// extractItems parses a ThreatLocker response into a slice of records. It
+// accepts both a bare JSON array and an object envelope; for an envelope it
+// uses itemsPath when provided, otherwise it auto-detects a common key.
+func extractItems(raw []byte, itemsPath string) ([]utils.Dict, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var arr []json.RawMessage
+		if err := json.Unmarshal([]byte(trimmed), &arr); err != nil {
+			return nil, fmt.Errorf("invalid JSON array: %v", err)
+		}
+		return rawMessagesToDicts(arr)
+
+	case '{':
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
+			return nil, fmt.Errorf("invalid JSON object: %v", err)
+		}
+		var arrRaw json.RawMessage
+		if itemsPath != "" {
+			arrRaw = obj[itemsPath]
+			if arrRaw == nil {
+				return nil, fmt.Errorf("items_path %q not present in response object (keys: %v)", itemsPath, keysOf(obj))
+			}
+		} else {
+			for _, k := range itemsArrayKeys {
+				if v, ok := obj[k]; ok {
+					arrRaw = v
+					break
+				}
+			}
+			if arrRaw == nil {
+				return nil, fmt.Errorf("could not locate a records array in response object (keys: %v); set items_path", keysOf(obj))
+			}
+		}
+		var arr []json.RawMessage
+		if err := json.Unmarshal(arrRaw, &arr); err != nil {
+			return nil, fmt.Errorf("response field is not an array: %v", err)
+		}
+		return rawMessagesToDicts(arr)
+
+	default:
+		return nil, errors.New("response is neither a JSON array nor a JSON object")
+	}
+}
+
+// rawMessagesToDicts decodes each record with utils.UnmarshalCleanJSON, which
+// preserves integer precision (no float coercion) so payloads round-trip
+// faithfully.
+func rawMessagesToDicts(raw []json.RawMessage) ([]utils.Dict, error) {
+	items := make([]utils.Dict, 0, len(raw))
+	for i, r := range raw {
+		m, err := utils.UnmarshalCleanJSON(string(r))
+		if err != nil {
+			return nil, fmt.Errorf("record %d is not a JSON object: %v", i, err)
+		}
+		items = append(items, utils.Dict(m))
+	}
+	return items, nil
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func parseTimestamp(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range timestampLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}

--- a/threatlocker/client.go
+++ b/threatlocker/client.go
@@ -240,11 +240,20 @@ func (c *ThreatLockerConfig) Validate() error {
 	return nil
 }
 
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 // ThreatLockerAdapter polls one or more ThreatLocker feeds and ships their
 // records to LimaCharlie.
 type ThreatLockerAdapter struct {
 	conf        ThreatLockerConfig
-	uspClient   *uspclient.Client
+	uspClient   uspSink
 	client      *ThreatLockerClient
 	deduper     utils.Deduper
 	ownsDeduper bool
@@ -259,7 +268,15 @@ type ThreatLockerAdapter struct {
 	ctx context.Context
 }
 
+// NewThreatLockerAdapter creates a ThreatLocker adapter wired to LimaCharlie.
 func NewThreatLockerAdapter(ctx context.Context, conf ThreatLockerConfig) (*ThreatLockerAdapter, chan struct{}, error) {
+	return newThreatLockerAdapter(ctx, conf, nil)
+}
+
+// newThreatLockerAdapter is the implementation behind NewThreatLockerAdapter.
+// When sink is non-nil it is used in place of a real LimaCharlie client -- the
+// seam tests use to capture shipped events.
+func newThreatLockerAdapter(ctx context.Context, conf ThreatLockerConfig, sink uspSink) (*ThreatLockerAdapter, chan struct{}, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, nil, err
 	}
@@ -287,14 +304,18 @@ func NewThreatLockerAdapter(ctx context.Context, conf ThreatLockerConfig) (*Thre
 		a.ownsDeduper = true
 	}
 
-	uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		if a.ownsDeduper {
-			a.deduper.Close()
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			if a.ownsDeduper {
+				a.deduper.Close()
+			}
+			return nil, nil, err
 		}
-		return nil, nil, err
+		a.uspClient = uspClient
 	}
-	a.uspClient = uspClient
 
 	a.client = NewThreatLockerClient(resolveBaseURL(conf), conf.APIKey, conf.ManagedOrganizationID)
 	a.chStopped = make(chan struct{})

--- a/threatlocker/client_test.go
+++ b/threatlocker/client_test.go
@@ -1,0 +1,511 @@
+package usp_threatlocker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// approvalItem builds a minimal ThreatLocker approval-request-shaped record.
+func approvalItem(id string) map[string]interface{} {
+	return map[string]interface{}{
+		"approvalRequestId": id,
+		"dateTime":          "2026-05-21T12:00:00Z",
+		"statusId":          1,
+		"hostname":          "WIN-" + id,
+	}
+}
+
+func decodeRequestBody(t *testing.T, r *http.Request) map[string]interface{} {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	m := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal(body, &m))
+	return m
+}
+
+// --- unit tests -------------------------------------------------------------
+
+func TestExtractItems(t *testing.T) {
+	t.Run("bare array", func(t *testing.T) {
+		items, err := extractItems([]byte(`[{"id":"a"},{"id":"b"}]`), "")
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, "a", items[0].FindOneString("id"))
+		assert.Equal(t, "b", items[1].FindOneString("id"))
+	})
+
+	t.Run("object envelope auto-detect data", func(t *testing.T) {
+		items, err := extractItems([]byte(`{"data":[{"id":"a"}],"totalRecords":1}`), "")
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.Equal(t, "a", items[0].FindOneString("id"))
+	})
+
+	t.Run("object envelope auto-detect pageItems", func(t *testing.T) {
+		items, err := extractItems([]byte(`{"pageItems":[{"id":"a"},{"id":"b"}]}`), "")
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+	})
+
+	t.Run("object envelope explicit items_path", func(t *testing.T) {
+		items, err := extractItems([]byte(`{"customList":[{"id":"a"}]}`), "customList")
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+	})
+
+	t.Run("object envelope missing array errors", func(t *testing.T) {
+		_, err := extractItems([]byte(`{"totalRecords":0}`), "")
+		assert.Error(t, err)
+	})
+
+	t.Run("explicit items_path missing errors", func(t *testing.T) {
+		_, err := extractItems([]byte(`{"data":[]}`), "notHere")
+		assert.Error(t, err)
+	})
+
+	t.Run("empty body yields no items", func(t *testing.T) {
+		items, err := extractItems([]byte("   "), "")
+		require.NoError(t, err)
+		assert.Empty(t, items)
+	})
+
+	t.Run("non-json errors", func(t *testing.T) {
+		_, err := extractItems([]byte(`not json`), "")
+		assert.Error(t, err)
+	})
+
+	t.Run("large integers keep precision", func(t *testing.T) {
+		items, err := extractItems([]byte(`[{"big":123456789012345678}]`), "")
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		v, ok := items[0].GetInt("big")
+		require.True(t, ok)
+		assert.Equal(t, uint64(123456789012345678), v)
+	})
+}
+
+func TestRecordID(t *testing.T) {
+	t.Run("uses configured id field", func(t *testing.T) {
+		feed := ThreatLockerFeed{IDField: "approvalRequestId"}
+		assert.Equal(t, "abc", recordID(feed, utils.Dict{"approvalRequestId": "abc", "id": "other"}))
+	})
+
+	t.Run("falls back to common id field", func(t *testing.T) {
+		feed := ThreatLockerFeed{}
+		assert.Equal(t, "xyz", recordID(feed, utils.Dict{"id": "xyz"}))
+	})
+
+	t.Run("accepts numeric ids", func(t *testing.T) {
+		feed := ThreatLockerFeed{IDField: "actionId"}
+		assert.Equal(t, "42", recordID(feed, utils.Dict{"actionId": uint64(42)}))
+	})
+
+	t.Run("content hash fallback is stable and distinct", func(t *testing.T) {
+		feed := ThreatLockerFeed{}
+		a1 := recordID(feed, utils.Dict{"foo": "bar"})
+		a2 := recordID(feed, utils.Dict{"foo": "bar"})
+		b := recordID(feed, utils.Dict{"foo": "baz"})
+		assert.Equal(t, a1, a2)
+		assert.NotEqual(t, a1, b)
+		assert.Contains(t, a1, "sha256:")
+	})
+}
+
+func TestResolveBaseURL(t *testing.T) {
+	assert.Equal(t, "https://portalapi.g.threatlocker.com/portalapi",
+		resolveBaseURL(ThreatLockerConfig{Instance: "g"}))
+	assert.Equal(t, "https://custom.example.com/portalapi",
+		resolveBaseURL(ThreatLockerConfig{BaseURL: "https://custom.example.com/portalapi/"}))
+	// base_url wins over instance.
+	assert.Equal(t, "https://custom.example.com/portalapi",
+		resolveBaseURL(ThreatLockerConfig{Instance: "g", BaseURL: "https://custom.example.com/portalapi"}))
+}
+
+func TestBuildRequestBody(t *testing.T) {
+	a := &ThreatLockerAdapter{conf: ThreatLockerConfig{PageSize: 50}}
+
+	t.Run("applies pagination and defaults", func(t *testing.T) {
+		feed := ThreatLockerFeed{OrderBy: "dateTime", Parameters: utils.Dict{"statusId": 1}}
+		body := a.buildRequestBody(feed, 3)
+		assert.Equal(t, 3, body["pageNumber"])
+		assert.Equal(t, 50, body["pageSize"])
+		assert.Equal(t, "dateTime", body["orderBy"])
+		assert.Equal(t, false, body["isAscending"])
+		assert.Equal(t, 1, body["statusId"])
+	})
+
+	t.Run("feed parameters can override sort but not pagination", func(t *testing.T) {
+		feed := ThreatLockerFeed{
+			OrderBy:    "dateTime",
+			Parameters: utils.Dict{"orderBy": "custom", "isAscending": true, "pageNumber": 99},
+		}
+		body := a.buildRequestBody(feed, 7)
+		assert.Equal(t, 7, body["pageNumber"], "adapter must own pageNumber")
+		assert.Equal(t, "custom", body["orderBy"])
+		assert.Equal(t, true, body["isAscending"])
+	})
+}
+
+func TestParseTimestamp(t *testing.T) {
+	cases := []string{
+		"2026-05-21T12:00:00Z",
+		"2026-05-21T12:00:00.123456Z",
+		"2026-05-21T12:00:00",
+		"2026-05-21 12:00:00",
+	}
+	for _, c := range cases {
+		_, ok := parseTimestamp(c)
+		assert.True(t, ok, "expected %q to parse", c)
+	}
+	_, ok := parseTimestamp("not a date")
+	assert.False(t, ok)
+}
+
+func TestIsTransientError(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		isTransient bool
+	}{
+		{"500", &HTTPError{StatusCode: 500}, true},
+		{"503", &HTTPError{StatusCode: 503}, true},
+		{"429", &HTTPError{StatusCode: 429}, true},
+		{"401", &HTTPError{StatusCode: 401}, false},
+		{"403", &HTTPError{StatusCode: 403}, false},
+		{"404", &HTTPError{StatusCode: 404}, false},
+		{"400", &HTTPError{StatusCode: 400}, false},
+		{"network", fmt.Errorf("failed to execute request %q: connection refused", "x"), true},
+		{"context canceled", context.Canceled, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.isTransient, isTransientError(c.err))
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("requires api_key", func(t *testing.T) {
+		c := ThreatLockerConfig{ClientOptions: testClientOptions(t), Instance: "g"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires instance or base_url", func(t *testing.T) {
+		c := ThreatLockerConfig{ClientOptions: testClientOptions(t), APIKey: "k"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("applies defaults and the default feed", func(t *testing.T) {
+		c := ThreatLockerConfig{ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g"}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, defaultPageSize, c.PageSize)
+		assert.Equal(t, defaultPollInterval, c.PollInterval)
+		require.Len(t, c.Feeds, 1)
+		assert.Equal(t, "approval_request", c.Feeds[0].Name)
+		assert.Equal(t, defaultMaxPages, c.Feeds[0].MaxPages)
+	})
+
+	t.Run("rejects feed without url", func(t *testing.T) {
+		c := ThreatLockerConfig{
+			ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g",
+			Feeds: []ThreatLockerFeed{{Name: "x"}},
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("rejects duplicate feed names", func(t *testing.T) {
+		c := ThreatLockerConfig{
+			ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g",
+			Feeds: []ThreatLockerFeed{
+				{Name: "x", URL: "A/AGetByParameters"},
+				{Name: "x", URL: "B/BGetByParameters"},
+			},
+		}
+		assert.Error(t, c.Validate())
+	})
+}
+
+// --- integration tests ------------------------------------------------------
+
+// TestApprovalRequestFeed verifies the default feed targets the approval
+// request endpoint with the expected method, auth header and request body.
+func TestApprovalRequestFeed(t *testing.T) {
+	var mu sync.Mutex
+	var gotPath, gotAuth, gotMethod, gotManagedOrg string
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		gotManagedOrg = r.Header.Get("managedOrganizationId")
+		gotBody = decodeRequestBody(t, r)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			approvalItem("req-1"), approvalItem("req-2"),
+		})
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions:         testClientOptions(t),
+		APIKey:                "secret-token",
+		BaseURL:               server.URL,
+		ManagedOrganizationID: "org-123",
+		PollInterval:          200 * time.Millisecond,
+	}
+	adapter, chStopped, err := NewThreatLockerAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return gotPath != ""
+	}, 3*time.Second, 20*time.Millisecond, "adapter never called the API")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped unexpectedly")
+	default:
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/ApprovalRequest/ApprovalRequestGetByParameters", gotPath)
+	assert.Equal(t, "secret-token", gotAuth)
+	assert.Equal(t, "org-123", gotManagedOrg)
+	assert.Equal(t, float64(1), gotBody["pageNumber"])
+	assert.Equal(t, float64(defaultPageSize), gotBody["pageSize"])
+	assert.Equal(t, "dateTime", gotBody["orderBy"])
+	assert.Equal(t, false, gotBody["isAscending"])
+	assert.Equal(t, float64(1), gotBody["statusId"], "default feed should query pending requests")
+}
+
+// pagingServer serves a fixed number of full pages then empty pages, counting
+// requests per page number. envelope controls bare-array vs object output.
+type pagingServer struct {
+	mu        sync.Mutex
+	pageHits  map[int]int
+	itemsByPg map[int][]map[string]interface{}
+	envelope  bool
+}
+
+func newPagingServer(envelope bool, itemsByPg map[int][]map[string]interface{}) *pagingServer {
+	return &pagingServer{
+		pageHits:  map[int]int{},
+		itemsByPg: itemsByPg,
+		envelope:  envelope,
+	}
+}
+
+func (s *pagingServer) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body := decodeRequestBody(t, r)
+		page := int(body["pageNumber"].(float64))
+
+		s.mu.Lock()
+		s.pageHits[page]++
+		items := s.itemsByPg[page]
+		s.mu.Unlock()
+
+		if items == nil {
+			items = []map[string]interface{}{}
+		}
+		w.WriteHeader(http.StatusOK)
+		if s.envelope {
+			json.NewEncoder(w).Encode(map[string]interface{}{"data": items, "totalRecords": len(items)})
+		} else {
+			json.NewEncoder(w).Encode(items)
+		}
+	}
+}
+
+func (s *pagingServer) hits(page int) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pageHits[page]
+}
+
+// TestPaginationAndDedup verifies the adapter walks pages while there is new
+// data, and that on later polls it deduplicates and early-stops (so deeper
+// pages are not re-fetched once their content has all been seen).
+func TestPaginationAndDedup(t *testing.T) {
+	ps := newPagingServer(false, map[int][]map[string]interface{}{
+		1: {approvalItem("a"), approvalItem("b")},
+		2: {approvalItem("c"), approvalItem("d")},
+	})
+	server := httptest.NewServer(ps.handler(t))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions: testClientOptions(t),
+		APIKey:        "k",
+		BaseURL:       server.URL,
+		PageSize:      2, // full page == 2 items, forcing multi-page walks
+		PollInterval:  80 * time.Millisecond,
+		DedupeTTL:     time.Hour,
+	}
+	adapter, _, err := NewThreatLockerAdapter(ctx, conf)
+	require.NoError(t, err)
+
+	// Allow several poll cycles to run.
+	time.Sleep(400 * time.Millisecond)
+	require.NoError(t, adapter.Close())
+
+	// First poll: page1 (full, new) -> page2 (full, new) -> page3 (empty).
+	// Later polls: page1 is entirely duplicates -> early-stop before page2.
+	assert.GreaterOrEqual(t, ps.hits(1), 2, "page 1 should be polled repeatedly")
+	assert.Equal(t, 1, ps.hits(2), "page 2 should be fetched once (only the first poll has new data)")
+	assert.Equal(t, 1, ps.hits(3), "page 3 should be fetched once (terminates the first poll)")
+}
+
+// TestObjectEnvelopeResponse verifies the same incremental behaviour when the
+// API wraps results in an object envelope instead of a bare array.
+func TestObjectEnvelopeResponse(t *testing.T) {
+	ps := newPagingServer(true, map[int][]map[string]interface{}{
+		1: {approvalItem("a")},
+		2: {approvalItem("b")},
+	})
+	server := httptest.NewServer(ps.handler(t))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions: testClientOptions(t),
+		APIKey:        "k",
+		BaseURL:       server.URL,
+		PageSize:      1,
+		PollInterval:  80 * time.Millisecond,
+		DedupeTTL:     time.Hour,
+	}
+	adapter, _, err := NewThreatLockerAdapter(ctx, conf)
+	require.NoError(t, err)
+
+	time.Sleep(400 * time.Millisecond)
+	require.NoError(t, adapter.Close())
+
+	// page2/page3 fetched exactly once proves the envelope was parsed (records
+	// extracted) AND deduplicated on later polls.
+	assert.GreaterOrEqual(t, ps.hits(1), 2)
+	assert.Equal(t, 1, ps.hits(2))
+	assert.Equal(t, 1, ps.hits(3))
+}
+
+// TestTransientErrorRetry verifies the adapter retries 5xx responses rather
+// than terminating.
+func TestTransientErrorRetry(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestCount.Add(1) <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"transient"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions:  testClientOptions(t),
+		APIKey:         "k",
+		BaseURL:        server.URL,
+		PollInterval:   100 * time.Millisecond,
+		RetryBaseDelay: 20 * time.Millisecond,
+		MaxRetryDelay:  40 * time.Millisecond,
+	}
+	adapter, chStopped, err := NewThreatLockerAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped on a transient error - it should have retried")
+	default:
+	}
+	assert.GreaterOrEqual(t, requestCount.Load(), int32(3), "expected retries then success")
+	assert.False(t, adapter.doStop.IsSet())
+}
+
+// TestPermanentAuthErrorStops verifies a 401/403 stops the whole adapter.
+func TestPermanentAuthErrorStops(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				w.Write([]byte(`{"error":"denied"}`))
+			}))
+			defer server.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			conf := ThreatLockerConfig{
+				ClientOptions: testClientOptions(t),
+				APIKey:        "bad-key",
+				BaseURL:       server.URL,
+				PollInterval:  100 * time.Millisecond,
+			}
+			adapter, chStopped, err := NewThreatLockerAdapter(ctx, conf)
+			require.NoError(t, err)
+			defer adapter.Close()
+
+			select {
+			case <-chStopped:
+				// Expected: an auth failure terminates the adapter.
+			case <-time.After(3 * time.Second):
+				t.Fatalf("adapter should have stopped on HTTP %d", status)
+			}
+			assert.True(t, adapter.doStop.IsSet())
+		})
+	}
+}

--- a/threatlocker/client_test.go
+++ b/threatlocker/client_test.go
@@ -36,6 +36,21 @@ func testClientOptions(t *testing.T) uspclient.ClientOptions {
 	}
 }
 
+// approvalRequestFeed is the single feed used by integration tests that focus
+// on adapter behavior rather than the default feed set. Tests pin the config
+// to this feed so they don't accidentally exercise unrelated default feeds
+// (unified_audit, system_audit) on shared httptest servers.
+func approvalRequestFeed() []ThreatLockerFeed {
+	return []ThreatLockerFeed{{
+		Name:           "approval_request",
+		URL:            "ApprovalRequest/ApprovalRequestGetByParameters",
+		Parameters:     utils.Dict{"statusId": 1},
+		OrderBy:        "dateTime",
+		TimestampField: "dateTime",
+		IDField:        "approvalRequestId",
+	}}
+}
+
 // approvalItem builds a minimal ThreatLocker approval-request-shaped record.
 func approvalItem(id string) map[string]interface{} {
 	return map[string]interface{}{
@@ -238,6 +253,45 @@ func TestBuildRequestBody(t *testing.T) {
 		assert.Equal(t, "custom", body["orderBy"])
 		assert.Equal(t, true, body["isAscending"])
 	})
+
+	t.Run("rolling window injects start/end on every poll", func(t *testing.T) {
+		aw := &ThreatLockerAdapter{conf: ThreatLockerConfig{PageSize: 50, PollInterval: 60 * time.Second}}
+		feed := ThreatLockerFeed{
+			Window:         5 * time.Minute,
+			StartDateField: defaultStartDateField,
+			EndDateField:   defaultEndDateField,
+		}
+
+		before := time.Now().UTC()
+		body := aw.buildRequestBody(feed, 1)
+		after := time.Now().UTC()
+
+		startStr, ok := body[defaultStartDateField].(string)
+		require.True(t, ok, "startDate must be a string, got %T", body[defaultStartDateField])
+		endStr, ok := body[defaultEndDateField].(string)
+		require.True(t, ok, "endDate must be a string, got %T", body[defaultEndDateField])
+
+		start, err := time.Parse(windowTimestampLayout, startStr)
+		require.NoError(t, err)
+		end, err := time.Parse(windowTimestampLayout, endStr)
+		require.NoError(t, err)
+
+		// end should be ~ now, start should be window + poll_interval before end
+		assert.False(t, end.Before(before.Truncate(time.Millisecond)), "end %v < before %v", end, before)
+		assert.False(t, end.After(after.Add(time.Second)), "end %v > after+1s %v", end, after)
+		gap := end.Sub(start)
+		assert.Equal(t, feed.Window+aw.conf.PollInterval, gap,
+			"start/end gap must equal window+poll_interval")
+	})
+
+	t.Run("no window means no date fields injected", func(t *testing.T) {
+		feed := ThreatLockerFeed{OrderBy: "dateTime"}
+		body := a.buildRequestBody(feed, 1)
+		_, hasStart := body[defaultStartDateField]
+		_, hasEnd := body[defaultEndDateField]
+		assert.False(t, hasStart, "startDate must be absent when window is unset")
+		assert.False(t, hasEnd, "endDate must be absent when window is unset")
+	})
 }
 
 func TestParseTimestamp(t *testing.T) {
@@ -290,14 +344,26 @@ func TestValidate(t *testing.T) {
 		assert.Error(t, c.Validate())
 	})
 
-	t.Run("applies defaults and the default feed", func(t *testing.T) {
+	t.Run("applies defaults and the default feed set", func(t *testing.T) {
 		c := ThreatLockerConfig{ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g"}
 		require.NoError(t, c.Validate())
 		assert.Equal(t, defaultPageSize, c.PageSize)
 		assert.Equal(t, defaultPollInterval, c.PollInterval)
-		require.Len(t, c.Feeds, 1)
-		assert.Equal(t, "approval_request", c.Feeds[0].Name)
-		assert.Equal(t, defaultMaxPages, c.Feeds[0].MaxPages)
+
+		names := make([]string, 0, len(c.Feeds))
+		for _, f := range c.Feeds {
+			names = append(names, f.Name)
+			assert.Equal(t, defaultMaxPages, f.MaxPages, "feed %q must inherit max_pages default", f.Name)
+		}
+		assert.ElementsMatch(t, []string{"approval_request", "unified_audit", "system_audit"}, names)
+
+		// Feeds with a Window must also have start/end field defaults applied.
+		for _, f := range c.Feeds {
+			if f.Window > 0 {
+				assert.Equal(t, defaultStartDateField, f.StartDateField, "feed %q", f.Name)
+				assert.Equal(t, defaultEndDateField, f.EndDateField, "feed %q", f.Name)
+			}
+		}
 	})
 
 	t.Run("rejects feed without url", func(t *testing.T) {
@@ -353,6 +419,7 @@ func TestApprovalRequestFeed(t *testing.T) {
 		BaseURL:               server.URL,
 		ManagedOrganizationID: "org-123",
 		PollInterval:          200 * time.Millisecond,
+		Feeds:                 approvalRequestFeed(),
 	}
 	adapter, chStopped, err := NewThreatLockerAdapter(ctx, conf)
 	require.NoError(t, err)
@@ -452,6 +519,7 @@ func TestPaginationAndDedup(t *testing.T) {
 		PageSize:      2, // a full page is 2 records, forcing a multi-page walk
 		PollInterval:  40 * time.Millisecond,
 		Deduper:       dd,
+		Feeds:         approvalRequestFeed(),
 	}
 	adapter, _, err := NewThreatLockerAdapter(ctx, conf)
 	require.NoError(t, err)
@@ -493,6 +561,7 @@ func TestObjectEnvelopeResponse(t *testing.T) {
 		BaseURL:       server.URL,
 		PollInterval:  40 * time.Millisecond,
 		Deduper:       dd,
+		Feeds:         approvalRequestFeed(),
 	}
 	adapter, _, err := NewThreatLockerAdapter(ctx, conf)
 	require.NoError(t, err)
@@ -598,6 +667,7 @@ func TestTransientErrorRetry(t *testing.T) {
 		PollInterval:   100 * time.Millisecond,
 		RetryBaseDelay: 20 * time.Millisecond,
 		MaxRetryDelay:  40 * time.Millisecond,
+		Feeds:          approvalRequestFeed(),
 	}
 	adapter, chStopped, err := NewThreatLockerAdapter(ctx, conf)
 	require.NoError(t, err)
@@ -632,6 +702,7 @@ func TestPermanentAuthErrorStops(t *testing.T) {
 				APIKey:        "bad-key",
 				BaseURL:       server.URL,
 				PollInterval:  100 * time.Millisecond,
+				Feeds:         approvalRequestFeed(),
 			}
 			adapter, chStopped, err := NewThreatLockerAdapter(ctx, conf)
 			require.NoError(t, err)

--- a/threatlocker/client_test.go
+++ b/threatlocker/client_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -45,13 +46,61 @@ func approvalItem(id string) map[string]interface{} {
 	}
 }
 
+// decodeRequestBody decodes a JSON request body. It runs inside httptest
+// handler goroutines, so it must not use require (whose FailNow/Goexit is only
+// valid on the test goroutine); assert reports failures safely from any
+// goroutine.
 func decodeRequestBody(t *testing.T, r *http.Request) map[string]interface{} {
 	t.Helper()
-	body, err := io.ReadAll(r.Body)
-	require.NoError(t, err)
 	m := map[string]interface{}{}
-	require.NoError(t, json.Unmarshal(body, &m))
+	body, err := io.ReadAll(r.Body)
+	if !assert.NoError(t, err) {
+		return m
+	}
+	assert.NoError(t, json.Unmarshal(body, &m))
 	return m
+}
+
+// countingDeduper wraps a Deduper and records, per key, how many times the key
+// was reported as new (CheckAndAdd returned false). The adapter ships a record
+// exactly when its key is new, so a count above 1 means a record was shipped
+// more than once -- a dedup failure.
+type countingDeduper struct {
+	inner utils.Deduper
+	mu    sync.Mutex
+	new   map[string]int
+}
+
+func newCountingDeduper(t *testing.T) *countingDeduper {
+	t.Helper()
+	// window == ttl gives a single bucket that never rotates within a test.
+	inner, err := utils.NewLocalDeduper(time.Hour, time.Hour)
+	require.NoError(t, err)
+	return &countingDeduper{inner: inner, new: map[string]int{}}
+}
+
+func (d *countingDeduper) CheckAndAdd(key string) bool {
+	exists := d.inner.CheckAndAdd(key)
+	if !exists {
+		d.mu.Lock()
+		d.new[key]++
+		d.mu.Unlock()
+	}
+	return exists
+}
+
+func (d *countingDeduper) Close() { d.inner.Close() }
+
+func (d *countingDeduper) newCount(key string) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.new[key]
+}
+
+func (d *countingDeduper) distinctKeys() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.new)
 }
 
 // --- unit tests -------------------------------------------------------------
@@ -113,6 +162,14 @@ func TestExtractItems(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, uint64(123456789012345678), v)
 	})
+
+	t.Run("non-object records are skipped, valid ones kept", func(t *testing.T) {
+		items, err := extractItems([]byte(`[{"id":"a"},"junk",123,null,{"id":"b"}]`), "")
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, "a", items[0].FindOneString("id"))
+		assert.Equal(t, "b", items[1].FindOneString("id"))
+	})
 }
 
 func TestRecordID(t *testing.T) {
@@ -129,6 +186,12 @@ func TestRecordID(t *testing.T) {
 	t.Run("accepts numeric ids", func(t *testing.T) {
 		feed := ThreatLockerFeed{IDField: "actionId"}
 		assert.Equal(t, "42", recordID(feed, utils.Dict{"actionId": uint64(42)}))
+	})
+
+	t.Run("accepts a numeric id of zero", func(t *testing.T) {
+		// A real id of 0 must not be mistaken for "absent".
+		feed := ThreatLockerFeed{IDField: "actionId"}
+		assert.Equal(t, "0", recordID(feed, utils.Dict{"actionId": uint64(0)}))
 	})
 
 	t.Run("content hash fallback is stable and distinct", func(t *testing.T) {
@@ -340,7 +403,10 @@ func newPagingServer(envelope bool, itemsByPg map[int][]map[string]interface{}) 
 func (s *pagingServer) handler(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		body := decodeRequestBody(t, r)
-		page := int(body["pageNumber"].(float64))
+		page := 1
+		if pn, ok := body["pageNumber"].(float64); ok {
+			page = int(pn)
+		}
 
 		s.mu.Lock()
 		s.pageHits[page]++
@@ -365,9 +431,8 @@ func (s *pagingServer) hits(page int) int {
 	return s.pageHits[page]
 }
 
-// TestPaginationAndDedup verifies the adapter walks pages while there is new
-// data, and that on later polls it deduplicates and early-stops (so deeper
-// pages are not re-fetched once their content has all been seen).
+// TestPaginationAndDedup verifies the adapter walks every page on every poll
+// and, despite re-fetching pages, ships each record exactly once.
 func TestPaginationAndDedup(t *testing.T) {
 	ps := newPagingServer(false, map[int][]map[string]interface{}{
 		1: {approvalItem("a"), approvalItem("b")},
@@ -379,34 +444,41 @@ func TestPaginationAndDedup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	dd := newCountingDeduper(t)
 	conf := ThreatLockerConfig{
 		ClientOptions: testClientOptions(t),
 		APIKey:        "k",
 		BaseURL:       server.URL,
-		PageSize:      2, // full page == 2 items, forcing multi-page walks
-		PollInterval:  80 * time.Millisecond,
-		DedupeTTL:     time.Hour,
+		PageSize:      2, // a full page is 2 records, forcing a multi-page walk
+		PollInterval:  40 * time.Millisecond,
+		Deduper:       dd,
 	}
 	adapter, _, err := NewThreatLockerAdapter(ctx, conf)
 	require.NoError(t, err)
 
-	// Allow several poll cycles to run.
-	time.Sleep(400 * time.Millisecond)
+	// Wait for at least three polls to complete.
+	require.Eventually(t, func() bool { return ps.hits(1) >= 3 },
+		5*time.Second, 20*time.Millisecond)
 	require.NoError(t, adapter.Close())
 
-	// First poll: page1 (full, new) -> page2 (full, new) -> page3 (empty).
-	// Later polls: page1 is entirely duplicates -> early-stop before page2.
-	assert.GreaterOrEqual(t, ps.hits(1), 2, "page 1 should be polled repeatedly")
-	assert.Equal(t, 1, ps.hits(2), "page 2 should be fetched once (only the first poll has new data)")
-	assert.Equal(t, 1, ps.hits(3), "page 3 should be fetched once (terminates the first poll)")
+	// Every poll re-walks every page (there is no early-stop): pages 2 and 3
+	// are fetched on every completed poll, not just the first.
+	assert.GreaterOrEqual(t, ps.hits(2), 2, "every poll re-walks page 2")
+	assert.GreaterOrEqual(t, ps.hits(3), 2, "every poll re-walks page 3 (empty, ends the walk)")
+
+	// Despite being re-fetched on every poll, each record ships exactly once.
+	for _, id := range []string{"a", "b", "c", "d"} {
+		assert.Equal(t, 1, dd.newCount("approval_request|"+id),
+			"record %q must ship exactly once", id)
+	}
+	assert.Equal(t, 4, dd.distinctKeys())
 }
 
-// TestObjectEnvelopeResponse verifies the same incremental behaviour when the
-// API wraps results in an object envelope instead of a bare array.
+// TestObjectEnvelopeResponse verifies the adapter parses an object-envelope
+// response ({"data": [...]}) and ships each record exactly once.
 func TestObjectEnvelopeResponse(t *testing.T) {
 	ps := newPagingServer(true, map[int][]map[string]interface{}{
-		1: {approvalItem("a")},
-		2: {approvalItem("b")},
+		1: {approvalItem("a"), approvalItem("b")},
 	})
 	server := httptest.NewServer(ps.handler(t))
 	defer server.Close()
@@ -414,25 +486,91 @@ func TestObjectEnvelopeResponse(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	dd := newCountingDeduper(t)
 	conf := ThreatLockerConfig{
 		ClientOptions: testClientOptions(t),
 		APIKey:        "k",
 		BaseURL:       server.URL,
-		PageSize:      1,
-		PollInterval:  80 * time.Millisecond,
-		DedupeTTL:     time.Hour,
+		PollInterval:  40 * time.Millisecond,
+		Deduper:       dd,
 	}
 	adapter, _, err := NewThreatLockerAdapter(ctx, conf)
 	require.NoError(t, err)
 
-	time.Sleep(400 * time.Millisecond)
+	require.Eventually(t, func() bool { return ps.hits(1) >= 3 },
+		5*time.Second, 20*time.Millisecond)
 	require.NoError(t, adapter.Close())
 
-	// page2/page3 fetched exactly once proves the envelope was parsed (records
-	// extracted) AND deduplicated on later polls.
-	assert.GreaterOrEqual(t, ps.hits(1), 2)
-	assert.Equal(t, 1, ps.hits(2))
-	assert.Equal(t, 1, ps.hits(3))
+	// The envelope was parsed and its records extracted; each ships exactly
+	// once even though page 1 is re-fetched on every poll.
+	assert.Equal(t, 1, dd.newCount("approval_request|a"))
+	assert.Equal(t, 1, dd.newCount("approval_request|b"))
+	assert.Equal(t, 2, dd.distinctKeys())
+}
+
+// TestMaxPagesCap verifies a feed stops paginating at max_pages rather than
+// walking an unbounded result set.
+func TestMaxPagesCap(t *testing.T) {
+	var mu sync.Mutex
+	hits := map[int]int{}
+	var idCounter atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := decodeRequestBody(t, r)
+		page := 1
+		if pn, ok := body["pageNumber"].(float64); ok {
+			page = int(pn)
+		}
+		mu.Lock()
+		hits[page]++
+		mu.Unlock()
+		// Always return a full page of brand-new records, so pagination would
+		// never terminate on its own.
+		items := []map[string]interface{}{
+			approvalItem(fmt.Sprintf("rec-%d", idCounter.Add(1))),
+			approvalItem(fmt.Sprintf("rec-%d", idCounter.Add(1))),
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(items)
+	}))
+	defer server.Close()
+
+	var maxPagesWarned atomic.Bool
+	opts := testClientOptions(t)
+	opts.OnWarning = func(msg string) {
+		t.Logf("WRN: %s", msg)
+		if strings.Contains(msg, "max_pages") {
+			maxPagesWarned.Store(true)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions: opts,
+		APIKey:        "k",
+		BaseURL:       server.URL,
+		PageSize:      2,
+		PollInterval:  1 * time.Hour, // only the initial poll runs during the test
+		Feeds: []ThreatLockerFeed{
+			{Name: "capped", URL: "Capped/CappedGetByParameters", MaxPages: 3},
+		},
+	}
+	adapter, _, err := NewThreatLockerAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The poll must stop at the cap; the warning is emitted when it does.
+	require.Eventually(t, maxPagesWarned.Load, 5*time.Second, 20*time.Millisecond,
+		"adapter should warn when max_pages is reached")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 0, hits[4], "page 4 must not be fetched (max_pages=3)")
+	for p := 1; p <= 3; p++ {
+		assert.GreaterOrEqual(t, hits[p], 1, "page %d should be fetched", p)
+	}
 }
 
 // TestTransientErrorRetry verifies the adapter retries 5xx responses rather

--- a/threatlocker/mock_test.go
+++ b/threatlocker/mock_test.go
@@ -1,0 +1,503 @@
+package usp_threatlocker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock ThreatLocker Portal
+// API, capturing the exact messages it ships so their content -- event type,
+// timestamp and verbatim payload -- can be asserted.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock ThreatLocker Portal API -------------------------------------------
+
+// mockThreatLocker is an in-memory stand-in for the ThreatLocker Portal API. It
+// honours the "*GetByParameters" contract: a POST carrying the Authorization
+// header and a JSON body with pageNumber/pageSize, returning a paginated slice
+// of the dataset registered for that path.
+type mockThreatLocker struct {
+	mu       sync.Mutex
+	token    string
+	datasets map[string][]utils.Dict // request path -> records (newest-first)
+	envelope bool                    // wrap results as {"data": [...]} instead of a bare array
+	requests int
+}
+
+func newMockThreatLocker(token string) *mockThreatLocker {
+	return &mockThreatLocker{token: token, datasets: map[string][]utils.Dict{}}
+}
+
+// setDataset registers the records a feed URL serves. The request path the
+// adapter hits is "/" + feedURL (BaseURL has no trailing path in these tests).
+func (m *mockThreatLocker) setDataset(feedURL string, records []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.datasets["/"+feedURL] = records
+}
+
+// appendRecord inserts a record at the top of a feed (newest-first), as the
+// real API would when a new event occurs.
+func (m *mockThreatLocker) appendRecord(feedURL string, record utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	path := "/" + feedURL
+	m.datasets[path] = append([]utils.Dict{record}, m.datasets[path]...)
+}
+
+func (m *mockThreatLocker) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+func (m *mockThreatLocker) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.requests++
+		m.mu.Unlock()
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		// The Portal API authenticates with the token in the Authorization header.
+		if r.Header.Get("Authorization") != m.token {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid or missing API token"}`))
+			return
+		}
+
+		body := decodeRequestBody(t, r)
+		pageNumber := 1
+		if v, ok := body["pageNumber"].(float64); ok && v >= 1 {
+			pageNumber = int(v)
+		}
+		pageSize := defaultPageSize
+		if v, ok := body["pageSize"].(float64); ok && v > 0 {
+			pageSize = int(v)
+		}
+
+		m.mu.Lock()
+		records := m.datasets[r.URL.Path]
+		m.mu.Unlock()
+
+		// Paginate; pageNumber is 1-based.
+		var page []utils.Dict
+		if start := (pageNumber - 1) * pageSize; start < len(records) {
+			end := start + pageSize
+			if end > len(records) {
+				end = len(records)
+			}
+			page = records[start:end]
+		}
+		if page == nil {
+			page = []utils.Dict{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if m.envelope {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data":         page,
+				"totalRecords": len(records),
+				"pageNumber":   pageNumber,
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(page)
+	}
+}
+
+// --- realistic record fixtures ----------------------------------------------
+
+// realisticApprovalRequest returns a record shaped like a real ThreatLocker
+// Application Control approval request: the documented top-level fields plus
+// the nested threatLockerActionDto with a certs array and assorted scalar
+// types (strings, ints, bools, arrays).
+func realisticApprovalRequest(id, dateTime string) utils.Dict {
+	return utils.Dict{
+		"approvalRequestId": id,
+		"organizationId":    "5b7e3c9a-1d2f-4a6b-8c0e-9f1a2b3c4d5e",
+		"computerId":        "a1b2c3d4-e5f6-4071-9a0b-1c2d3e4f5061",
+		"hostname":          "WIN-DESKTOP-" + id,
+		"username":          `ACME\jdoe`,
+		"path":              `C:\Users\jdoe\Downloads\setup.exe`,
+		"hash":              "9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08",
+		"statusId":          1,
+		"dateTime":          dateTime,
+		"threatLockerActionDto": utils.Dict{
+			"fullPath":    `C:\Users\jdoe\Downloads\setup.exe`,
+			"hash":        "TL-9F86D081",
+			"sha256":      "9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08",
+			"processName": "explorer.exe",
+			"osType":      1,
+			"fileSize":    18874368,
+			"certs": []interface{}{
+				utils.Dict{
+					"sha":       "3C5F8E2A9B1D4C6E7F8A0B1C2D3E4F5061728394",
+					"subject":   "CN=Acme Software Inc., O=Acme, C=US",
+					"validCert": true,
+				},
+			},
+			"installedBy": []interface{}{"explorer.exe", "chrome.exe"},
+		},
+	}
+}
+
+// realisticActionLog returns a record shaped like a ThreatLocker Unified Audit
+// (ActionLog) entry.
+func realisticActionLog(id, dateTime string) utils.Dict {
+	return utils.Dict{
+		"actionId":     id,
+		"dateTime":     dateTime,
+		"action":       "Execute",
+		"actionType":   2,
+		"computerName": "WIN-SRV-01",
+		"fullPath":     `C:\Windows\System32\cmd.exe`,
+		"hash":         "ABCD1234EF567890",
+		"username":     `ACME\svc-backup`,
+		"policyName":   "Default Deny",
+		"wasBlocked":   true,
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestMockApprovalRequestEndToEnd drives the adapter against the mock API and
+// asserts the exact events shipped: event type, timestamp parsed from the
+// record's dateTime, and the payload preserved verbatim (nested objects and
+// arrays included).
+func TestMockApprovalRequestEndToEnd(t *testing.T) {
+	const token = "tl-api-token-xyz"
+	const feedURL = "ApprovalRequest/ApprovalRequestGetByParameters"
+
+	mock := newMockThreatLocker(token)
+	want := []utils.Dict{
+		realisticApprovalRequest("req-1001", "2026-05-21T13:45:30Z"),
+		realisticApprovalRequest("req-1002", "2026-05-21T13:50:05Z"),
+		realisticApprovalRequest("req-1003", "2026-05-21T14:02:11Z"),
+	}
+	mock.setDataset(feedURL, want)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions: testClientOptions(t),
+		APIKey:        token,
+		BaseURL:       server.URL,
+		PollInterval:  40 * time.Millisecond,
+	}
+	adapter, _, err := newThreatLockerAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 approval requests to ship")
+
+	// Re-polling must not re-ship: the count stays at 3.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "records were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		assert.Equal(t, "approval_request", msg.EventType)
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["approvalRequestId"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	for _, src := range want {
+		id := src["approvalRequestId"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "record %s was not shipped", id)
+
+		// The event timestamp is parsed from the record's dateTime field.
+		ts, perr := time.Parse(time.RFC3339, src["dateTime"].(string))
+		require.NoError(t, perr)
+		assert.Equal(t, uint64(ts.UnixMilli()), msg.TimestampMs,
+			"event time should come from the record's dateTime")
+
+		// The payload is shipped verbatim -- nested objects and arrays included.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original ThreatLocker record")
+	}
+}
+
+// TestMockNewRequestShippedOnce verifies a request that appears mid-run is
+// shipped exactly once, and already-shipped requests are never re-sent.
+func TestMockNewRequestShippedOnce(t *testing.T) {
+	const token = "tok"
+	const feedURL = "ApprovalRequest/ApprovalRequestGetByParameters"
+
+	mock := newMockThreatLocker(token)
+	mock.setDataset(feedURL, []utils.Dict{
+		realisticApprovalRequest("a", "2026-05-21T10:00:00Z"),
+		realisticApprovalRequest("b", "2026-05-21T10:01:00Z"),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions: testClientOptions(t),
+		APIKey:        token,
+		BaseURL:       server.URL,
+		PollInterval:  30 * time.Millisecond,
+	}
+	adapter, _, err := newThreatLockerAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new pending request appears at the top of the feed.
+	mock.appendRecord(feedURL, realisticApprovalRequest("c", "2026-05-21T10:05:00Z"))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new request should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["approvalRequestId"].(string)]++
+	}
+	assert.Equal(t, map[string]int{"a": 1, "b": 1, "c": 1}, shippedPerID,
+		"every request must ship exactly once")
+}
+
+// TestMockPaginationFullDataset verifies a dataset larger than one page is
+// walked completely and every record is shipped exactly once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const token = "tok"
+	const feedURL = "ApprovalRequest/ApprovalRequestGetByParameters"
+	const total = 250
+
+	mock := newMockThreatLocker(token)
+	records := make([]utils.Dict, total)
+	for i := 0; i < total; i++ {
+		records[i] = realisticApprovalRequest(
+			fmt.Sprintf("req-%03d", i),
+			time.Date(2026, 5, 21, 0, 0, i, 0, time.UTC).Format(time.RFC3339))
+	}
+	mock.setDataset(feedURL, records)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions: testClientOptions(t),
+		APIKey:        token,
+		BaseURL:       server.URL,
+		PageSize:      100, // 250 records => 3 pages
+		PollInterval:  50 * time.Millisecond,
+	}
+	adapter, _, err := newThreatLockerAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 25*time.Millisecond, "all paginated records should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["approvalRequestId"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct record should be shipped once")
+}
+
+// TestMockMultipleFeeds verifies that several feeds collect concurrently and
+// each event is tagged with its feed's name.
+func TestMockMultipleFeeds(t *testing.T) {
+	const token = "tok"
+
+	mock := newMockThreatLocker(token)
+	mock.setDataset("ApprovalRequest/ApprovalRequestGetByParameters", []utils.Dict{
+		realisticApprovalRequest("ar-1", "2026-05-21T09:00:00Z"),
+		realisticApprovalRequest("ar-2", "2026-05-21T09:01:00Z"),
+	})
+	mock.setDataset("ActionLog/ActionLogGetByParametersV2", []utils.Dict{
+		realisticActionLog("al-1", "2026-05-21T09:02:00Z"),
+		realisticActionLog("al-2", "2026-05-21T09:03:00Z"),
+		realisticActionLog("al-3", "2026-05-21T09:04:00Z"),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions: testClientOptions(t),
+		APIKey:        token,
+		BaseURL:       server.URL,
+		PollInterval:  40 * time.Millisecond,
+		Feeds: []ThreatLockerFeed{
+			{
+				Name:       "approval_request",
+				URL:        "ApprovalRequest/ApprovalRequestGetByParameters",
+				Parameters: utils.Dict{"statusId": 1},
+				IDField:    "approvalRequestId",
+			},
+			{
+				Name:    "unified_audit",
+				URL:     "ActionLog/ActionLogGetByParametersV2",
+				IDField: "actionId",
+			},
+		},
+	}
+	adapter, _, err := newThreatLockerAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 5 },
+		5*time.Second, 20*time.Millisecond)
+	require.Never(t, func() bool { return sink.count() != 5 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	byType := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		byType[msg.EventType]++
+	}
+	assert.Equal(t, map[string]int{"approval_request": 2, "unified_audit": 3}, byType)
+}
+
+// TestMockObjectEnvelopeResponse verifies the adapter handles a mock that wraps
+// results in an object envelope ({"data": [...]}).
+func TestMockObjectEnvelopeResponse(t *testing.T) {
+	const token = "tok"
+
+	mock := newMockThreatLocker(token)
+	mock.envelope = true
+	mock.setDataset("ApprovalRequest/ApprovalRequestGetByParameters", []utils.Dict{
+		realisticApprovalRequest("a", "2026-05-21T10:00:00Z"),
+		realisticApprovalRequest("b", "2026-05-21T10:01:00Z"),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions: testClientOptions(t),
+		APIKey:        token,
+		BaseURL:       server.URL,
+		PollInterval:  40 * time.Millisecond,
+	}
+	adapter, _, err := newThreatLockerAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "records inside the envelope should ship")
+	require.Never(t, func() bool { return sink.count() != 2 },
+		300*time.Millisecond, 30*time.Millisecond)
+}
+
+// TestMockRejectsBadToken verifies the adapter stops, and ships nothing, when
+// the mock API rejects the supplied token.
+func TestMockRejectsBadToken(t *testing.T) {
+	mock := newMockThreatLocker("correct-token")
+	mock.setDataset("ApprovalRequest/ApprovalRequestGetByParameters", []utils.Dict{
+		realisticApprovalRequest("a", "2026-05-21T10:00:00Z"),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ThreatLockerConfig{
+		ClientOptions: testClientOptions(t),
+		APIKey:        "wrong-token",
+		BaseURL:       server.URL,
+		PollInterval:  50 * time.Millisecond,
+	}
+	adapter, chStopped, err := newThreatLockerAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	select {
+	case <-chStopped:
+		// Expected: a rejected token stops the adapter.
+	case <-time.After(3 * time.Second):
+		t.Fatal("adapter should stop when the API rejects the token")
+	}
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	assert.GreaterOrEqual(t, mock.requestCount(), 1, "the adapter should have called the API")
+}


### PR DESCRIPTION
## Summary

Adds a new `threatlocker` USP adapter that pulls events from the [ThreatLocker](https://www.threatlocker.com/) Portal API into LimaCharlie, in their original ThreatLocker JSON form (no payload reshaping).

The default deployment ingests three feeds that together cover the bulk of ThreatLocker's telemetry surface:

| Default feed | ThreatLocker endpoint | Purpose |
|---|---|---|
| `approval_request` | `ApprovalRequest/ApprovalRequestGetByParameters` (`statusId = 1`) | New Application Control whitelist requests — one event per pending request, shipped exactly once. Drives automated investigations in LimaCharlie. |
| `unified_audit` | `ActionLog/ActionLogGetByParametersV2` | The **Unified Audit** — combined execute / install / network / registry / read / write / move / delete / baseline / powershell / elevate / web activity across every ThreatLocker module. |
| `system_audit` | `SystemAudit/SystemAuditGetByParameters` | Portal / administrator activity — logins, policy edits, approval decisions, organization changes. |

The adapter is designed to be generic so additional ThreatLocker event types can be added with **configuration only — no code changes**.

## Design

The ThreatLocker Portal API is uniform: every queryable resource exposes a `<Resource>GetByParameters` endpoint that takes a `POST` with a JSON body describing filter, sort and pagination (`pageNumber`/`pageSize`). The adapter models each such endpoint as a **feed**:

- **Generic feed model**: each feed sets a `name` (becomes the `EventType`), the endpoint `url`, arbitrary request `parameters`, and optional `order_by` / `items_path` / `timestamp_field` / `id_field` / `max_pages`.
- **Rolling time-window** (new in this PR): feeds with `window: 5m` automatically rewrite `startDate`/`endDate` on every poll to `[now − window − poll_interval, now]`. Required for endpoints that mandate a date range (`ActionLog`, `SystemAudit`). The `poll_interval` term keeps consecutive polls overlapping so a slipped poll cycle does not leave a gap; the per-feed deduper suppresses re-shipping records in the overlap.
- **Pagination**: every poll re-walks a feed's pages until the result set is exhausted (short/empty page) or `max_pages` is reached. The API paginates by offset over a live, mutable list, so the adapter deliberately does *not* early-stop on already-seen records (that could permanently skip a record that shifted across a page boundary mid-poll). Correctness over request count; bound large feeds with `parameters` filters + `max_pages`.
- **Deduplication**: an in-memory per-feed deduper ships each record exactly once.
- **Per-feed isolation**: a permanent error on one feed abandons that poll cycle for that feed only; other feeds keep polling. Authentication failures (`401`/`403`) stop the whole adapter, since they affect every feed.
- **Resilience**: transient failures (HTTP `5xx`, `429`, network) retried with exponential backoff; `Close()` is idempotent. Both bare-array and object-envelope responses are handled; a single malformed record is skipped, not fatal; integer precision preserved via `utils.UnmarshalCleanJSON`.

## Authentication & instance

API token (Portal → API Users) sent verbatim in the `Authorization` header. API root is `https://portalapi.<instance>.threatlocker.com/portalapi` (`instance` config), with a `base_url` override and an optional `managedOrganizationId` header for child-org scoping.

Tokens are instance-scoped server-side: presenting a valid token to the wrong regional instance returns the same `403 TOKEN_REVOKED` response as a genuinely revoked token. The adapter detects 401/403, surfaces a follow-up error that explicitly names the `instance` setting and points at the Portal Help menu where the instance letter is shown, then stops cleanly so the operator does not chase a token rotation when the real fix is a one-letter config change. The README documents the same.

## Files

- `threatlocker/api.go` — Portal API HTTP client + transient-error classification.
- `threatlocker/client.go` — adapter: config/validation, generic feed model, rolling window, pagination, dedup, retries, shipping.
- `threatlocker/client_test.go` — unit + httptest-backed integration tests.
- `threatlocker/README.md` — adapter documentation.
- Wired into `containers/conf/all.go` and `containers/general/tool.go`; example added to the main `README.md`.

## Testing

- `go test ./threatlocker/...` passes, including under `-race` (run repeatedly for flakiness).
- `go build ./...` and `go vet ./...` clean.
- Unit + httptest coverage: response parsing (array / envelope / precision / non-object skipping), record-id resolution (incl. numeric `0`), base-URL resolution, request-body assembly (including rolling-window start/end injection), timestamp parsing, transient-error classification, config validation, default feed set, the approval-request feed end-to-end, multi-page pagination + dedup (verified via an injected counting deduper), object-envelope polling, `max_pages` cap, transient-error retry, and auth-error shutdown.
- **Validated end-to-end against a live ThreatLocker tenant**: token + instance discovery, the default 3-feed set, real records flowed into LimaCharlie with the original ThreatLocker JSON preserved and the correct `event_type` per feed, per-feed isolation on per-tenant API permission gaps, and the auth-failure shutdown path.

## References

- ThreatLocker [API documentation](https://threatlocker.kb.help/api-documentation/) (Help Center).
- ThreatLocker [Processing Approval Requests through API](https://threatlocker.kb.help/processing-application-control-approval-requests-through-api/).
- ThreatLocker [Using the Unified Audit](https://threatlocker.kb.help/using-the-threatlocker-unified-audit/).
- ThreatLocker [API Users](https://threatlocker.kb.help/api-users/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)