### PR TITLE
Add generic HaloPSA adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,38 @@ journalctl -f -q | netcat 127.0.0.1 4444
 ```
 ./adapter stdin client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=text "client_options.mapping.parsing_re=(?P<date>... \d\d \d\d:\d\d:\d\d) (?P<host>.+) (?P<exe>.+?)\[(?P<pid>\d+)\]: (?P<msg>.*)" client_options.sensor_seed_key=testclient3 client_options.mapping.event_type_path=exe
 ```
+
+### HaloPSA
+
+The `halopsa` adapter polls a [HaloPSA](https://halopsa.com) REST API list endpoint and
+ingests every record into LimaCharlie in its original JSON form. It is generic: the
+default configuration ingests the **audit log** (the `Audit` endpoint), but pointing it
+at any other list endpoint (`Tickets`, `Actions`, ...) only requires changing the
+`endpoint`, `data_field` and `id_field` configurations — no code changes.
+
+Authentication uses the HaloPSA OAuth2 client credentials flow. Create an API
+application under `Configuration > Integrations > HaloPSA API` in HaloPSA to obtain a
+`client_id`/`client_secret`, and grant it permission to read the resources you intend
+to ingest.
+
+Audit log example (hosted HaloPSA instance):
+```
+./general halopsa client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=halopsa-audit instance_url=https://example.halopsa.com client_id=00000000-0000-0000-0000-000000000000 client_secret=XXXXXXXX
+```
+
+Useful configurations:
+
+* `instance_url`: base URL of the HaloPSA instance (e.g. `https://example.halopsa.com`). The authorisation server (`<instance_url>/auth`) and resource server (`<instance_url>/api`) are derived from it. Use `auth_url` / `api_url` to override them when they differ.
+* `client_id` / `client_secret`: credentials of the HaloPSA API application.
+* `tenant`: optional tenant identifier required by some hosted HaloPSA deployments.
+* `scope`: OAuth2 scope requested for the token (defaults to `all`).
+* `endpoint`: the API resource to poll (defaults to `Audit`).
+* `data_field`: response field holding the records array; auto-detected when omitted.
+* `id_field`: monotonically increasing integer field used as the incremental cursor (defaults to `id`).
+* `extra_params`: extra static query string parameters added to every request (e.g. `extra_params.excludesys=true`).
+* `page_size`: records per page (defaults to `100`).
+* `poll_interval`: seconds between polls (defaults to `60`).
+
+The first poll only establishes the cursor; subsequent polls ship newly created
+records. Set `client_options.mapping.event_time_path` (e.g. to `date` for the audit
+log) so LimaCharlie uses the record's own timestamp as the event time.

--- a/containers/conf/all.go
+++ b/containers/conf/all.go
@@ -16,6 +16,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/falconcloud"
 	"github.com/refractionPOINT/usp-adapters/file"
 	"github.com/refractionPOINT/usp-adapters/gcs"
+	"github.com/refractionPOINT/usp-adapters/halopsa"
 	"github.com/refractionPOINT/usp-adapters/harmony"
 	"github.com/refractionPOINT/usp-adapters/hubspot"
 	"github.com/refractionPOINT/usp-adapters/imap"
@@ -89,4 +90,5 @@ type GeneralConfigs struct {
 	SentinelOne       usp_sentinelone.SentinelOneConfig               `json:"sentinel_one" yaml:"sentinel_one"`
 	TrendMicro        usp_trendmicro.TrendMicroConfig                 `json:"trendmicro" yaml:"trendmicro"`
 	Wiz               usp_wiz.WizConfig                               `json:"wiz" yaml:"wiz"`
+	HaloPSA           usp_halopsa.HaloPSAConfig                       `json:"halopsa" yaml:"halopsa"`
 }

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -30,6 +30,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/falconcloud"
 	"github.com/refractionPOINT/usp-adapters/file"
 	"github.com/refractionPOINT/usp-adapters/gcs"
+	"github.com/refractionPOINT/usp-adapters/halopsa"
 	"github.com/refractionPOINT/usp-adapters/harmony"
 	"github.com/refractionPOINT/usp-adapters/hubspot"
 	"github.com/refractionPOINT/usp-adapters/imap"
@@ -492,6 +493,11 @@ func runAdapter(ctx context.Context, method string, configs Configuration, showC
 		configs.TrendMicro.ClientOptions.Architecture = "usp_adapter"
 		configToShow = configs.TrendMicro
 		client, chRunning, err = usp_trendmicro.NewTrendMicroAdapter(ctx, configs.TrendMicro)
+	} else if method == "halopsa" {
+		configs.HaloPSA.ClientOptions = applyLogging(configs.HaloPSA.ClientOptions)
+		configs.HaloPSA.ClientOptions.Architecture = "usp_adapter"
+		configToShow = configs.HaloPSA
+		client, chRunning, err = usp_halopsa.NewHaloPSAAdapter(ctx, configs.HaloPSA)
 	} else {
 		return nil, nil, errors.New(logError("unknown adapter_type: %s", method))
 	}

--- a/halopsa/client.go
+++ b/halopsa/client.go
@@ -1,0 +1,563 @@
+package usp_halopsa
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+// The HaloPSA adapter is intentionally generic: it polls any HaloPSA REST list
+// endpoint and ships every record into LimaCharlie in its original JSON shape.
+// The default configuration targets the audit log (the "/Audit" endpoint), but
+// pointing it at another endpoint (Tickets, Actions, ...) only requires
+// changing configuration, not code.
+//
+// HaloPSA reference:
+//   - Authentication (OAuth2 client credentials):
+//     https://haloacademy.halopsa.com/apidoc/authentication/client
+//   - API reference / Swagger:
+//     https://haloacademy.halopsa.com/apidoc
+
+const (
+	defaultEndpoint     = "Audit"
+	defaultIDField      = "id"
+	defaultScope        = "all"
+	defaultPageSize     = 100
+	defaultPollInterval = 60 // seconds
+	defaultTokenTTL     = 3600
+
+	recordCountField = "record_count"
+	maxErrBodyLen    = 512
+)
+
+// HaloPSAConfig holds the configuration for one HaloPSA adapter instance.
+type HaloPSAConfig struct {
+	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+	// InstanceURL is the base URL of the HaloPSA instance, e.g.
+	// "https://example.halopsa.com". The authorisation server and the
+	// resource (API) server are derived from it unless overridden below.
+	InstanceURL string `json:"instance_url" yaml:"instance_url"`
+	// AuthURL optionally overrides the authorisation server URL (the part
+	// before "/token"). Defaults to "<instance_url>/auth".
+	AuthURL string `json:"auth_url" yaml:"auth_url"`
+	// APIURL optionally overrides the resource (API) server URL.
+	// Defaults to "<instance_url>/api".
+	APIURL string `json:"api_url" yaml:"api_url"`
+
+	// ClientID and ClientSecret identify the HaloPSA API application
+	// (configured under Configuration > Integrations > HaloPSA API).
+	ClientID     string `json:"client_id" yaml:"client_id"`
+	ClientSecret string `json:"client_secret" yaml:"client_secret"`
+	// Tenant is the optional tenant identifier required by some hosted
+	// HaloPSA deployments. Leave empty for self-hosted instances.
+	Tenant string `json:"tenant" yaml:"tenant"`
+	// Scope is the OAuth2 scope requested for the token. Defaults to "all".
+	Scope string `json:"scope" yaml:"scope"`
+
+	// Endpoint is the API resource to poll, e.g. "Audit" (the default),
+	// "Tickets", "Actions", etc. Any list endpoint exposing a monotonically
+	// increasing integer id can be ingested.
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
+	// DataField is the response field holding the array of records. When
+	// empty (the default) the first array-valued field is auto-detected.
+	DataField string `json:"data_field" yaml:"data_field"`
+	// IDField is the record field used as the incremental cursor. It must be
+	// a monotonically increasing integer. Defaults to "id".
+	IDField string `json:"id_field" yaml:"id_field"`
+	// ExtraParams are additional static query string parameters added to
+	// every request (e.g. {"excludesys": "true"}). They override the
+	// adapter's own defaults, so ordering/filtering can be tuned per
+	// endpoint without code changes.
+	ExtraParams map[string]string `json:"extra_params" yaml:"extra_params"`
+
+	// PageSize is the number of records requested per page. Defaults to 100.
+	PageSize int `json:"page_size" yaml:"page_size"`
+	// PollInterval is the delay in seconds between polls. Defaults to 60.
+	PollInterval int `json:"poll_interval" yaml:"poll_interval"`
+}
+
+func (c *HaloPSAConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+	if c.ClientID == "" {
+		return errors.New("missing client_id")
+	}
+	if c.ClientSecret == "" {
+		return errors.New("missing client_secret")
+	}
+	if c.InstanceURL == "" && c.AuthURL == "" {
+		return errors.New("missing instance_url (or auth_url)")
+	}
+	if c.InstanceURL == "" && c.APIURL == "" {
+		return errors.New("missing instance_url (or api_url)")
+	}
+	return nil
+}
+
+func trimURL(u string) string {
+	return strings.TrimRight(strings.TrimSpace(u), "/")
+}
+
+// tokenURL returns the full OAuth2 token endpoint, including the optional
+// tenant query parameter.
+func (c *HaloPSAConfig) tokenURL() string {
+	authBase := trimURL(c.AuthURL)
+	if authBase == "" {
+		authBase = trimURL(c.InstanceURL) + "/auth"
+	}
+	u := authBase + "/token"
+	if c.Tenant != "" {
+		u += "?tenant=" + url.QueryEscape(c.Tenant)
+	}
+	return u
+}
+
+// resourceBaseURL returns the resource (API) server base URL, with no
+// trailing slash.
+func (c *HaloPSAConfig) resourceBaseURL() string {
+	apiBase := trimURL(c.APIURL)
+	if apiBase == "" {
+		apiBase = trimURL(c.InstanceURL) + "/api"
+	}
+	return apiBase
+}
+
+type HaloPSAAdapter struct {
+	conf       HaloPSAConfig
+	uspClient  *uspclient.Client
+	httpClient *http.Client
+
+	chStopped chan struct{}
+	wgSenders sync.WaitGroup
+	doStop    *utils.Event
+
+	ctx context.Context
+
+	accessToken string
+	tokenExpiry time.Time
+
+	// initialized is false until the baseline cursor has been established.
+	initialized bool
+	// lastMaxID is the incremental cursor: the highest id already shipped.
+	lastMaxID uint64
+}
+
+func NewHaloPSAAdapter(ctx context.Context, conf HaloPSAConfig) (*HaloPSAAdapter, chan struct{}, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	// Apply defaults.
+	if conf.Endpoint == "" {
+		conf.Endpoint = defaultEndpoint
+	}
+	if conf.IDField == "" {
+		conf.IDField = defaultIDField
+	}
+	if conf.Scope == "" {
+		conf.Scope = defaultScope
+	}
+	if conf.PageSize <= 0 {
+		conf.PageSize = defaultPageSize
+	}
+	if conf.PollInterval <= 0 {
+		conf.PollInterval = defaultPollInterval
+	}
+
+	a := &HaloPSAAdapter{
+		conf:   conf,
+		ctx:    ctx,
+		doStop: utils.NewEvent(),
+	}
+
+	var err error
+	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a.httpClient = &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 10 * time.Second,
+			}).Dial,
+		},
+	}
+
+	a.chStopped = make(chan struct{})
+
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf("halopsa: polling %s/%s every %ds",
+		a.conf.resourceBaseURL(), strings.Trim(a.conf.Endpoint, "/"), a.conf.PollInterval))
+
+	a.wgSenders.Add(1)
+	go a.fetchEvents()
+
+	go func() {
+		a.wgSenders.Wait()
+		close(a.chStopped)
+	}()
+
+	return a, a.chStopped, nil
+}
+
+func (a *HaloPSAAdapter) Close() error {
+	a.conf.ClientOptions.DebugLog("halopsa: closing")
+	a.doStop.Set()
+	a.wgSenders.Wait()
+	err1 := a.uspClient.Drain(1 * time.Minute)
+	_, err2 := a.uspClient.Close()
+	a.httpClient.CloseIdleConnections()
+
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+func (a *HaloPSAAdapter) fetchEvents() {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog("halopsa: event fetch loop exiting")
+
+	interval := time.Duration(a.conf.PollInterval) * time.Second
+
+	// The first poll establishes the baseline cursor without shipping, so
+	// the adapter starts from "now" rather than replaying the full history.
+	if items, err := a.poll(); err != nil {
+		a.conf.ClientOptions.OnError(fmt.Errorf("halopsa: initial poll: %v", err))
+	} else {
+		a.shipItems(items)
+	}
+
+	for !a.doStop.WaitFor(interval) {
+		items, err := a.poll()
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("halopsa: poll: %v", err))
+			continue
+		}
+		if !a.shipItems(items) {
+			return
+		}
+	}
+}
+
+// poll fetches the new records since the last successful poll. On the very
+// first call it only establishes the baseline cursor and returns no records.
+func (a *HaloPSAAdapter) poll() ([]utils.Dict, error) {
+	token, err := a.getToken()
+	if err != nil {
+		return nil, err
+	}
+
+	fetchPage := func(pageNo int) ([]utils.Dict, int, error) {
+		return a.requestPage(token, pageNo)
+	}
+
+	if !a.initialized {
+		items, _, err := fetchPage(1)
+		if err != nil {
+			return nil, err
+		}
+		a.lastMaxID = maxID(items, a.conf.IDField)
+		a.initialized = true
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf("halopsa: baseline established at %s=%d",
+			a.conf.IDField, a.lastMaxID))
+		return nil, nil
+	}
+
+	items, newMax, err := collectNewItems(fetchPage, a.conf.IDField, a.lastMaxID, a.doStop.IsSet)
+	if err != nil {
+		return nil, err
+	}
+	a.lastMaxID = newMax
+	if len(items) > 0 {
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf("halopsa: collected %d new records (cursor %s=%d)",
+			len(items), a.conf.IDField, newMax))
+	}
+	return items, nil
+}
+
+// shipItems ships every item to LimaCharlie. It returns false if a fatal
+// error occurred and the fetch loop should terminate.
+func (a *HaloPSAAdapter) shipItems(items []utils.Dict) bool {
+	for _, item := range items {
+		msg := &protocol.DataMessage{
+			JsonPayload: item,
+			TimestampMs: uint64(time.Now().UnixNano() / int64(time.Millisecond)),
+		}
+		err := a.uspClient.Ship(msg, 10*time.Second)
+		if err == uspclient.ErrorBufferFull {
+			a.conf.ClientOptions.OnWarning("stream falling behind")
+			err = a.uspClient.Ship(msg, 1*time.Hour)
+		}
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("Ship(): %v", err))
+			a.doStop.Set()
+			return false
+		}
+	}
+	return true
+}
+
+// getToken returns a valid OAuth2 access token, fetching a new one when the
+// cached token is missing or about to expire.
+func (a *HaloPSAAdapter) getToken() (string, error) {
+	if a.accessToken != "" && time.Until(a.tokenExpiry) > time.Minute {
+		return a.accessToken, nil
+	}
+
+	a.conf.ClientOptions.DebugLog("halopsa: fetching access token")
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", a.conf.ClientID)
+	form.Set("client_secret", a.conf.ClientSecret)
+	form.Set("scope", a.conf.Scope)
+
+	req, err := http.NewRequest("POST", a.conf.tokenURL(), strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("token request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint %s: %s", resp.Status, truncate(body))
+	}
+
+	var tok struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return "", fmt.Errorf("token response: %v", err)
+	}
+	if tok.AccessToken == "" {
+		return "", errors.New("token response missing access_token")
+	}
+
+	expiresIn := tok.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = defaultTokenTTL
+	}
+	a.accessToken = tok.AccessToken
+	a.tokenExpiry = time.Now().Add(time.Duration(expiresIn) * time.Second)
+	return a.accessToken, nil
+}
+
+// requestPage fetches a single page of records from the configured endpoint.
+func (a *HaloPSAAdapter) requestPage(token string, pageNo int) ([]utils.Dict, int, error) {
+	reqURL := a.conf.resourceBaseURL() + "/" + strings.Trim(a.conf.Endpoint, "/")
+
+	q := url.Values{}
+	q.Set("pageinate", "true")
+	q.Set("page_size", strconv.Itoa(a.conf.PageSize))
+	q.Set("page_no", strconv.Itoa(pageNo))
+	// Newest-first ordering lets the incremental poll stop as soon as it
+	// reaches a record it has already seen.
+	q.Set("order", a.conf.IDField)
+	q.Set("orderdesc", "true")
+	// Caller-supplied parameters win over the adapter's defaults.
+	for k, v := range a.conf.ExtraParams {
+		q.Set(k, v)
+	}
+
+	req, err := http.NewRequest("GET", reqURL+"?"+q.Encode(), nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading response: %v", err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		// Force a token refresh on the next poll.
+		a.accessToken = ""
+		return nil, 0, fmt.Errorf("halopsa api 401 unauthorized: %s", truncate(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, fmt.Errorf("halopsa api %s: %s", resp.Status, truncate(body))
+	}
+
+	return parseListResponse(body, a.conf.DataField)
+}
+
+// parseListResponse extracts the array of records and the total record count
+// from a HaloPSA list response. HaloPSA list endpoints normally return an
+// envelope of the form {"record_count": N, "<resource>": [...]}, but some
+// return a bare JSON array, so both shapes are supported.
+func parseListResponse(body []byte, dataField string) ([]utils.Dict, int, error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil, 0, nil
+	}
+
+	if trimmed[0] == '[' {
+		var arr []utils.Dict
+		if err := json.Unmarshal(trimmed, &arr); err != nil {
+			return nil, 0, fmt.Errorf("invalid json array: %v", err)
+		}
+		return arr, len(arr), nil
+	}
+
+	var resp utils.Dict
+	if err := json.Unmarshal(trimmed, &resp); err != nil {
+		return nil, 0, fmt.Errorf("invalid json: %v", err)
+	}
+	recordCount := int(resp.FindOneInt(recordCountField))
+	return extractItems(resp, dataField), recordCount, nil
+}
+
+// extractItems returns the array of records from a HaloPSA list envelope.
+// When dataField is set it is used directly; otherwise the first array-valued
+// field is used, which makes the adapter work against any list endpoint
+// without per-endpoint configuration.
+func extractItems(resp utils.Dict, dataField string) []utils.Dict {
+	if dataField != "" {
+		items, _ := resp.GetListOfDict(dataField)
+		return items
+	}
+	keys := resp.Keys()
+	sort.Strings(keys)
+	for _, k := range keys {
+		if k == recordCountField {
+			continue
+		}
+		if items, ok := resp.GetListOfDict(k); ok {
+			return items
+		}
+	}
+	return nil
+}
+
+// collectNewItems walks the endpoint pages (newest-first) via fetchPage and
+// returns every record whose id is greater than lastMaxID, ordered oldest
+// first. It also returns the new high-water-mark id to use as the next cursor.
+//
+// In steady state this only fetches the first page, since it stops as soon as
+// it reaches an already-seen id. It keeps paging only when catching up after
+// downtime.
+func collectNewItems(
+	fetchPage func(pageNo int) ([]utils.Dict, int, error),
+	idField string,
+	lastMaxID uint64,
+	stop func() bool,
+) ([]utils.Dict, uint64, error) {
+	var collected []utils.Dict
+	seen := map[uint64]struct{}{}
+	newMax := lastMaxID
+	totalSeen := 0
+
+	for pageNo := 1; ; pageNo++ {
+		if stop != nil && stop() {
+			break
+		}
+
+		items, recordCount, err := fetchPage(pageNo)
+		if err != nil {
+			return nil, lastMaxID, err
+		}
+		// An empty page marks the end of the result set.
+		if len(items) == 0 {
+			break
+		}
+		totalSeen += len(items)
+
+		reachedKnown := false
+		for _, item := range items {
+			id, ok := item.GetInt(idField)
+			if !ok {
+				// No usable cursor id: include the record rather than
+				// risk dropping data. Endpoints used with this adapter
+				// should expose a monotonic integer id field.
+				collected = append(collected, item)
+				continue
+			}
+			if id <= lastMaxID {
+				reachedKnown = true
+				continue
+			}
+			if _, dup := seen[id]; dup {
+				// Records can shift between pages while new ones are
+				// inserted; skip anything already collected this poll.
+				continue
+			}
+			seen[id] = struct{}{}
+			collected = append(collected, item)
+			if id > newMax {
+				newMax = id
+			}
+		}
+
+		if reachedKnown {
+			break
+		}
+		// Stop once the whole result set has been walked. This is based on
+		// the record count rather than the page length so it stays correct
+		// even when the server clamps page_size to a lower maximum.
+		if recordCount > 0 && totalSeen >= recordCount {
+			break
+		}
+	}
+
+	// Pages are walked newest-first; deliver records oldest-first.
+	for i, j := 0, len(collected)-1; i < j; i, j = i+1, j-1 {
+		collected[i], collected[j] = collected[j], collected[i]
+	}
+	return collected, newMax, nil
+}
+
+// maxID returns the highest id found among items, or 0 if none have one.
+func maxID(items []utils.Dict, idField string) uint64 {
+	var m uint64
+	for _, item := range items {
+		if id, ok := item.GetInt(idField); ok && id > m {
+			m = id
+		}
+	}
+	return m
+}
+
+// truncate shortens a response body for safe inclusion in error messages.
+func truncate(b []byte) string {
+	s := strings.TrimSpace(string(b))
+	if len(s) > maxErrBodyLen {
+		return s[:maxErrBodyLen] + "...(truncated)"
+	}
+	return s
+}

--- a/halopsa/client.go
+++ b/halopsa/client.go
@@ -81,10 +81,12 @@ type HaloPSAConfig struct {
 	// a monotonically increasing integer. Defaults to "id".
 	IDField string `json:"id_field" yaml:"id_field"`
 	// ExtraParams are additional static query string parameters added to
-	// every request (e.g. {"excludesys": "true"}). They override the
-	// adapter's own defaults, so ordering/filtering can be tuned per
-	// endpoint without code changes.
-	ExtraParams map[string]string `json:"extra_params" yaml:"extra_params"`
+	// every request (e.g. {"excludesys": true, "user_id": 42}). They
+	// override the adapter's own defaults, so ordering/filtering can be
+	// tuned per endpoint without code changes. Values are stringified for
+	// the query, so bools, numbers and strings can all be used directly
+	// from YAML or the CLI.
+	ExtraParams map[string]interface{} `json:"extra_params" yaml:"extra_params"`
 
 	// PageSize is the number of records requested per page. Defaults to 100.
 	PageSize int `json:"page_size" yaml:"page_size"`
@@ -383,9 +385,7 @@ func (a *HaloPSAAdapter) requestPage(token string, pageNo int) ([]utils.Dict, in
 	q.Set("order", a.conf.IDField)
 	q.Set("orderdesc", "true")
 	// Caller-supplied parameters win over the adapter's defaults.
-	for k, v := range a.conf.ExtraParams {
-		q.Set(k, v)
-	}
+	applyExtraParams(q, a.conf.ExtraParams)
 
 	req, err := http.NewRequest("GET", reqURL+"?"+q.Encode(), nil)
 	if err != nil {
@@ -551,6 +551,19 @@ func maxID(items []utils.Dict, idField string) uint64 {
 		}
 	}
 	return m
+}
+
+// applyExtraParams copies user-supplied static query parameters into q,
+// stringifying each value so bools and numbers from YAML/CLI configs work
+// as transparently as strings. A nil entry is treated as an empty string.
+func applyExtraParams(q url.Values, extra map[string]interface{}) {
+	for k, v := range extra {
+		if v == nil {
+			q.Set(k, "")
+			continue
+		}
+		q.Set(k, fmt.Sprint(v))
+	}
 }
 
 // truncate shortens a response body for safe inclusion in error messages.

--- a/halopsa/client_test.go
+++ b/halopsa/client_test.go
@@ -1,0 +1,341 @@
+package usp_halopsa
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+// validClientOptions returns a minimal ClientOptions that passes
+// uspclient.ClientOptions.Validate(), so tests can focus on the
+// HaloPSA-specific validation.
+func validClientOptions() uspclient.ClientOptions {
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "22222222-2222-2222-2222-222222222222",
+		},
+		Platform: "json",
+	}
+}
+
+func TestTokenURL(t *testing.T) {
+	cases := []struct {
+		name string
+		conf HaloPSAConfig
+		want string
+	}{
+		{
+			name: "instance only",
+			conf: HaloPSAConfig{InstanceURL: "https://acme.halopsa.com"},
+			want: "https://acme.halopsa.com/auth/token",
+		},
+		{
+			name: "trailing slash is trimmed",
+			conf: HaloPSAConfig{InstanceURL: "https://acme.halopsa.com/"},
+			want: "https://acme.halopsa.com/auth/token",
+		},
+		{
+			name: "auth_url override",
+			conf: HaloPSAConfig{InstanceURL: "https://acme.halopsa.com", AuthURL: "https://auth.example.com/auth/"},
+			want: "https://auth.example.com/auth/token",
+		},
+		{
+			name: "hosted tenant parameter",
+			conf: HaloPSAConfig{InstanceURL: "https://acme.halopsa.com", Tenant: "acme corp"},
+			want: "https://acme.halopsa.com/auth/token?tenant=acme+corp",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.conf.tokenURL(); got != c.want {
+				t.Fatalf("tokenURL() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestResourceBaseURL(t *testing.T) {
+	cases := []struct {
+		name string
+		conf HaloPSAConfig
+		want string
+	}{
+		{
+			name: "derived from instance",
+			conf: HaloPSAConfig{InstanceURL: "https://acme.halopsa.com/"},
+			want: "https://acme.halopsa.com/api",
+		},
+		{
+			name: "api_url override",
+			conf: HaloPSAConfig{InstanceURL: "https://acme.halopsa.com", APIURL: "https://api.example.com/api/"},
+			want: "https://api.example.com/api",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.conf.resourceBaseURL(); got != c.want {
+				t.Fatalf("resourceBaseURL() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	base := HaloPSAConfig{
+		ClientOptions: validClientOptions(),
+		InstanceURL:   "https://acme.halopsa.com",
+		ClientID:      "id",
+		ClientSecret:  "secret",
+	}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("expected valid config, got %v", err)
+	}
+
+	noURL := base
+	noURL.InstanceURL = ""
+	if err := noURL.Validate(); err == nil {
+		t.Fatal("expected error when no instance/auth/api URL is set")
+	}
+
+	splitURLs := HaloPSAConfig{
+		ClientOptions: validClientOptions(),
+		AuthURL:       "https://auth.example.com/auth",
+		APIURL:        "https://api.example.com/api",
+		ClientID:      "id",
+		ClientSecret:  "secret",
+	}
+	if err := splitURLs.Validate(); err != nil {
+		t.Fatalf("expected split auth/api URLs to be valid, got %v", err)
+	}
+
+	noSecret := base
+	noSecret.ClientSecret = ""
+	if err := noSecret.Validate(); err == nil {
+		t.Fatal("expected error when client_secret is missing")
+	}
+}
+
+func TestParseListResponse(t *testing.T) {
+	t.Run("envelope with auto-detected array", func(t *testing.T) {
+		body := []byte(`{"record_count":3,"audit":[{"id":7},{"id":6},{"id":5}]}`)
+		items, count, err := parseListResponse(body, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 3 {
+			t.Fatalf("record_count = %d, want 3", count)
+		}
+		if got := idsOf(items); !reflect.DeepEqual(got, []uint64{7, 6, 5}) {
+			t.Fatalf("ids = %v, want [7 6 5]", got)
+		}
+	})
+
+	t.Run("envelope with explicit data_field", func(t *testing.T) {
+		body := []byte(`{"record_count":1,"tickets":[{"id":42}]}`)
+		items, _, err := parseListResponse(body, "tickets")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := idsOf(items); !reflect.DeepEqual(got, []uint64{42}) {
+			t.Fatalf("ids = %v, want [42]", got)
+		}
+	})
+
+	t.Run("bare json array", func(t *testing.T) {
+		body := []byte(`[{"id":1},{"id":2}]`)
+		items, count, err := parseListResponse(body, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 2 {
+			t.Fatalf("count = %d, want 2", count)
+		}
+		if got := idsOf(items); !reflect.DeepEqual(got, []uint64{1, 2}) {
+			t.Fatalf("ids = %v, want [1 2]", got)
+		}
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		items, count, err := parseListResponse([]byte("  "), "")
+		if err != nil || items != nil || count != 0 {
+			t.Fatalf("expected empty result, got items=%v count=%d err=%v", items, count, err)
+		}
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		if _, _, err := parseListResponse([]byte(`{not json`), ""); err == nil {
+			t.Fatal("expected error for invalid json")
+		}
+	})
+}
+
+// fakePager turns a list of newest-first pages into a fetchPage function.
+func fakePager(pages [][]utils.Dict) func(int) ([]utils.Dict, int, error) {
+	total := 0
+	for _, p := range pages {
+		total += len(p)
+	}
+	return func(pageNo int) ([]utils.Dict, int, error) {
+		if pageNo < 1 || pageNo > len(pages) {
+			return nil, total, nil
+		}
+		return pages[pageNo-1], total, nil
+	}
+}
+
+func TestCollectNewItems(t *testing.T) {
+	t.Run("steady state single page", func(t *testing.T) {
+		pages := [][]utils.Dict{mkItems(103, 102, 101, 100, 99)}
+		items, newMax, err := collectNewItems(fakePager(pages), "id", 100, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if newMax != 103 {
+			t.Fatalf("newMax = %d, want 103", newMax)
+		}
+		if got := idsOf(items); !reflect.DeepEqual(got, []uint64{101, 102, 103}) {
+			t.Fatalf("ids = %v, want [101 102 103] (oldest-first)", got)
+		}
+	})
+
+	t.Run("no new events", func(t *testing.T) {
+		pages := [][]utils.Dict{mkItems(100, 99, 98)}
+		items, newMax, err := collectNewItems(fakePager(pages), "id", 100, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 0 || newMax != 100 {
+			t.Fatalf("expected no items and cursor 100, got items=%d newMax=%d", len(items), newMax)
+		}
+	})
+
+	t.Run("multi-page catch up", func(t *testing.T) {
+		pages := [][]utils.Dict{
+			mkItems(110, 109, 108, 107, 106),
+			mkItems(105, 104, 103, 102, 101),
+			mkItems(100, 99, 98, 97, 96),
+		}
+		items, newMax, err := collectNewItems(fakePager(pages), "id", 100, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if newMax != 110 {
+			t.Fatalf("newMax = %d, want 110", newMax)
+		}
+		want := []uint64{101, 102, 103, 104, 105, 106, 107, 108, 109, 110}
+		if got := idsOf(items); !reflect.DeepEqual(got, want) {
+			t.Fatalf("ids = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("deduplicates records that shift between pages", func(t *testing.T) {
+		// 106 appears on both page 1 and page 2 because new records were
+		// inserted while paginating.
+		pages := [][]utils.Dict{
+			mkItems(110, 109, 108, 107, 106),
+			mkItems(106, 105, 104, 103, 102),
+			mkItems(101, 100, 99),
+		}
+		items, newMax, err := collectNewItems(fakePager(pages), "id", 100, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if newMax != 110 {
+			t.Fatalf("newMax = %d, want 110", newMax)
+		}
+		want := []uint64{101, 102, 103, 104, 105, 106, 107, 108, 109, 110}
+		if got := idsOf(items); !reflect.DeepEqual(got, want) {
+			t.Fatalf("ids = %v, want %v (each id exactly once)", got, want)
+		}
+	})
+
+	t.Run("empty endpoint", func(t *testing.T) {
+		items, newMax, err := collectNewItems(fakePager(nil), "id", 50, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 0 || newMax != 50 {
+			t.Fatalf("expected no items and cursor unchanged, got items=%d newMax=%d", len(items), newMax)
+		}
+	})
+
+	t.Run("fetch error is propagated and cursor preserved", func(t *testing.T) {
+		boom := errors.New("boom")
+		fp := func(int) ([]utils.Dict, int, error) { return nil, 0, boom }
+		_, newMax, err := collectNewItems(fp, "id", 77, nil)
+		if !errors.Is(err, boom) {
+			t.Fatalf("expected boom error, got %v", err)
+		}
+		if newMax != 77 {
+			t.Fatalf("cursor = %d, want preserved 77", newMax)
+		}
+	})
+
+	t.Run("stop function halts pagination", func(t *testing.T) {
+		// Every page is full of new records, so without the stop function
+		// this would page forever.
+		calls := 0
+		fp := func(int) ([]utils.Dict, int, error) {
+			calls++
+			return mkItems(1000, 999, 998, 997, 996), 1 << 30, nil
+		}
+		stopped := false
+		stop := func() bool {
+			if calls >= 3 {
+				stopped = true
+			}
+			return stopped
+		}
+		if _, _, err := collectNewItems(fp, "id", 0, stop); err != nil {
+			t.Fatal(err)
+		}
+		if calls > 3 {
+			t.Fatalf("expected pagination to stop near 3 pages, made %d calls", calls)
+		}
+	})
+}
+
+func TestMaxID(t *testing.T) {
+	if got := maxID(mkItems(3, 9, 5), "id"); got != 9 {
+		t.Fatalf("maxID = %d, want 9", got)
+	}
+	if got := maxID(nil, "id"); got != 0 {
+		t.Fatalf("maxID of empty = %d, want 0", got)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	long := make([]byte, maxErrBodyLen+100)
+	for i := range long {
+		long[i] = 'x'
+	}
+	out := truncate(long)
+	if len(out) <= maxErrBodyLen || out[len(out)-len("(truncated)"):] != "(truncated)" {
+		t.Fatalf("expected truncated marker, got len %d", len(out))
+	}
+	if truncate([]byte("  short  ")) != "short" {
+		t.Fatal("expected short body to be trimmed and returned as-is")
+	}
+}
+
+// mkItems builds newest-first records carrying the given ids.
+func mkItems(ids ...int) []utils.Dict {
+	out := make([]utils.Dict, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, utils.Dict{"id": uint64(id)})
+	}
+	return out
+}
+
+func idsOf(items []utils.Dict) []uint64 {
+	out := make([]uint64, 0, len(items))
+	for _, it := range items {
+		id, _ := it.GetInt("id")
+		out = append(out, id)
+	}
+	return out
+}

--- a/halopsa/client_test.go
+++ b/halopsa/client_test.go
@@ -2,6 +2,7 @@ package usp_halopsa
 
 import (
 	"errors"
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -297,6 +298,32 @@ func TestCollectNewItems(t *testing.T) {
 			t.Fatalf("expected pagination to stop near 3 pages, made %d calls", calls)
 		}
 	})
+}
+
+func TestApplyExtraParams(t *testing.T) {
+	// The CLI/env parser auto-types values, so an extra_params map can
+	// receive bool/int/float as well as strings. Each must be stringified
+	// so url.Values can carry it.
+	q := url.Values{}
+	applyExtraParams(q, map[string]interface{}{
+		"excludesys": true,
+		"user_id":    42,
+		"ratio":      1.5,
+		"name":       "alice",
+		"missing":    nil,
+	})
+	cases := map[string]string{
+		"excludesys": "true",
+		"user_id":    "42",
+		"ratio":      "1.5",
+		"name":       "alice",
+		"missing":    "",
+	}
+	for k, want := range cases {
+		if got := q.Get(k); got != want {
+			t.Fatalf("q.Get(%q) = %q, want %q", k, got, want)
+		}
+	}
 }
 
 func TestMaxID(t *testing.T) {

--- a/halopsa/live_test.go
+++ b/halopsa/live_test.go
@@ -1,0 +1,245 @@
+//go:build halopsa_live
+// +build halopsa_live
+
+package usp_halopsa
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+// These tests run only with -tags halopsa_live and require live creds via
+// HALOPSA_INSTANCE_URL / HALOPSA_CLIENT_ID / HALOPSA_CLIENT_SECRET.
+
+func liveAdapter(t *testing.T) *HaloPSAAdapter {
+	t.Helper()
+	inst := os.Getenv("HALOPSA_INSTANCE_URL")
+	id := os.Getenv("HALOPSA_CLIENT_ID")
+	sec := os.Getenv("HALOPSA_CLIENT_SECRET")
+	if inst == "" || id == "" || sec == "" {
+		t.Skip("HALOPSA_INSTANCE_URL/HALOPSA_CLIENT_ID/HALOPSA_CLIENT_SECRET not set")
+	}
+
+	noop := func(string) {}
+	noopErr := func(err error) { t.Logf("adapter error: %v", err) }
+	a := &HaloPSAAdapter{
+		conf: HaloPSAConfig{
+			ClientOptions: uspclient.ClientOptions{
+				DebugLog:  noop,
+				OnError:   noopErr,
+				OnWarning: noop,
+			},
+			InstanceURL:  inst,
+			ClientID:     id,
+			ClientSecret: sec,
+			Scope:        defaultScope,
+			IDField:      defaultIDField,
+			PageSize:     5,
+			PollInterval: defaultPollInterval,
+		},
+		ctx:    context.Background(),
+		doStop: utils.NewEvent(),
+		httpClient: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: &http.Transport{Dial: (&net.Dialer{Timeout: 10 * time.Second}).Dial},
+		},
+	}
+	return a
+}
+
+func TestLive_GetToken(t *testing.T) {
+	a := liveAdapter(t)
+	tok, err := a.getToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok == "" {
+		t.Fatal("empty token")
+	}
+	if time.Until(a.tokenExpiry) <= time.Minute {
+		t.Fatalf("token expires too soon: %v", a.tokenExpiry)
+	}
+	// Cached token returned without a refresh.
+	tok2, err := a.getToken()
+	if err != nil || tok2 != tok {
+		t.Fatalf("expected cached token, got %v / %v", tok2, err)
+	}
+}
+
+func TestLive_RequestPage_Tickets(t *testing.T) {
+	a := liveAdapter(t)
+	a.conf.Endpoint = "Tickets"
+	tok, err := a.getToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, count, err := a.requestPage(tok, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count == 0 {
+		t.Fatalf("expected non-zero record_count on Tickets")
+	}
+	if len(items) == 0 {
+		t.Fatalf("expected at least one ticket")
+	}
+	if _, ok := items[0].GetInt("id"); !ok {
+		t.Fatal("ticket missing id field")
+	}
+	t.Logf("Tickets page1: %d records (total=%d)", len(items), count)
+}
+
+func TestLive_RequestPage_Actions(t *testing.T) {
+	a := liveAdapter(t)
+	a.conf.Endpoint = "Actions"
+	tok, _ := a.getToken()
+	items, count, err := a.requestPage(tok, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count == 0 || len(items) == 0 {
+		t.Fatalf("expected Actions records, got count=%d items=%d", count, len(items))
+	}
+	t.Logf("Actions page1: %d records (total=%d)", len(items), count)
+}
+
+func TestLive_RequestPage_Agent_ResultsEnvelope(t *testing.T) {
+	a := liveAdapter(t)
+	a.conf.Endpoint = "Agent"
+	tok, _ := a.getToken()
+	items, count, err := a.requestPage(tok, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Agent returns {"results":[...]} envelope — the auto-detect should still work.
+	if len(items) == 0 {
+		t.Fatalf("Agent envelope auto-detect failed; got 0 items (count=%d)", count)
+	}
+	t.Logf("Agent page1: %d records (auto-detected results envelope)", len(items))
+}
+
+func TestLive_CollectNewItems_Tickets(t *testing.T) {
+	a := liveAdapter(t)
+	a.conf.Endpoint = "Tickets"
+
+	tok, _ := a.getToken()
+	first, _, err := a.requestPage(tok, 1)
+	if err != nil || len(first) == 0 {
+		t.Fatalf("seed page: items=%d err=%v", len(first), err)
+	}
+	// Pick a cursor that should leave exactly one new record on top.
+	cursor, _ := first[1].GetInt("id")
+	expectedTopID, _ := first[0].GetInt("id")
+
+	fetch := func(pageNo int) ([]utils.Dict, int, error) {
+		return a.requestPage(tok, pageNo)
+	}
+	items, newMax, err := collectNewItems(fetch, "id", cursor, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newMax != expectedTopID {
+		t.Fatalf("newMax=%d, want %d", newMax, expectedTopID)
+	}
+	if len(items) == 0 {
+		t.Fatalf("expected at least one new item beyond cursor=%d", cursor)
+	}
+	// All returned ids must be > cursor and oldest-first.
+	var prev uint64
+	for _, it := range items {
+		id, _ := it.GetInt("id")
+		if id <= cursor {
+			t.Fatalf("returned id=%d <= cursor=%d", id, cursor)
+		}
+		if id < prev {
+			t.Fatalf("not oldest-first: %d after %d", id, prev)
+		}
+		prev = id
+	}
+	t.Logf("collectNewItems with cursor=%d returned %d new ids up to %d", cursor, len(items), newMax)
+}
+
+func TestLive_PollLifecycle_Tickets(t *testing.T) {
+	a := liveAdapter(t)
+	a.conf.Endpoint = "Tickets"
+
+	// First poll establishes baseline and returns nothing.
+	items, err := a.poll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items != nil {
+		t.Fatalf("expected baseline to ship nothing, got %d items", len(items))
+	}
+	if !a.initialized || a.lastMaxID == 0 {
+		t.Fatalf("expected baseline established, initialized=%v lastMaxID=%d", a.initialized, a.lastMaxID)
+	}
+	baseline := a.lastMaxID
+
+	// Second poll should ship nothing because cursor is already at the top.
+	items, err = a.poll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected no new items on second poll, got %d", len(items))
+	}
+
+	// Simulate downtime by rewinding the cursor by one ticket.
+	pageToken, _ := a.getToken()
+	page1, _, _ := a.requestPage(pageToken, 1)
+	if len(page1) < 2 {
+		t.Skip("not enough tickets to simulate rewind")
+	}
+	rewindTo, _ := page1[1].GetInt("id")
+	a.lastMaxID = rewindTo
+
+	items, err = a.poll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) == 0 {
+		t.Fatalf("expected catch-up items after rewind")
+	}
+	if a.lastMaxID != baseline {
+		t.Fatalf("cursor after catch-up = %d, want %d", a.lastMaxID, baseline)
+	}
+}
+
+// TestLive_FullJSONSampleOnce dumps a single record per endpoint so we can
+// pattern-match the mock fixtures against real-world shapes.
+func TestLive_FullJSONSampleOnce(t *testing.T) {
+	a := liveAdapter(t)
+	tok, _ := a.getToken()
+	for _, ep := range []string{"Tickets", "Actions", "Agent"} {
+		a.conf.Endpoint = ep
+		a.conf.DataField = ""
+		items, _, err := a.requestPage(tok, 1)
+		if err != nil {
+			t.Errorf("%s: %v", ep, err)
+			continue
+		}
+		if len(items) == 0 {
+			t.Logf("%s: no records", ep)
+			continue
+		}
+		b, _ := json.MarshalIndent(items[0], "", "  ")
+		t.Logf("%s sample (first %d bytes):\n%s", ep, min(len(b), 400), b[:min(len(b), 400)])
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+

--- a/halopsa/mock_test.go
+++ b/halopsa/mock_test.go
@@ -1,0 +1,585 @@
+package usp_halopsa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+// mockHaloPSA emulates the bits of the real HaloPSA OAuth2 + REST API the
+// adapter relies on: the /auth/token endpoint and any number of resource
+// endpoints under /api/<resource>. Response shapes mirror what HaloPSA's
+// /api/Tickets, /api/Actions, and /api/Agent endpoints actually return,
+// including the {"<resource>": [...]} envelope and the {"results": [...]}
+// shape used by /api/Agent.
+type mockHaloPSA struct {
+	server *httptest.Server
+
+	mu sync.Mutex
+
+	// resource state: name -> records, newest-first (highest id first).
+	resources map[string][]utils.Dict
+	// dataField per resource (e.g. "tickets", "actions", "results").
+	dataFields map[string]string
+
+	// auth state
+	clientID      string
+	clientSecret  string
+	tokens        map[string]time.Time
+	tokenTTL      time.Duration
+	requireScope  string
+	authCalls     atomic.Int32
+	expectedGrant string
+
+	// observed request inspection
+	lastQuery map[string]string
+
+	// fault injection
+	failNextTokenFetches atomic.Int32
+	failNextAPICalls     atomic.Int32
+}
+
+func newMockHaloPSA(t *testing.T) *mockHaloPSA {
+	t.Helper()
+	m := &mockHaloPSA{
+		clientID:      "test-client",
+		clientSecret:  "test-secret",
+		resources:     map[string][]utils.Dict{},
+		dataFields:    map[string]string{},
+		tokens:        map[string]time.Time{},
+		tokenTTL:      2 * time.Hour,
+		requireScope:  "all",
+		expectedGrant: "client_credentials",
+		lastQuery:     map[string]string{},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/token", m.handleToken)
+	mux.HandleFunc("/api/", m.handleAPI)
+	m.server = httptest.NewServer(mux)
+	t.Cleanup(m.server.Close)
+	return m
+}
+
+func (m *mockHaloPSA) URL() string { return m.server.URL }
+
+func (m *mockHaloPSA) setResource(name, dataField string, records []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.resources[name] = records
+	if dataField != "" {
+		m.dataFields[name] = dataField
+	}
+}
+
+func (m *mockHaloPSA) prependRecord(name string, rec utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.resources[name] = append([]utils.Dict{rec}, m.resources[name]...)
+}
+
+func (m *mockHaloPSA) handleToken(w http.ResponseWriter, r *http.Request) {
+	m.authCalls.Add(1)
+	if n := m.failNextTokenFetches.Add(-1); n >= 0 {
+		http.Error(w, `{"error":"server_error"}`, http.StatusInternalServerError)
+		return
+	}
+	// Restore to zero — Add(-1) goes negative when no failures pending.
+	m.failNextTokenFetches.Store(0)
+
+	_ = r.ParseForm()
+	if r.Form.Get("grant_type") != m.expectedGrant {
+		http.Error(w, `{"error":"unsupported_grant_type"}`, http.StatusBadRequest)
+		return
+	}
+	if r.Form.Get("client_id") != m.clientID || r.Form.Get("client_secret") != m.clientSecret {
+		http.Error(w, `{"error":"invalid_client","error_description":"The specified client credentials are invalid."}`, http.StatusUnauthorized)
+		return
+	}
+	if m.requireScope != "" && r.Form.Get("scope") != m.requireScope {
+		http.Error(w, `{"error":"invalid_scope"}`, http.StatusBadRequest)
+		return
+	}
+
+	tok := fmt.Sprintf("tok-%d", time.Now().UnixNano())
+	m.mu.Lock()
+	m.tokens[tok] = time.Now().Add(m.tokenTTL)
+	m.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"access_token": tok,
+		"token_type":   "Bearer",
+		"expires_in":   int(m.tokenTTL.Seconds()),
+		"scope":        m.requireScope,
+	})
+}
+
+func (m *mockHaloPSA) handleAPI(w http.ResponseWriter, r *http.Request) {
+	if n := m.failNextAPICalls.Add(-1); n >= 0 {
+		http.Error(w, `{"error":"backend_unavailable"}`, http.StatusBadGateway)
+		return
+	}
+	m.failNextAPICalls.Store(0)
+
+	auth := r.Header.Get("Authorization")
+	if len(auth) < len("Bearer ") || auth[:len("Bearer ")] != "Bearer " {
+		http.Error(w, "missing bearer", http.StatusUnauthorized)
+		return
+	}
+	tok := auth[len("Bearer "):]
+	m.mu.Lock()
+	exp, ok := m.tokens[tok]
+	m.mu.Unlock()
+	if !ok || time.Now().After(exp) {
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	// Capture the query for assertions.
+	m.mu.Lock()
+	m.lastQuery = map[string]string{}
+	for k := range r.URL.Query() {
+		m.lastQuery[k] = r.URL.Query().Get(k)
+	}
+	m.mu.Unlock()
+
+	// Strip "/api/" prefix.
+	resource := r.URL.Path[len("/api/"):]
+	m.mu.Lock()
+	records, known := m.resources[resource]
+	dataField := m.dataFields[resource]
+	m.mu.Unlock()
+	if !known {
+		http.NotFound(w, r)
+		return
+	}
+	if dataField == "" {
+		dataField = lowerFirstChar(resource)
+	}
+
+	// Honour orderdesc=true: records are stored newest-first.
+	// (Real Halo also exposes orderdesc=false, but the adapter only requests desc.)
+
+	pageNo, _ := strconv.Atoi(r.URL.Query().Get("page_no"))
+	if pageNo < 1 {
+		pageNo = 1
+	}
+	pageSize, _ := strconv.Atoi(r.URL.Query().Get("page_size"))
+	if pageSize <= 0 {
+		pageSize = 50
+	}
+
+	total := len(records)
+	start := (pageNo - 1) * pageSize
+	end := start + pageSize
+	if start > total {
+		start = total
+	}
+	if end > total {
+		end = total
+	}
+	page := records[start:end]
+
+	w.Header().Set("Content-Type", "application/json")
+	if r.URL.Query().Get("envelope_style") == "bare_array" {
+		_ = json.NewEncoder(w).Encode(page)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"page_no":      pageNo,
+		"page_size":    pageSize,
+		"record_count": total,
+		dataField:      page,
+	})
+}
+
+func lowerFirstChar(s string) string {
+	if s == "" {
+		return s
+	}
+	b := []byte(s)
+	if b[0] >= 'A' && b[0] <= 'Z' {
+		b[0] += 'a' - 'A'
+	}
+	return string(b)
+}
+
+// newTestAdapter builds a HaloPSAAdapter pointing at the mock, with sane
+// no-op log callbacks so the adapter doesn't nil-panic in tests.
+func newTestAdapter(t *testing.T, m *mockHaloPSA, endpoint string) *HaloPSAAdapter {
+	t.Helper()
+	logs := func(string) {}
+	logE := func(err error) { t.Logf("adapter error: %v", err) }
+	a := &HaloPSAAdapter{
+		conf: HaloPSAConfig{
+			ClientOptions: uspclient.ClientOptions{
+				DebugLog:  logs,
+				OnError:   logE,
+				OnWarning: logs,
+			},
+			InstanceURL:  m.URL(),
+			ClientID:     m.clientID,
+			ClientSecret: m.clientSecret,
+			Scope:        m.requireScope,
+			IDField:      defaultIDField,
+			Endpoint:     endpoint,
+			PageSize:     5,
+			PollInterval: defaultPollInterval,
+		},
+		ctx:    context.Background(),
+		doStop: utils.NewEvent(),
+		httpClient: &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: &http.Transport{Dial: (&net.Dialer{Timeout: 2 * time.Second}).Dial},
+		},
+	}
+	return a
+}
+
+// rec is a tiny helper to build a record carrying a numeric id and arbitrary
+// extra fields, matching the shape of real HaloPSA records.
+func rec(id int, extras ...any) utils.Dict {
+	d := utils.Dict{"id": uint64(id)}
+	for i := 0; i+1 < len(extras); i += 2 {
+		k, _ := extras[i].(string)
+		d[k] = extras[i+1]
+	}
+	return d
+}
+
+// newestFirst returns records ordered newest-first (highest id first).
+func newestFirst(start, count int) []utils.Dict {
+	out := make([]utils.Dict, 0, count)
+	for i := 0; i < count; i++ {
+		out = append(out, rec(start-i, "summary", fmt.Sprintf("ticket-%d", start-i)))
+	}
+	return out
+}
+
+func TestMock_TokenFetchAndCaching(t *testing.T) {
+	m := newMockHaloPSA(t)
+	a := newTestAdapter(t, m, "Tickets")
+
+	tok1, err := a.getToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok1 == "" {
+		t.Fatal("empty token")
+	}
+	if got := m.authCalls.Load(); got != 1 {
+		t.Fatalf("authCalls = %d, want 1", got)
+	}
+
+	// Second call reuses the cached token; no extra auth hit.
+	tok2, _ := a.getToken()
+	if tok2 != tok1 {
+		t.Fatal("expected cached token reuse")
+	}
+	if got := m.authCalls.Load(); got != 1 {
+		t.Fatalf("authCalls after cached read = %d, want 1", got)
+	}
+
+	// Force expiry → next call must re-authenticate.
+	a.tokenExpiry = time.Now().Add(-time.Second)
+	tok3, _ := a.getToken()
+	if tok3 == tok1 {
+		t.Fatal("expected new token after expiry")
+	}
+	if got := m.authCalls.Load(); got != 2 {
+		t.Fatalf("authCalls after refresh = %d, want 2", got)
+	}
+}
+
+func TestMock_TokenFetchFailsOnBadCreds(t *testing.T) {
+	m := newMockHaloPSA(t)
+	a := newTestAdapter(t, m, "Tickets")
+	a.conf.ClientSecret = "wrong"
+
+	_, err := a.getToken()
+	if err == nil {
+		t.Fatal("expected error on bad creds")
+	}
+}
+
+func TestMock_RequestPage_TicketsEnvelope(t *testing.T) {
+	m := newMockHaloPSA(t)
+	m.setResource("Tickets", "tickets", newestFirst(110, 5))
+	a := newTestAdapter(t, m, "Tickets")
+
+	tok, _ := a.getToken()
+	items, count, err := a.requestPage(tok, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 5 {
+		t.Fatalf("record_count=%d, want 5", count)
+	}
+	want := []uint64{110, 109, 108, 107, 106}
+	if got := idsOf(items); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ids=%v, want %v", got, want)
+	}
+
+	// Adapter must have sent the expected query parameters.
+	expectedQuery := map[string]string{
+		"pageinate":  "true",
+		"page_size":  "5",
+		"page_no":    "1",
+		"order":      "id",
+		"orderdesc":  "true",
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k, v := range expectedQuery {
+		if got := m.lastQuery[k]; got != v {
+			t.Fatalf("query %q=%q, want %q", k, got, v)
+		}
+	}
+}
+
+func TestMock_RequestPage_AgentResultsEnvelope(t *testing.T) {
+	// Real-world quirk: the /api/Agent endpoint returns its records under a
+	// "results" key rather than "agent". The auto-detect must still pick it up.
+	m := newMockHaloPSA(t)
+	m.setResource("Agent", "results", []utils.Dict{
+		rec(14, "name", "Maxime Lamothe-Brassard"),
+		rec(3, "name", "Bruce Wayne"),
+		rec(1, "name", "Unassigned"),
+	})
+	a := newTestAdapter(t, m, "Agent")
+
+	tok, _ := a.getToken()
+	items, count, err := a.requestPage(tok, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Fatalf("record_count=%d, want 3", count)
+	}
+	if got := idsOf(items); !reflect.DeepEqual(got, []uint64{14, 3, 1}) {
+		t.Fatalf("ids=%v, want [14 3 1]", got)
+	}
+}
+
+func TestMock_RequestPage_ExplicitDataField(t *testing.T) {
+	m := newMockHaloPSA(t)
+	m.setResource("Custom", "weird_name", []utils.Dict{rec(1), rec(2)})
+	a := newTestAdapter(t, m, "Custom")
+	a.conf.DataField = "weird_name"
+
+	tok, _ := a.getToken()
+	items, _, err := a.requestPage(tok, 1)
+	if err != nil || len(items) != 2 {
+		t.Fatalf("items=%d err=%v", len(items), err)
+	}
+}
+
+func TestMock_RequestPage_401ClearsToken(t *testing.T) {
+	m := newMockHaloPSA(t)
+	m.setResource("Tickets", "tickets", newestFirst(100, 3))
+	a := newTestAdapter(t, m, "Tickets")
+
+	_, _ = a.getToken()
+	// Sabotage the cached token. The adapter must clear it on 401 so the
+	// next poll fetches a fresh one (real-world recovery from token rotation).
+	a.accessToken = "obviously-invalid"
+	a.tokenExpiry = time.Now().Add(time.Hour)
+
+	_, _, err := a.requestPage(a.accessToken, 1)
+	if err == nil {
+		t.Fatal("expected error from 401")
+	}
+	if a.accessToken != "" {
+		t.Fatalf("accessToken should have been cleared, got %q", a.accessToken)
+	}
+}
+
+func TestMock_RequestPage_404Errors(t *testing.T) {
+	m := newMockHaloPSA(t)
+	a := newTestAdapter(t, m, "DoesNotExist")
+	tok, _ := a.getToken()
+	if _, _, err := a.requestPage(tok, 1); err == nil {
+		t.Fatal("expected error on unknown endpoint")
+	}
+}
+
+func TestMock_ExtraParamsForwarded(t *testing.T) {
+	m := newMockHaloPSA(t)
+	m.setResource("Tickets", "tickets", newestFirst(100, 1))
+	a := newTestAdapter(t, m, "Tickets")
+	a.conf.ExtraParams = map[string]interface{}{
+		"open_only":  true,
+		"client_id":  42,
+		"agent_name": "alice",
+	}
+
+	tok, _ := a.getToken()
+	if _, _, err := a.requestPage(tok, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k, want := range map[string]string{
+		"open_only":  "true",
+		"client_id":  "42",
+		"agent_name": "alice",
+	} {
+		if got := m.lastQuery[k]; got != want {
+			t.Fatalf("extra param %q forwarded as %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestMock_PollLifecycle(t *testing.T) {
+	m := newMockHaloPSA(t)
+	m.setResource("Tickets", "tickets", newestFirst(105, 5)) // 105,104,103,102,101
+	a := newTestAdapter(t, m, "Tickets")
+
+	// 1) Baseline poll establishes the cursor at the newest id and ships nothing.
+	items, err := a.poll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items != nil {
+		t.Fatalf("baseline should ship nothing, got %d items", len(items))
+	}
+	if a.lastMaxID != 105 || !a.initialized {
+		t.Fatalf("baseline cursor=%d initialized=%v, want cursor=105 initialized=true", a.lastMaxID, a.initialized)
+	}
+
+	// 2) No-op poll: nothing new, cursor unchanged.
+	items, err = a.poll()
+	if err != nil || len(items) != 0 || a.lastMaxID != 105 {
+		t.Fatalf("noop poll: items=%d cursor=%d err=%v", len(items), a.lastMaxID, err)
+	}
+
+	// 3) A new ticket arrives.
+	m.prependRecord("Tickets", rec(106, "summary", "new!"))
+	items, err = a.poll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := idsOf(items); !reflect.DeepEqual(got, []uint64{106}) {
+		t.Fatalf("incremental poll ids=%v, want [106]", got)
+	}
+	if a.lastMaxID != 106 {
+		t.Fatalf("cursor after new record = %d, want 106", a.lastMaxID)
+	}
+}
+
+func TestMock_CatchUpAcrossMultiplePages(t *testing.T) {
+	// Simulate the adapter recovering from downtime: while it was offline,
+	// many new records were added. Cursor advances correctly across pages.
+	m := newMockHaloPSA(t)
+	m.setResource("Tickets", "tickets", newestFirst(120, 20)) // 120..101
+	a := newTestAdapter(t, m, "Tickets")
+	a.conf.PageSize = 5
+
+	// Force an initial state as if cursor was at 105 (the adapter "knew"
+	// about 105 before downtime).
+	a.initialized = true
+	a.lastMaxID = 105
+
+	items, err := a.poll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []uint64{106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120}
+	if got := idsOf(items); !reflect.DeepEqual(got, want) {
+		t.Fatalf("catch-up ids=%v\nwant %v", got, want)
+	}
+	if a.lastMaxID != 120 {
+		t.Fatalf("cursor after catch-up = %d, want 120", a.lastMaxID)
+	}
+}
+
+func TestMock_TransientAPIErrorPreservesCursor(t *testing.T) {
+	m := newMockHaloPSA(t)
+	m.setResource("Tickets", "tickets", newestFirst(110, 5))
+	a := newTestAdapter(t, m, "Tickets")
+
+	// Baseline.
+	if _, err := a.poll(); err != nil {
+		t.Fatal(err)
+	}
+	cursorBefore := a.lastMaxID
+
+	// Inject a transient API error on the next poll.
+	m.failNextAPICalls.Store(1)
+	_, err := a.poll()
+	if err == nil {
+		t.Fatal("expected transient error")
+	}
+	if a.lastMaxID != cursorBefore {
+		t.Fatalf("cursor moved on error: before=%d after=%d", cursorBefore, a.lastMaxID)
+	}
+
+	// Recovery: subsequent poll succeeds with cursor preserved.
+	m.prependRecord("Tickets", rec(111))
+	items, err := a.poll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := idsOf(items); !reflect.DeepEqual(got, []uint64{111}) {
+		t.Fatalf("recovery poll ids=%v, want [111]", got)
+	}
+}
+
+func TestMock_BareJSONArrayEndpoint(t *testing.T) {
+	// Some HaloPSA list endpoints return a bare array instead of an envelope.
+	// The adapter advertises this is supported; verify it works end-to-end.
+	m := newMockHaloPSA(t)
+	m.setResource("Tickets", "tickets", newestFirst(103, 3))
+	a := newTestAdapter(t, m, "Tickets")
+	// Trigger the mock's bare-array mode for every page request.
+	a.conf.ExtraParams = map[string]interface{}{"envelope_style": "bare_array"}
+
+	tok, _ := a.getToken()
+	items, count, err := a.requestPage(tok, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Fatalf("count=%d, want 3", count)
+	}
+	if got := idsOf(items); !reflect.DeepEqual(got, []uint64{103, 102, 101}) {
+		t.Fatalf("ids=%v, want [103 102 101]", got)
+	}
+}
+
+func TestMock_PageBeyondEndReturnsEmpty(t *testing.T) {
+	// Confirms that fetchPage stops paginating when a page is empty, which is
+	// the same shape the live API returns past the last page.
+	m := newMockHaloPSA(t)
+	m.setResource("Tickets", "tickets", newestFirst(102, 2)) // only 102, 101
+	a := newTestAdapter(t, m, "Tickets")
+	a.conf.PageSize = 2
+
+	a.initialized = true
+	a.lastMaxID = 50
+
+	items, err := a.poll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := idsOf(items); !reflect.DeepEqual(got, []uint64{101, 102}) {
+		t.Fatalf("ids=%v, want [101 102]", got)
+	}
+	if a.lastMaxID != 102 {
+		t.Fatalf("cursor=%d, want 102", a.lastMaxID)
+	}
+}
+


### PR DESCRIPTION
## Summary

Adds a new `halopsa` USP adapter that pulls events from [HaloPSA](https://halopsa.com) into LimaCharlie in as close to their original format as possible.

The first target use case is **audit log ingestion**, but the adapter is intentionally generic — supporting a new HaloPSA event type only requires configuration changes, not code.

## How it works

- **Authentication** — HaloPSA OAuth2 client credentials flow. Works for hosted instances (optional `tenant` parameter) and self-hosted deployments. The authorisation server (`/auth`) and resource server (`/api`) are derived from `instance_url`, or can each be overridden via `auth_url` / `api_url`.
- **Generic endpoint polling** — `endpoint` selects the API resource (default `Audit`). The records array is auto-detected from the response envelope (`{record_count, <resource>: [...]}`) or set explicitly with `data_field`. Bare-array responses are also handled.
- **Reliable incremental ingestion** — uses a monotonic id high-water-mark (`id_field`, default `id`). Pages are walked newest-first and paging stops as soon as an already-seen record is reached, so steady-state polling is a single request. Records that shift between pages while new ones are inserted are de-duplicated within a poll. The first poll only establishes the cursor, so the adapter starts from "now" rather than replaying the full history.
- **Escape hatch** — `extra_params` injects arbitrary static query string parameters per endpoint (e.g. `extra_params.excludesys=true`).
- **Resilience** — transient HTTP / token errors are logged and retried on the next poll; a `401` forces a token refresh.

## Configuration

| Key | Description | Default |
|---|---|---|
| `instance_url` | Base HaloPSA URL (e.g. `https://example.halopsa.com`) | required* |
| `auth_url` / `api_url` | Override authorisation / resource server URLs | derived from `instance_url` |
| `client_id` / `client_secret` | HaloPSA API application credentials | required |
| `tenant` | Tenant identifier for some hosted deployments | – |
| `scope` | OAuth2 scope | `all` |
| `endpoint` | API resource to poll | `Audit` |
| `data_field` | Response array field | auto-detected |
| `id_field` | Monotonic integer cursor field | `id` |
| `extra_params` | Extra static query parameters | – |
| `page_size` | Records per page | `100` |
| `poll_interval` | Seconds between polls | `60` |

\* or both `auth_url` and `api_url`.

## Testing

- `go build ./containers/general` — OK
- `go vet ./halopsa/ ./containers/...` — OK
- `go test ./halopsa/` (incl. `-race`) — OK

Unit tests cover URL derivation (hosted/self-hosted/overrides/tenant), response parsing (envelope / explicit field / bare array / auto-detection / malformed), and the pagination + cursor logic (steady state, multi-page catch-up, page-shift de-dup, stop handling, error propagation).

Verified the adapter registers correctly: it appears in the CLI usage output and config validation reports missing required fields.

## Notes / follow-ups

- HaloPSA's Swagger spec does not document query parameters for `GET /Audit`; the adapter uses the pagination/ordering parameters (`pageinate`, `page_size`, `page_no`, `order`, `orderdesc`) that are standard across HaloPSA list controllers. Left as draft pending a validation run against a live HaloPSA instance.
- Recommend setting `client_options.mapping.event_time_path` (e.g. `date` for the audit log) so LimaCharlie uses each record's own timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)