### PR TITLE
Add QuickBooks Online adapter (ChangeDataCapture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,15 @@ be added purely through configuration. See [threatlocker/README.md](./threatlock
 ```
 ./general threatlocker client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=threatlocker api_key=$THREATLOCKER_API_TOKEN instance=g
 ```
+
+### QuickBooks Online
+
+Collects change/activity data from a QuickBooks Online company via the
+Accounting API's ChangeDataCapture (CDC) operation, using OAuth 2.0. Note that
+QuickBooks' user-attributed *Audit Log* is not exposed via any API; CDC is the
+authoritative programmatic source of change activity. See
+[quickbooks/README.md](./quickbooks/README.md).
+
+```
+./general quickbooks client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=quickbooks client_id=$QB_CLIENT_ID client_secret=$QB_CLIENT_SECRET refresh_token=$QB_REFRESH_TOKEN realm_id=$QB_REALM_ID
+```

--- a/containers/conf/all.go
+++ b/containers/conf/all.go
@@ -29,6 +29,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/pandadoc"
 	"github.com/refractionPOINT/usp-adapters/proofpoint_tap"
 	"github.com/refractionPOINT/usp-adapters/pubsub"
+	"github.com/refractionPOINT/usp-adapters/quickbooks"
 	"github.com/refractionPOINT/usp-adapters/s3"
 	"github.com/refractionPOINT/usp-adapters/sentinelone"
 	"github.com/refractionPOINT/usp-adapters/simulator"
@@ -85,6 +86,7 @@ type GeneralConfigs struct {
 	Zendesk           usp_zendesk.ZendeskConfig                       `json:"zendesk" yaml:"zendesk"`
 	PandaDoc          usp_pandadoc.PandaDocConfig                     `json:"pandadoc" yaml:"pandadoc"`
 	ProofpointTap     usp_proofpoint_tap.ProofpointTapConfig          `json:"proofpoint_tap" yaml:"proofpoint_tap"`
+	QuickBooks        usp_quickbooks.QuickBooksConfig                 `json:"quickbooks" yaml:"quickbooks"`
 	Box               usp_box.BoxConfig                               `json:"box" yaml:"box"`
 	Sublime           usp_sublime.SublimeConfig                       `json:"sublime" yaml:"sublime"`
 	SentinelOne       usp_sentinelone.SentinelOneConfig               `json:"sentinel_one" yaml:"sentinel_one"`

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -43,6 +43,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/pandadoc"
 	"github.com/refractionPOINT/usp-adapters/proofpoint_tap"
 	"github.com/refractionPOINT/usp-adapters/pubsub"
+	"github.com/refractionPOINT/usp-adapters/quickbooks"
 	"github.com/refractionPOINT/usp-adapters/s3"
 	"github.com/refractionPOINT/usp-adapters/sentinelone"
 	"github.com/refractionPOINT/usp-adapters/simulator"
@@ -498,6 +499,11 @@ func runAdapter(ctx context.Context, method string, configs Configuration, showC
 		configs.ThreatLocker.ClientOptions.Architecture = "usp_adapter"
 		configToShow = configs.ThreatLocker
 		client, chRunning, err = usp_threatlocker.NewThreatLockerAdapter(ctx, configs.ThreatLocker)
+	} else if method == "quickbooks" {
+		configs.QuickBooks.ClientOptions = applyLogging(configs.QuickBooks.ClientOptions)
+		configs.QuickBooks.ClientOptions.Architecture = "usp_adapter"
+		configToShow = configs.QuickBooks
+		client, chRunning, err = usp_quickbooks.NewQuickBooksAdapter(ctx, configs.QuickBooks)
 	} else {
 		return nil, nil, errors.New(logError("unknown adapter_type: %s", method))
 	}

--- a/quickbooks/README.md
+++ b/quickbooks/README.md
@@ -1,0 +1,165 @@
+# QuickBooks Online Adapter
+
+Collects change / activity data from a [QuickBooks Online](https://quickbooks.intuit.com/)
+company into LimaCharlie, via the Accounting API's **ChangeDataCapture (CDC)**
+operation. Each changed entity is forwarded in its original QuickBooks JSON
+form — the adapter does not reshape payloads — tagged with its entity type as
+the LimaCharlie `EventType`.
+
+## What this collects (and what it does not)
+
+> ⚠️ **QuickBooks Online's user-attributed "Audit Log"** — the UI feature under
+> *Settings → Audit Log* that shows *who* did *what* — **is not exposed through
+> any public Intuit API.** Intuit confirms this repeatedly; the Audit Log is an
+> internal report only available in the web UI.
+
+The authoritative programmatic way to track activity in a QuickBooks company is
+**ChangeDataCapture**, which this adapter polls. CDC returns the **full current
+state of every entity that changed** since a given timestamp — creations,
+updates, and deletions (reported with `"status": "Deleted"`). It tells you
+*what changed and when*, but not the acting user and not a field-level diff.
+
+If you need a true user-attributed audit trail, that data is not available from
+QuickBooks programmatically and this adapter cannot provide it.
+
+References:
+- [ChangeDataCapture operation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/changedatacapture)
+- [CDC overview](https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/change-data-capture)
+- [OAuth 2.0](https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0)
+
+## Out of the box
+
+With no `entities` configured, the adapter polls CDC for a default set of core
+transactional and name-list entities that together form a company's activity
+trail:
+
+```
+Account, Bill, BillPayment, CreditMemo, Customer, Employee, Estimate,
+Invoice, Item, JournalEntry, Payment, Purchase, SalesReceipt, Vendor,
+VendorCredit
+```
+
+Override `entities` to widen or narrow this list to the objects you care about.
+
+## Authentication
+
+QuickBooks Online uses **OAuth 2.0** (authorization-code grant). There is no
+service-account flow: a human must authorize the app once against the company,
+which yields a long-lived **refresh token** and the company's **realm id**
+(a.k.a. company id). The adapter exchanges the refresh token for short-lived
+(1-hour) access tokens and refreshes them automatically.
+
+You need, from the [Intuit developer portal](https://developer.intuit.com/):
+
+| Value | Where it comes from |
+|-------|---------------------|
+| `client_id` / `client_secret` | Your app → **Keys & credentials**. |
+| `refresh_token` | The result of running the OAuth authorization-code flow against the target company (e.g. with Intuit's [OAuth playground](https://developer.intuit.com/app/developer/playground) or your own connect flow). Must be granted the `com.intuit.quickbooks.accounting` scope. |
+| `realm_id` | Returned on the OAuth callback (`?realmId=...`); it is the QuickBooks company id. |
+
+### Refresh-token rotation
+
+Intuit may return a **new refresh token** on any refresh call. The adapter
+always adopts the latest value for the lifetime of the process and logs a
+warning when a rotation happens (the value itself is a secret and is never
+logged). The refresh token you configure remains valid until its own expiry, so
+a process restart is safe. For very long-lived deployments, persist rotated
+tokens from your own OAuth store. If the refresh token is revoked or expires,
+the adapter stops with a clear credential error.
+
+## Configuration
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `client_options` | yes | Standard USP adapter options (see the repo README). |
+| `client_id` | yes | OAuth 2.0 app client id. |
+| `client_secret` | yes | OAuth 2.0 app client secret. |
+| `refresh_token` | yes | Long-lived OAuth refresh token authorized for the company. |
+| `realm_id` | yes | QuickBooks company id (realmId). |
+| `entities` | no | List of CDC entity names to poll. Defaults to the set under [Out of the box](#out-of-the-box). |
+| `sandbox` | no | Use the sandbox API root instead of production. Default `false`. |
+| `base_url` | no | Full API root override (e.g. for testing). When set, `sandbox` is ignored. |
+| `token_url` | no | OAuth token endpoint override (e.g. for testing). |
+| `minor_version` | no | Pins the Accounting API schema minor version. Default `75`. |
+| `poll_interval` | no | Wait between CDC polls, as a Go duration in nanoseconds. Default `300000000000` (5 minutes). |
+| `overlap` | no | Extends each poll's window backwards past the previous poll so a slipped cycle leaves no gap. The deduper absorbs the overlap. Default 5 minutes. |
+| `initial_lookback` | no | When > 0, the first poll reaches back this far (capped at 30 days) to backfill recent changes on startup. Default `0` (collect from launch time). |
+| `dedupe_ttl` | no | How long a change's identity is remembered to suppress re-shipping it. Default 7 days. |
+| `retry_base_delay` / `max_retry_delay` / `max_retry_attempts` | no | Transient-failure retry tuning. |
+
+## How polling works
+
+On each poll the adapter issues one CDC request covering the window
+`[since - overlap, now]`, where `since` is the high-water mark advanced after
+every successful poll. It parses the `CDCResponse` envelope, flattens every
+per-entity block, and ships each change exactly once — an in-memory deduper
+keyed on `entityType | Id | LastUpdatedTime` absorbs the overlap between
+consecutive windows while still emitting a fresh event when the *same* object
+is edited again (a new `LastUpdatedTime`).
+
+A few QuickBooks-specific constraints the adapter handles:
+
+- **30-day horizon.** CDC rejects a `changedSince` older than 30 days. The
+  adapter clamps the window to just under 30 days and warns if it has to.
+- **1000-object cap.** A single CDC response carries at most 1000 objects. If a
+  response hits that cap, changes may have been dropped from the window; the
+  adapter warns and recommends a shorter `poll_interval` or a narrower
+  `entities` list.
+- **Rate limits.** QuickBooks throttles at ~500 requests/minute per realm and
+  returns HTTP 429 when exceeded. The adapter retries 429 and 5xx responses
+  with exponential backoff.
+- **Token expiry.** Access tokens last one hour and are refreshed transparently;
+  a 401 triggers a one-shot refresh-and-retry. A permanently rejected refresh
+  token (revoked/expired, or bad client credentials) stops the adapter with a
+  credential error.
+
+The event time of each shipped record is taken from
+`MetaData.LastUpdatedTime`, falling back to the collection time when absent.
+
+## Examples
+
+Production, via the CLI (default entity set):
+
+```
+./general quickbooks \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=json \
+  client_options.sensor_seed_key=quickbooks \
+  client_id=$QB_CLIENT_ID \
+  client_secret=$QB_CLIENT_SECRET \
+  refresh_token=$QB_REFRESH_TOKEN \
+  realm_id=$QB_REALM_ID
+```
+
+Narrowing the entity set and backfilling the last 7 days on startup, via a YAML
+config file:
+
+```yaml
+quickbooks:
+  client_options:
+    identity:
+      oid: $OID
+      installation_key: $INSTALLATION_KEY
+    platform: json
+    sensor_seed_key: quickbooks
+  client_id: $QB_CLIENT_ID
+  client_secret: $QB_CLIENT_SECRET
+  refresh_token: $QB_REFRESH_TOKEN
+  realm_id: $QB_REALM_ID
+  entities:
+    - Invoice
+    - Bill
+    - Payment
+    - JournalEntry
+  initial_lookback: 168h   # 7 days
+  poll_interval: 5m
+```
+
+Against the sandbox company:
+
+```yaml
+quickbooks:
+  # ... credentials ...
+  sandbox: true
+```

--- a/quickbooks/api.go
+++ b/quickbooks/api.go
@@ -1,0 +1,299 @@
+package usp_quickbooks
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HTTPError represents a non-2xx response from the QuickBooks Online API. It
+// carries the status code so callers can classify the error (retry vs. give up)
+// without parsing error strings.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	body := e.Body
+	if len(body) > 512 {
+		body = body[:512] + "..."
+	}
+	return fmt.Sprintf("unexpected status code %d for %q: %s", e.StatusCode, e.URL, body)
+}
+
+// TokenError wraps a failure to obtain an OAuth access token from the refresh
+// token. It lets the adapter tell a credential problem (fatal) apart from a
+// data-request error, while still allowing isTransientError to see through to
+// the underlying cause (a 5xx/network blip refreshing the token is retryable).
+type TokenError struct{ Err error }
+
+func (e *TokenError) Error() string { return "token refresh failed: " + e.Err.Error() }
+func (e *TokenError) Unwrap() error { return e.Err }
+
+// isTransientError reports whether an error is worth retrying.
+//
+// Transient (retry):
+//   - HTTP 5xx server errors
+//   - HTTP 429 Too Many Requests (QuickBooks throttles at 500 req/min/realm)
+//   - network errors (timeouts, connection refused, DNS failures, ...)
+//
+// Permanent (do not retry):
+//   - HTTP 4xx other than 429 (bad request, not found, ...)
+//   - HTTP 401 is handled separately by the client (a token refresh + retry),
+//     so by the time it surfaces here it is non-transient.
+//   - context cancellation (intentional shutdown)
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 500 && httpErr.StatusCode <= 599 {
+			return true
+		}
+		if httpErr.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+		return false
+	}
+
+	// Context cancellation is an intentional shutdown, not a transient blip.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Anything that failed before we got a response (DNS, dial, timeout, ...)
+	// is wrapped with this prefix by the request helpers; treat it as transient.
+	if strings.Contains(err.Error(), "failed to execute request") {
+		return true
+	}
+
+	return false
+}
+
+// tokenResponse is the JSON body returned by Intuit's OAuth 2.0 token endpoint
+// for a refresh_token grant.
+//
+// Reference:
+// https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0
+type tokenResponse struct {
+	AccessToken           string `json:"access_token"`
+	RefreshToken          string `json:"refresh_token"`
+	TokenType             string `json:"token_type"`
+	ExpiresIn             int    `json:"expires_in"`                 // access token lifetime, seconds (3600)
+	RefreshTokenExpiresIn int    `json:"x_refresh_token_expires_in"` // refresh token lifetime, seconds
+}
+
+// QuickBooksClient wraps the QuickBooks Online Accounting API. It owns the
+// OAuth 2.0 access token: it mints one from the configured refresh token on
+// first use and silently re-mints it when it nears expiry (or when the API
+// rejects it with a 401).
+//
+// QuickBooks access tokens live for one hour; refresh tokens are long-lived but
+// MAY rotate on a refresh call. The client always adopts the newest refresh
+// token returned by the token endpoint so a rotation does not break a
+// long-running collector mid-flight.
+type QuickBooksClient struct {
+	baseURL      string
+	tokenURL     string
+	clientID     string
+	clientSecret string
+	realmID      string
+	minorVersion string
+	httpClient   *http.Client
+
+	mu           sync.Mutex
+	accessToken  string
+	tokenExpiry  time.Time
+	refreshToken string
+
+	// onRefreshToken, when set, is invoked with the latest refresh token each
+	// time the token endpoint returns one. It lets an embedder persist a
+	// rotated token. It is never invoked with an empty value.
+	onRefreshToken func(string)
+}
+
+// tokenRefreshBuffer is how long before an access token's stated expiry the
+// client proactively refreshes it, to avoid racing the boundary.
+const tokenRefreshBuffer = 5 * time.Minute
+
+// NewQuickBooksClient builds a client. baseURL is the API root (e.g.
+// "https://quickbooks.api.intuit.com"); tokenURL is the OAuth 2.0 token
+// endpoint.
+func NewQuickBooksClient(baseURL, tokenURL, clientID, clientSecret, realmID, minorVersion, refreshToken string) *QuickBooksClient {
+	return &QuickBooksClient{
+		baseURL:      strings.TrimRight(baseURL, "/"),
+		tokenURL:     tokenURL,
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		realmID:      realmID,
+		minorVersion: minorVersion,
+		refreshToken: refreshToken,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout: 10 * time.Second,
+				}).Dial,
+			},
+		},
+	}
+}
+
+// refreshAccessToken exchanges the stored refresh token for a fresh access
+// token. The caller must hold c.mu.
+//
+// The request is a standard OAuth 2.0 refresh_token grant: an
+// application/x-www-form-urlencoded body POSTed to the token endpoint, with the
+// client id/secret presented via HTTP Basic auth.
+func (c *QuickBooksClient) refreshAccessToken(ctx context.Context) error {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", c.refreshToken)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create token request: %v", err)
+	}
+	basic := base64.StdEncoding.EncodeToString([]byte(c.clientID + ":" + c.clientSecret))
+	req.Header.Set("Authorization", "Basic "+basic)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request %q: %v", c.tokenURL, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read token response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return &HTTPError{StatusCode: resp.StatusCode, URL: c.tokenURL, Body: string(respBody)}
+	}
+
+	var tok tokenResponse
+	if err := json.Unmarshal(respBody, &tok); err != nil {
+		return fmt.Errorf("failed to parse token response: %v", err)
+	}
+	if tok.AccessToken == "" {
+		return errors.New("token endpoint returned an empty access_token")
+	}
+
+	c.accessToken = tok.AccessToken
+	lifetime := time.Duration(tok.ExpiresIn) * time.Second
+	if lifetime <= 0 {
+		// Intuit's documented access-token lifetime is one hour; fall back to
+		// it if the response omits expires_in.
+		lifetime = time.Hour
+	}
+	c.tokenExpiry = time.Now().Add(lifetime)
+
+	// Adopt a rotated refresh token if one came back. Intuit may return the
+	// same value or a new one; persisting the latest is mandatory.
+	if tok.RefreshToken != "" && tok.RefreshToken != c.refreshToken {
+		c.refreshToken = tok.RefreshToken
+		if c.onRefreshToken != nil {
+			c.onRefreshToken(tok.RefreshToken)
+		}
+	}
+	return nil
+}
+
+// ensureToken returns a valid access token, refreshing it if it is missing or
+// within tokenRefreshBuffer of expiry. force re-mints unconditionally (used
+// after a 401).
+func (c *QuickBooksClient) ensureToken(ctx context.Context, force bool) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if force || c.accessToken == "" || time.Now().After(c.tokenExpiry.Add(-tokenRefreshBuffer)) {
+		if err := c.refreshAccessToken(ctx); err != nil {
+			return "", &TokenError{Err: err}
+		}
+	}
+	return c.accessToken, nil
+}
+
+// CurrentRefreshToken returns the latest refresh token the client holds (which
+// may differ from the one it was constructed with, if Intuit rotated it).
+func (c *QuickBooksClient) CurrentRefreshToken() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.refreshToken
+}
+
+// GetCDC issues a ChangeDataCapture request for the given entities and returns
+// the raw response body. entities is the comma-separated entity list;
+// changedSince is the lower bound of the change window.
+//
+// On an HTTP 401 the client refreshes the access token once and retries, so a
+// token that expired between two polls does not surface as an error.
+//
+// Reference:
+// https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/changedatacapture
+func (c *QuickBooksClient) GetCDC(ctx context.Context, entities string, changedSince time.Time) ([]byte, error) {
+	body, err := c.doCDC(ctx, entities, changedSince, false)
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized {
+		// The access token was rejected; force a refresh and retry once.
+		return c.doCDC(ctx, entities, changedSince, true)
+	}
+	return body, err
+}
+
+func (c *QuickBooksClient) doCDC(ctx context.Context, entities string, changedSince time.Time, forceToken bool) ([]byte, error) {
+	token, err := c.ensureToken(ctx, forceToken)
+	if err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("entities", entities)
+	// QuickBooks accepts ISO 8601 / RFC 3339 for changedSince.
+	q.Set("changedSince", changedSince.UTC().Format(time.RFC3339))
+	if c.minorVersion != "" {
+		q.Set("minorversion", c.minorVersion)
+	}
+
+	reqURL := fmt.Sprintf("%s/v3/company/%s/cdc?%s", c.baseURL, url.PathEscape(c.realmID), q.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request %q: %v", reqURL, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request %q: %v", reqURL, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response %q: %v", reqURL, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: reqURL, Body: string(respBody)}
+	}
+	return respBody, nil
+}
+
+// Close releases idle connections held by the underlying transport.
+func (c *QuickBooksClient) Close() {
+	c.httpClient.CloseIdleConnections()
+}

--- a/quickbooks/client.go
+++ b/quickbooks/client.go
@@ -1,0 +1,634 @@
+// Package usp_quickbooks implements a USP adapter that collects change/activity
+// data from QuickBooks Online via the Accounting API's ChangeDataCapture (CDC)
+// operation.
+//
+// A note on scope: QuickBooks Online's user-attributed "Audit Log" (the UI
+// feature showing who did what) is NOT exposed through any public API. The
+// authoritative programmatic way to track activity is ChangeDataCapture, which
+// returns the full current state of every entity that changed since a given
+// timestamp -- including deletions (status="Deleted"). This adapter polls CDC
+// on a rolling window and ships each changed entity to LimaCharlie, tagged with
+// its entity type. It captures *what changed and when*, not the acting user.
+//
+// References:
+//   - CDC: https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/changedatacapture
+//   - OAuth 2.0: https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0
+package usp_quickbooks
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	defaultPollInterval     = 5 * time.Minute
+	defaultOverlap          = 5 * time.Minute
+	defaultDedupeTTL        = 7 * 24 * time.Hour
+	dedupeBucketWindow      = 1 * time.Hour
+	defaultMinorVersion     = "75"
+	defaultMaxRetryAttempts = 3
+	defaultRetryBaseDelay   = 5 * time.Second
+	defaultMaxRetryDelay    = 30 * time.Second
+
+	shipTimeout = 10 * time.Second
+
+	// cdcMaxLookback is the furthest back a CDC request may reach. QuickBooks
+	// rejects changedSince values older than 30 days; the adapter clamps to a
+	// hair under that to stay clear of the boundary.
+	cdcMaxLookback = 29 * 24 * time.Hour
+
+	// cdcObjectCap is the maximum number of objects a single CDC response can
+	// carry. Crossing it means changes were silently dropped from the window.
+	cdcObjectCap = 1000
+
+	// Production / sandbox API roots and the OAuth token endpoint.
+	prodBaseURL    = "https://quickbooks.api.intuit.com"
+	sandboxBaseURL = "https://sandbox-quickbooks.api.intuit.com"
+	tokenEndpoint  = "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
+)
+
+// defaultEntities is the out-of-the-box CDC entity set. It covers the core
+// transactional and name-list objects whose changes constitute an activity
+// trail for a QuickBooks company. Override via the `entities` config to widen
+// or narrow it.
+var defaultEntities = []string{
+	"Account",
+	"Bill",
+	"BillPayment",
+	"CreditMemo",
+	"Customer",
+	"Employee",
+	"Estimate",
+	"Invoice",
+	"Item",
+	"JournalEntry",
+	"Payment",
+	"Purchase",
+	"SalesReceipt",
+	"Vendor",
+	"VendorCredit",
+}
+
+// envelopeKeys are the per-QueryResponse keys that are not entity arrays and
+// must be skipped when walking a CDC response block.
+var envelopeKeys = map[string]struct{}{
+	"startPosition": {},
+	"maxResults":    {},
+	"totalCount":    {},
+}
+
+// QuickBooksConfig is the adapter configuration.
+type QuickBooksConfig struct {
+	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+	// OAuth 2.0 application credentials (Intuit developer portal > your app >
+	// Keys & credentials).
+	ClientID     string `json:"client_id" yaml:"client_id"`
+	ClientSecret string `json:"client_secret" yaml:"client_secret"`
+
+	// RefreshToken is a long-lived OAuth 2.0 refresh token obtained from the
+	// authorization-code flow. The adapter exchanges it for short-lived access
+	// tokens and adopts any rotated refresh token returned by Intuit.
+	RefreshToken string `json:"refresh_token" yaml:"refresh_token"`
+
+	// RealmID is the QuickBooks company id (a.k.a. realmId), returned on the
+	// OAuth callback and present in every API path.
+	RealmID string `json:"realm_id" yaml:"realm_id"`
+
+	// Entities is the CDC entity list to poll. Defaults to defaultEntities.
+	Entities []string `json:"entities" yaml:"entities"`
+
+	// Sandbox selects the sandbox API root instead of production. Ignored when
+	// BaseURL is set.
+	Sandbox bool `json:"sandbox" yaml:"sandbox"`
+
+	// BaseURL fully overrides the API root (e.g. for testing). When set,
+	// Sandbox is ignored.
+	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// TokenURL overrides the OAuth token endpoint (e.g. for testing).
+	TokenURL string `json:"token_url" yaml:"token_url"`
+
+	// MinorVersion pins the Accounting API schema minor version. Default "75".
+	MinorVersion string `json:"minor_version" yaml:"minor_version"`
+
+	// PollInterval is the wait between CDC polls. Default 5 minutes.
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+
+	// Overlap extends each poll's window backwards past the previous poll so a
+	// slipped or delayed cycle leaves no gap; the deduper suppresses the
+	// resulting re-fetches. Default 5 minutes.
+	Overlap time.Duration `json:"overlap" yaml:"overlap"`
+
+	// InitialLookback, when > 0, makes the first poll reach back this far
+	// (capped at 30 days) to backfill recent changes on startup. Default 0:
+	// collection starts from the moment the adapter launches.
+	InitialLookback time.Duration `json:"initial_lookback" yaml:"initial_lookback"`
+
+	// DedupeTTL is how long a change's identity is remembered to suppress
+	// re-shipping it across overlapping windows. Default 7 days.
+	DedupeTTL time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
+
+	// Retry tuning for transient API failures.
+	RetryBaseDelay   time.Duration `json:"retry_base_delay" yaml:"retry_base_delay"`
+	MaxRetryDelay    time.Duration `json:"max_retry_delay" yaml:"max_retry_delay"`
+	MaxRetryAttempts int           `json:"max_retry_attempts" yaml:"max_retry_attempts"`
+
+	// Deduper, when set, replaces the built-in in-memory deduper. Not settable
+	// through a config file; it is a seam for tests and embedders.
+	Deduper utils.Deduper `json:"-" yaml:"-"`
+}
+
+func (c *QuickBooksConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+	if c.ClientID == "" {
+		return errors.New("missing client_id")
+	}
+	if c.ClientSecret == "" {
+		return errors.New("missing client_secret")
+	}
+	if c.RefreshToken == "" {
+		return errors.New("missing refresh_token")
+	}
+	if strings.TrimSpace(c.RealmID) == "" {
+		return errors.New("missing realm_id")
+	}
+
+	if len(c.Entities) == 0 {
+		c.Entities = append([]string(nil), defaultEntities...)
+	} else {
+		cleaned := c.Entities[:0]
+		seen := map[string]struct{}{}
+		for _, e := range c.Entities {
+			e = strings.TrimSpace(e)
+			if e == "" {
+				continue
+			}
+			if _, ok := seen[e]; ok {
+				continue
+			}
+			seen[e] = struct{}{}
+			cleaned = append(cleaned, e)
+		}
+		if len(cleaned) == 0 {
+			return errors.New("entities is set but contains no usable entity names")
+		}
+		c.Entities = cleaned
+	}
+
+	if c.MinorVersion == "" {
+		c.MinorVersion = defaultMinorVersion
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
+	if c.Overlap < 0 {
+		c.Overlap = 0
+	}
+	if c.Overlap == 0 {
+		c.Overlap = defaultOverlap
+	}
+	if c.InitialLookback > cdcMaxLookback {
+		c.InitialLookback = cdcMaxLookback
+	}
+	if c.DedupeTTL <= 0 {
+		c.DedupeTTL = defaultDedupeTTL
+	}
+	if c.RetryBaseDelay <= 0 {
+		c.RetryBaseDelay = defaultRetryBaseDelay
+	}
+	if c.MaxRetryDelay <= 0 {
+		c.MaxRetryDelay = defaultMaxRetryDelay
+	}
+	if c.MaxRetryAttempts <= 0 {
+		c.MaxRetryAttempts = defaultMaxRetryAttempts
+	}
+	return nil
+}
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink; *uspclient.Client
+// satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
+// QuickBooksAdapter polls QuickBooks Online CDC and ships changed entities to
+// LimaCharlie.
+type QuickBooksAdapter struct {
+	conf        QuickBooksConfig
+	uspClient   uspSink
+	client      *QuickBooksClient
+	deduper     utils.Deduper
+	ownsDeduper bool
+
+	// since is the high-water mark of the change window. It advances to the
+	// poll's end time after every successful poll.
+	since time.Time
+
+	chStopped chan struct{}
+	wgSenders sync.WaitGroup
+	doStop    *utils.Event
+
+	closeOnce sync.Once
+	closeErr  error
+
+	ctx context.Context
+}
+
+// NewQuickBooksAdapter creates a QuickBooks adapter wired to LimaCharlie.
+func NewQuickBooksAdapter(ctx context.Context, conf QuickBooksConfig) (*QuickBooksAdapter, chan struct{}, error) {
+	return newQuickBooksAdapter(ctx, conf, nil)
+}
+
+// newQuickBooksAdapter is the implementation behind NewQuickBooksAdapter. When
+// sink is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newQuickBooksAdapter(ctx context.Context, conf QuickBooksConfig, sink uspSink) (*QuickBooksAdapter, chan struct{}, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	a := &QuickBooksAdapter{
+		conf:   conf,
+		ctx:    ctx,
+		doStop: utils.NewEvent(),
+	}
+
+	now := time.Now()
+	a.since = now
+	if conf.InitialLookback > 0 {
+		a.since = now.Add(-conf.InitialLookback)
+	}
+
+	// CDC re-reports a change for the whole overlap window, so a deduper is
+	// required to ship each change exactly once.
+	a.deduper = conf.Deduper
+	if a.deduper == nil {
+		window := dedupeBucketWindow
+		if window > conf.DedupeTTL {
+			window = conf.DedupeTTL
+		}
+		deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("quickbooks: deduper: %v", err)
+		}
+		a.deduper = deduper
+		a.ownsDeduper = true
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			if a.ownsDeduper {
+				a.deduper.Close()
+			}
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
+	}
+
+	a.client = NewQuickBooksClient(
+		resolveBaseURL(conf),
+		resolveTokenURL(conf),
+		conf.ClientID,
+		conf.ClientSecret,
+		conf.RealmID,
+		conf.MinorVersion,
+		conf.RefreshToken,
+	)
+	// Surface a rotated refresh token so an operator can update their stored
+	// config; the value itself is a secret, so only its rotation is logged.
+	a.client.onRefreshToken = func(string) {
+		a.conf.ClientOptions.OnWarning("quickbooks: Intuit rotated the refresh token; " +
+			"the new value is held in memory for this run. Persist it from your OAuth " +
+			"store -- the value configured here remains valid until its own expiry.")
+	}
+
+	a.chStopped = make(chan struct{})
+	a.wgSenders.Add(1)
+	go a.run()
+
+	go func() {
+		a.wgSenders.Wait()
+		close(a.chStopped)
+	}()
+
+	return a, a.chStopped, nil
+}
+
+// Close stops the adapter. It is idempotent.
+func (a *QuickBooksAdapter) Close() error {
+	a.closeOnce.Do(func() {
+		a.conf.ClientOptions.DebugLog("quickbooks: closing")
+		a.doStop.Set()
+		a.wgSenders.Wait()
+		err1 := a.uspClient.Drain(1 * time.Minute)
+		_, err2 := a.uspClient.Close()
+		a.client.Close()
+		if a.ownsDeduper {
+			a.deduper.Close()
+		}
+		if err1 != nil {
+			a.closeErr = err1
+		} else {
+			a.closeErr = err2
+		}
+	})
+	return a.closeErr
+}
+
+// resolveBaseURL computes the API root from the config.
+func resolveBaseURL(conf QuickBooksConfig) string {
+	if conf.BaseURL != "" {
+		return strings.TrimRight(conf.BaseURL, "/")
+	}
+	if conf.Sandbox {
+		return sandboxBaseURL
+	}
+	return prodBaseURL
+}
+
+// resolveTokenURL computes the OAuth token endpoint from the config.
+func resolveTokenURL(conf QuickBooksConfig) string {
+	if conf.TokenURL != "" {
+		return conf.TokenURL
+	}
+	return tokenEndpoint
+}
+
+// run polls QuickBooks CDC forever, until the adapter is asked to stop.
+func (a *QuickBooksAdapter) run() {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog("quickbooks: collection stopped")
+
+	isFirstRun := true
+	for isFirstRun || !a.doStop.WaitFor(a.conf.PollInterval) {
+		isFirstRun = false
+		a.poll()
+	}
+}
+
+// poll performs one CDC request over the rolling window and ships every changed
+// entity that has not been seen before. On success the window's high-water mark
+// advances; on failure it does not, so the next poll re-covers the same range.
+func (a *QuickBooksAdapter) poll() {
+	end := time.Now()
+	start := a.since.Add(-a.conf.Overlap)
+	// Never reach past CDC's 30-day horizon.
+	if floor := end.Add(-cdcMaxLookback); start.Before(floor) {
+		start = floor
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"quickbooks: change window clamped to CDC's 30-day limit (since %s); "+
+				"changes older than that cannot be retrieved", start.UTC().Format(time.RFC3339)))
+	}
+
+	entities := strings.Join(a.conf.Entities, ",")
+	raw, ok := a.fetch(entities, start)
+	if !ok {
+		return
+	}
+
+	changes, err := parseCDCResponse(raw)
+	if err != nil {
+		a.conf.ClientOptions.OnError(fmt.Errorf("quickbooks: response parse error: %v", err))
+		return
+	}
+	if len(changes) >= cdcObjectCap {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"quickbooks: CDC returned %d objects, at or above the %d-object cap -- some "+
+				"changes in this window may have been dropped. Shorten poll_interval or "+
+				"narrow entities.", len(changes), cdcObjectCap))
+	}
+
+	nShipped := 0
+	for _, ch := range changes {
+		if a.doStop.IsSet() {
+			return
+		}
+		if a.deduper.CheckAndAdd(a.dedupeKey(ch)) {
+			continue
+		}
+		if !a.ship(ch) {
+			return
+		}
+		nShipped++
+	}
+
+	// Only advance the high-water mark once the poll fully succeeded.
+	a.since = end
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"quickbooks: poll complete (changed=%d shipped=%d) up to %s",
+		len(changes), nShipped, end.UTC().Format(time.RFC3339)))
+}
+
+// fetch performs one CDC request, retrying transient failures with exponential
+// backoff. The bool is false when the poll should be abandoned (a permanent
+// error, or the adapter is stopping).
+func (a *QuickBooksAdapter) fetch(entities string, changedSince time.Time) ([]byte, bool) {
+	var raw []byte
+	var err error
+	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
+		if a.doStop.IsSet() {
+			return nil, false
+		}
+
+		raw, err = a.client.GetCDC(a.ctx, entities, changedSince)
+		if err == nil {
+			return raw, true
+		}
+
+		if !isTransientError(err) {
+			a.conf.ClientOptions.OnError(fmt.Errorf("quickbooks: CDC request failed: %v", err))
+			// A credential problem needs operator attention, so stop the adapter
+			// rather than spin uselessly every interval. This covers a permanently
+			// failing token refresh (e.g. a revoked/expired refresh token, bad
+			// client_id/secret -> 400 invalid_grant), and a CDC call that still
+			// returns 401/403 after a forced token refresh (wrong scope/realm).
+			// Other permanent errors (e.g. a 400 for a bad entity name) abandon
+			// this poll but keep the adapter alive to retry on the next interval.
+			var tokenErr *TokenError
+			var httpErr *HTTPError
+			if errors.As(err, &tokenErr) ||
+				(errors.As(err, &httpErr) &&
+					(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden)) {
+				a.conf.ClientOptions.OnError(fmt.Errorf(
+					"quickbooks: credentials rejected. Verify client_id/client_secret, that the "+
+						"refresh_token is still valid and authorized for realm_id %q, and that the "+
+						"app has the com.intuit.quickbooks.accounting scope.", a.conf.RealmID))
+				a.doStop.Set()
+			}
+			return nil, false
+		}
+
+		if attempt+1 >= a.conf.MaxRetryAttempts {
+			break
+		}
+		delay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
+		if delay > a.conf.MaxRetryDelay {
+			delay = a.conf.MaxRetryDelay
+		}
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"quickbooks: transient error (attempt %d/%d), retrying in %v: %v",
+			attempt+1, a.conf.MaxRetryAttempts, delay, err))
+		if a.doStop.WaitFor(delay) {
+			return nil, false
+		}
+	}
+	a.conf.ClientOptions.OnError(fmt.Errorf(
+		"quickbooks: CDC request failed after %d attempts: %v", a.conf.MaxRetryAttempts, err))
+	return nil, false
+}
+
+// ship forwards a single change to LimaCharlie. It returns false if the adapter
+// should stop (an unrecoverable shipping error).
+func (a *QuickBooksAdapter) ship(ch cdcChange) bool {
+	msg := &protocol.DataMessage{
+		JsonPayload: ch.entity,
+		EventType:   ch.entityType,
+		TimestampMs: a.eventTime(ch),
+	}
+	if err := a.uspClient.Ship(msg, shipTimeout); err != nil {
+		if err == uspclient.ErrorBufferFull {
+			a.conf.ClientOptions.OnWarning("quickbooks: stream falling behind")
+			err = a.uspClient.Ship(msg, 1*time.Hour)
+		}
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("quickbooks: Ship(): %v", err))
+			a.doStop.Set()
+			return false
+		}
+	}
+	return true
+}
+
+// eventTime extracts the change's event time from MetaData.LastUpdatedTime,
+// falling back to now when it is absent or unparseable.
+func (a *QuickBooksAdapter) eventTime(ch cdcChange) uint64 {
+	if raw := ch.entity.FindOneString("MetaData/LastUpdatedTime"); raw != "" {
+		if t, err := time.Parse(time.RFC3339, strings.TrimSpace(raw)); err == nil {
+			return uint64(t.UnixMilli())
+		}
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+			"quickbooks: %s/%s unparseable LastUpdatedTime %q", ch.entityType, ch.id(), raw))
+	}
+	return uint64(time.Now().UnixMilli())
+}
+
+// dedupeKey returns a stable deduplication key for a change. CDC re-reports the
+// same change across overlapping windows; keying on entity type + id + the
+// last-updated time ships each distinct revision exactly once while still
+// emitting a new event when the same object changes again.
+func (a *QuickBooksAdapter) dedupeKey(ch cdcChange) string {
+	lut := ch.entity.FindOneString("MetaData/LastUpdatedTime")
+	rev := lut
+	if rev == "" {
+		// Fall back to the SyncToken (bumped on every write) then a content
+		// hash, so a change with no timestamp still ships at most once.
+		rev = ch.entity.FindOneString("SyncToken")
+	}
+	if rev == "" {
+		b, _ := json.Marshal(ch.entity)
+		sum := sha256.Sum256(b)
+		rev = "sha256:" + hex.EncodeToString(sum[:])
+	}
+	return ch.entityType + "|" + ch.id() + "|" + rev
+}
+
+// cdcChange is one entity that changed, paired with its entity type.
+type cdcChange struct {
+	entityType string
+	entity     utils.Dict
+}
+
+func (c cdcChange) id() string {
+	return c.entity.FindOneString("Id")
+}
+
+// cdcEnvelope mirrors the top-level shape of a CDC response.
+//
+//	{ "CDCResponse": [ { "QueryResponse": [ { "<Entity>": [...], ... } ] } ],
+//	  "time": "..." }
+//
+// A request error instead returns a Fault object, which we surface as an error.
+type cdcEnvelope struct {
+	CDCResponse []struct {
+		QueryResponse []map[string]json.RawMessage `json:"QueryResponse"`
+	} `json:"CDCResponse"`
+	Fault json.RawMessage `json:"Fault"`
+	Time  string          `json:"time"`
+}
+
+// parseCDCResponse flattens a CDC response into a deterministic slice of
+// changes. Entity blocks are grouped under each QueryResponse element keyed by
+// entity type; non-array envelope fields (startPosition/maxResults) are
+// skipped. Records are returned in a stable order (entity type, then their
+// order within the block) so polls are reproducible.
+func parseCDCResponse(raw []byte) ([]cdcChange, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	var env cdcEnvelope
+	if err := json.Unmarshal([]byte(trimmed), &env); err != nil {
+		return nil, fmt.Errorf("invalid CDC JSON: %v", err)
+	}
+	if len(env.Fault) > 0 {
+		return nil, fmt.Errorf("QuickBooks API fault: %s", string(env.Fault))
+	}
+
+	var changes []cdcChange
+	for _, cdc := range env.CDCResponse {
+		for _, block := range cdc.QueryResponse {
+			// Sort entity keys for a deterministic emission order.
+			keys := make([]string, 0, len(block))
+			for k := range block {
+				if _, skip := envelopeKeys[k]; skip {
+					continue
+				}
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+
+			for _, entityType := range keys {
+				var arr []json.RawMessage
+				if err := json.Unmarshal(block[entityType], &arr); err != nil {
+					// Not an array (e.g. a scalar count field we don't know);
+					// skip rather than fail the whole response.
+					continue
+				}
+				for _, r := range arr {
+					m, err := utils.UnmarshalCleanJSON(string(r))
+					if err != nil || len(m) == 0 {
+						continue
+					}
+					changes = append(changes, cdcChange{
+						entityType: entityType,
+						entity:     utils.Dict(m),
+					})
+				}
+			}
+		}
+	}
+	return changes, nil
+}

--- a/quickbooks/client_test.go
+++ b/quickbooks/client_test.go
@@ -1,0 +1,359 @@
+package usp_quickbooks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// baseTestConfig is a minimal valid config pointed at the given API/token URLs.
+func baseTestConfig(t *testing.T, baseURL, tokenURL string) QuickBooksConfig {
+	t.Helper()
+	return QuickBooksConfig{
+		ClientOptions: testClientOptions(t),
+		ClientID:      "test-client-id",
+		ClientSecret:  "test-client-secret",
+		RefreshToken:  "test-refresh-token",
+		RealmID:       "1234567890",
+		BaseURL:       baseURL,
+		TokenURL:      tokenURL,
+		PollInterval:  40 * time.Millisecond,
+	}
+}
+
+// --- unit tests: parseCDCResponse -------------------------------------------
+
+func TestParseCDCResponse(t *testing.T) {
+	t.Run("groups entities by type and preserves payloads", func(t *testing.T) {
+		raw := []byte(`{
+			"CDCResponse":[{"QueryResponse":[
+				{"Customer":[
+					{"Id":"1","SyncToken":"0","DisplayName":"Amy's Bird Sanctuary",
+					 "MetaData":{"LastUpdatedTime":"2026-05-12T13:39:32-07:00"}}
+				],"startPosition":1,"maxResults":1},
+				{"Invoice":[
+					{"Id":"130","SyncToken":"2","TotalAmt":362.07,
+					 "MetaData":{"LastUpdatedTime":"2026-05-12T14:00:00-07:00"}},
+					{"Id":"131","SyncToken":"0","status":"Deleted",
+					 "MetaData":{"LastUpdatedTime":"2026-05-12T14:05:00-07:00"}}
+				],"startPosition":1,"maxResults":2}
+			]}],
+			"time":"2026-05-12T14:10:00.000-07:00"
+		}`)
+		changes, err := parseCDCResponse(raw)
+		require.NoError(t, err)
+		require.Len(t, changes, 3)
+
+		byType := map[string]int{}
+		for _, c := range changes {
+			byType[c.entityType]++
+		}
+		assert.Equal(t, map[string]int{"Customer": 1, "Invoice": 2}, byType)
+
+		// The Customer payload survives verbatim, including nested MetaData.
+		var cust cdcChange
+		for _, c := range changes {
+			if c.entityType == "Customer" {
+				cust = c
+			}
+		}
+		assert.Equal(t, "1", cust.id())
+		assert.Equal(t, "Amy's Bird Sanctuary", cust.entity.FindOneString("DisplayName"))
+		assert.Equal(t, "2026-05-12T13:39:32-07:00", cust.entity.FindOneString("MetaData/LastUpdatedTime"))
+	})
+
+	t.Run("deleted entity is parsed with its status", func(t *testing.T) {
+		raw := []byte(`{"CDCResponse":[{"QueryResponse":[
+			{"Invoice":[{"Id":"99","status":"Deleted","MetaData":{"LastUpdatedTime":"2026-05-12T14:05:00Z"}}]}
+		]}]}`)
+		changes, err := parseCDCResponse(raw)
+		require.NoError(t, err)
+		require.Len(t, changes, 1)
+		assert.Equal(t, "Invoice", changes[0].entityType)
+		assert.Equal(t, "Deleted", changes[0].entity.FindOneString("status"))
+	})
+
+	t.Run("empty CDC response yields no changes", func(t *testing.T) {
+		// When nothing changed, a QueryResponse block carries no entity array.
+		raw := []byte(`{"CDCResponse":[{"QueryResponse":[{}]}],"time":"2026-05-12T14:10:00Z"}`)
+		changes, err := parseCDCResponse(raw)
+		require.NoError(t, err)
+		assert.Empty(t, changes)
+	})
+
+	t.Run("empty body yields no changes", func(t *testing.T) {
+		changes, err := parseCDCResponse([]byte("   "))
+		require.NoError(t, err)
+		assert.Empty(t, changes)
+	})
+
+	t.Run("fault response surfaces an error", func(t *testing.T) {
+		raw := []byte(`{"Fault":{"Error":[{"Message":"changedSince is more than 30 days ago","code":"4001"}],"type":"ValidationFault"},"time":"2026-05-12T14:10:00Z"}`)
+		_, err := parseCDCResponse(raw)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "fault")
+	})
+
+	t.Run("invalid json errors", func(t *testing.T) {
+		_, err := parseCDCResponse([]byte(`not json`))
+		assert.Error(t, err)
+	})
+
+	t.Run("large integers keep precision", func(t *testing.T) {
+		raw := []byte(`{"CDCResponse":[{"QueryResponse":[{"Invoice":[{"Id":"1","big":123456789012345678}]}]}]}`)
+		changes, err := parseCDCResponse(raw)
+		require.NoError(t, err)
+		require.Len(t, changes, 1)
+		v, ok := changes[0].entity.GetInt("big")
+		require.True(t, ok)
+		assert.Equal(t, uint64(123456789012345678), v)
+	})
+
+	t.Run("emission order is deterministic by entity type", func(t *testing.T) {
+		raw := []byte(`{"CDCResponse":[{"QueryResponse":[
+			{"Vendor":[{"Id":"v1"}]},
+			{"Account":[{"Id":"a1"}]},
+			{"Invoice":[{"Id":"i1"}]}
+		]}]}`)
+		changes, err := parseCDCResponse(raw)
+		require.NoError(t, err)
+		require.Len(t, changes, 3)
+		// Within each QueryResponse block keys are sorted; here each block has a
+		// single key, so the order follows the blocks but each block's key is
+		// emitted deterministically. Assert all three are present.
+		got := map[string]string{}
+		for _, c := range changes {
+			got[c.entityType] = c.id()
+		}
+		assert.Equal(t, map[string]string{"Vendor": "v1", "Account": "a1", "Invoice": "i1"}, got)
+	})
+}
+
+// --- unit tests: dedupe key -------------------------------------------------
+
+func TestDedupeKey(t *testing.T) {
+	a := &QuickBooksAdapter{}
+
+	t.Run("keys on type, id and last-updated time", func(t *testing.T) {
+		ch := cdcChange{entityType: "Invoice", entity: utils.Dict{
+			"Id":       "130",
+			"MetaData": utils.Dict{"LastUpdatedTime": "2026-05-12T14:00:00Z"},
+		}}
+		assert.Equal(t, "Invoice|130|2026-05-12T14:00:00Z", a.dedupeKey(ch))
+	})
+
+	t.Run("a new revision of the same object yields a new key", func(t *testing.T) {
+		mk := func(lut string) cdcChange {
+			return cdcChange{entityType: "Invoice", entity: utils.Dict{
+				"Id":       "130",
+				"MetaData": utils.Dict{"LastUpdatedTime": lut},
+			}}
+		}
+		assert.NotEqual(t, a.dedupeKey(mk("2026-05-12T14:00:00Z")), a.dedupeKey(mk("2026-05-12T15:00:00Z")))
+	})
+
+	t.Run("falls back to SyncToken when no timestamp", func(t *testing.T) {
+		ch := cdcChange{entityType: "Invoice", entity: utils.Dict{"Id": "130", "SyncToken": "5"}}
+		assert.Equal(t, "Invoice|130|5", a.dedupeKey(ch))
+	})
+
+	t.Run("falls back to a content hash when no timestamp or synctoken", func(t *testing.T) {
+		ch := cdcChange{entityType: "Invoice", entity: utils.Dict{"Id": "130", "x": "y"}}
+		key := a.dedupeKey(ch)
+		assert.Contains(t, key, "Invoice|130|sha256:")
+	})
+}
+
+// --- unit tests: config -----------------------------------------------------
+
+func TestValidate(t *testing.T) {
+	valid := func() QuickBooksConfig {
+		return QuickBooksConfig{
+			ClientOptions: testClientOptions(t),
+			ClientID:      "id", ClientSecret: "secret",
+			RefreshToken: "rt", RealmID: "123",
+		}
+	}
+
+	t.Run("requires every credential field", func(t *testing.T) {
+		for _, mut := range []func(*QuickBooksConfig){
+			func(c *QuickBooksConfig) { c.ClientID = "" },
+			func(c *QuickBooksConfig) { c.ClientSecret = "" },
+			func(c *QuickBooksConfig) { c.RefreshToken = "" },
+			func(c *QuickBooksConfig) { c.RealmID = "" },
+		} {
+			c := valid()
+			mut(&c)
+			assert.Error(t, c.Validate())
+		}
+	})
+
+	t.Run("applies defaults", func(t *testing.T) {
+		c := valid()
+		require.NoError(t, c.Validate())
+		assert.Equal(t, defaultMinorVersion, c.MinorVersion)
+		assert.Equal(t, defaultPollInterval, c.PollInterval)
+		assert.Equal(t, defaultOverlap, c.Overlap)
+		assert.Equal(t, defaultDedupeTTL, c.DedupeTTL)
+		assert.Equal(t, defaultMaxRetryAttempts, c.MaxRetryAttempts)
+		assert.Equal(t, defaultEntities, c.Entities)
+	})
+
+	t.Run("dedupes and trims a custom entity list", func(t *testing.T) {
+		c := valid()
+		c.Entities = []string{" Invoice ", "Customer", "Invoice", "", "  "}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, []string{"Invoice", "Customer"}, c.Entities)
+	})
+
+	t.Run("rejects an entity list with no usable names", func(t *testing.T) {
+		c := valid()
+		c.Entities = []string{"", "  "}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("clamps initial_lookback to the 30-day CDC horizon", func(t *testing.T) {
+		c := valid()
+		c.InitialLookback = 60 * 24 * time.Hour
+		require.NoError(t, c.Validate())
+		assert.Equal(t, cdcMaxLookback, c.InitialLookback)
+	})
+}
+
+func TestResolveBaseURL(t *testing.T) {
+	assert.Equal(t, prodBaseURL, resolveBaseURL(QuickBooksConfig{}))
+	assert.Equal(t, sandboxBaseURL, resolveBaseURL(QuickBooksConfig{Sandbox: true}))
+	assert.Equal(t, "https://example.test", resolveBaseURL(QuickBooksConfig{BaseURL: "https://example.test/"}))
+	// base_url wins over sandbox.
+	assert.Equal(t, "https://example.test", resolveBaseURL(QuickBooksConfig{Sandbox: true, BaseURL: "https://example.test"}))
+}
+
+func TestResolveTokenURL(t *testing.T) {
+	assert.Equal(t, tokenEndpoint, resolveTokenURL(QuickBooksConfig{}))
+	assert.Equal(t, "https://token.test", resolveTokenURL(QuickBooksConfig{TokenURL: "https://token.test"}))
+}
+
+func TestIsTransientError(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		isTransient bool
+	}{
+		{"500", &HTTPError{StatusCode: 500}, true},
+		{"503", &HTTPError{StatusCode: 503}, true},
+		{"429", &HTTPError{StatusCode: 429}, true},
+		{"401", &HTTPError{StatusCode: 401}, false},
+		{"403", &HTTPError{StatusCode: 403}, false},
+		{"400", &HTTPError{StatusCode: 400}, false},
+		{"token error wrapping 400 is permanent", &TokenError{Err: &HTTPError{StatusCode: 400}}, false},
+		{"token error wrapping 500 is transient", &TokenError{Err: &HTTPError{StatusCode: 500}}, true},
+		{"network", fmt.Errorf("failed to execute request %q: connection refused", "x"), true},
+		{"context canceled", context.Canceled, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.isTransient, isTransientError(c.err))
+		})
+	}
+}
+
+// --- integration test: request shape ----------------------------------------
+
+// TestCDCRequestShape asserts the adapter authenticates correctly and issues a
+// well-formed CDC request: a refresh_token grant to the token endpoint, then a
+// GET to /v3/company/{realmId}/cdc carrying the bearer token, the entity list,
+// a changedSince and the pinned minor version.
+func TestCDCRequestShape(t *testing.T) {
+	var mu sync.Mutex
+	var tokenGrant, tokenAuth string
+	var cdcMethod, cdcPath, cdcAuth, cdcAccept string
+	var cdcQuery url.Values
+	tokenHits, cdcHits := 0, 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/v1/tokens/bearer", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		mu.Lock()
+		tokenHits++
+		tokenGrant = r.Form.Get("grant_type")
+		tokenAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"AT-1","refresh_token":"test-refresh-token","token_type":"bearer","expires_in":3600,"x_refresh_token_expires_in":8726400}`))
+	})
+	mux.HandleFunc("/v3/company/1234567890/cdc", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		cdcHits++
+		cdcMethod = r.Method
+		cdcPath = r.URL.Path
+		cdcAuth = r.Header.Get("Authorization")
+		cdcAccept = r.Header.Get("Accept")
+		cdcQuery = r.URL.Query()
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"CDCResponse":[{"QueryResponse":[{}]}],"time":"2026-05-12T14:10:00Z"}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := baseTestConfig(t, server.URL, server.URL+"/oauth2/v1/tokens/bearer")
+	conf.Entities = []string{"Customer", "Invoice"}
+	conf.MinorVersion = "75"
+	adapter, _, err := NewQuickBooksAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return cdcHits >= 1 && tokenHits >= 1
+	}, 3*time.Second, 20*time.Millisecond, "adapter never completed an authenticated CDC request")
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Token request: refresh_token grant with HTTP Basic client credentials.
+	assert.Equal(t, "refresh_token", tokenGrant)
+	// base64("test-client-id:test-client-secret")
+	assert.Equal(t, "Basic dGVzdC1jbGllbnQtaWQ6dGVzdC1jbGllbnQtc2VjcmV0", tokenAuth)
+	// CDC request shape.
+	assert.Equal(t, http.MethodGet, cdcMethod)
+	assert.Equal(t, "/v3/company/1234567890/cdc", cdcPath)
+	assert.Equal(t, "Bearer AT-1", cdcAuth)
+	assert.Equal(t, "application/json", cdcAccept)
+	assert.Equal(t, "Customer,Invoice", cdcQuery.Get("entities"))
+	assert.Equal(t, "75", cdcQuery.Get("minorversion"))
+	assert.NotEmpty(t, cdcQuery.Get("changedSince"), "changedSince must be sent")
+	_, perr := time.Parse(time.RFC3339, cdcQuery.Get("changedSince"))
+	assert.NoError(t, perr, "changedSince must be RFC3339")
+}

--- a/quickbooks/mock_test.go
+++ b/quickbooks/mock_test.go
@@ -1,0 +1,590 @@
+package usp_quickbooks
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock QuickBooks Online
+// API -- the OAuth token endpoint and the ChangeDataCapture endpoint -- and
+// captures the exact messages it ships so their content (entity type as event
+// type, timestamp from MetaData.LastUpdatedTime, and verbatim payload) can be
+// asserted.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock QuickBooks Online API ---------------------------------------------
+
+const (
+	mockClientID     = "test-client-id"
+	mockClientSecret = "test-client-secret"
+	mockRefreshToken = "test-refresh-token"
+	mockRealmID      = "1234567890"
+)
+
+// mockQuickBooks stands in for the QBO OAuth + CDC surface. It mints
+// counter-numbered access tokens (so re-mints are observable), validates the
+// bearer token on CDC, and serves per-entity datasets filtered by changedSince.
+type mockQuickBooks struct {
+	mu sync.Mutex
+
+	datasets map[string][]utils.Dict // entity type -> records
+
+	tokensIssued int
+	activeToken  string
+
+	// rejectTokensBefore makes the CDC endpoint answer 401 for any access token
+	// numbered at or below this value, simulating an expired access token and
+	// forcing the adapter to refresh.
+	rejectTokensBefore int
+
+	tokenRequests int
+	cdcRequests   int
+
+	// failTokenStatus, when non-zero, makes the token endpoint return that
+	// status instead of issuing a token (e.g. 400 invalid_grant).
+	failTokenStatus int
+}
+
+func newMockQuickBooks() *mockQuickBooks {
+	return &mockQuickBooks{datasets: map[string][]utils.Dict{}}
+}
+
+func (m *mockQuickBooks) setDataset(entityType string, records []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.datasets[entityType] = records
+}
+
+// appendRecord adds a record to an entity's dataset, as the API would when a
+// new change occurs.
+func (m *mockQuickBooks) appendRecord(entityType string, record utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.datasets[entityType] = append(m.datasets[entityType], record)
+}
+
+func (m *mockQuickBooks) counts() (tokens, cdc int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests, m.cdcRequests
+}
+
+func (m *mockQuickBooks) handler(t *testing.T) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/v1/tokens/bearer", func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.tokenRequests++
+		failStatus := m.failTokenStatus
+		m.mu.Unlock()
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if !assert.NoError(t, r.ParseForm()) {
+			return
+		}
+		// Validate HTTP Basic client credentials.
+		wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(mockClientID+":"+mockClientSecret))
+		if r.Header.Get("Authorization") != wantAuth {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+			return
+		}
+		if r.Form.Get("grant_type") != "refresh_token" || r.Form.Get("refresh_token") != mockRefreshToken {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+			return
+		}
+		if failStatus != 0 {
+			w.WriteHeader(failStatus)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+			return
+		}
+
+		m.mu.Lock()
+		m.tokensIssued++
+		m.activeToken = fmt.Sprintf("AT-%d", m.tokensIssued)
+		token := m.activeToken
+		m.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fmt.Sprintf(
+			`{"access_token":%q,"refresh_token":%q,"token_type":"bearer","expires_in":3600,"x_refresh_token_expires_in":8726400}`,
+			token, mockRefreshToken)))
+	})
+
+	mux.HandleFunc("/v3/company/"+mockRealmID+"/cdc", func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.cdcRequests++
+		m.mu.Unlock()
+
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		auth := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		m.mu.Lock()
+		active := m.activeToken
+		reject := m.tokenRejected(auth)
+		m.mu.Unlock()
+		if auth == "" || auth != active || reject {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"Fault":{"Error":[{"Message":"AuthenticationFailed"}],"type":"AUTHENTICATION"}}`))
+			return
+		}
+
+		changedSince, _ := time.Parse(time.RFC3339, r.URL.Query().Get("changedSince"))
+		entities := strings.Split(r.URL.Query().Get("entities"), ",")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(m.buildCDC(entities, changedSince))
+	})
+	return mux
+}
+
+// tokenRejected reports whether the given access token should be answered with
+// a 401. Caller holds m.mu.
+func (m *mockQuickBooks) tokenRejected(token string) bool {
+	if m.rejectTokensBefore == 0 {
+		return false
+	}
+	var n int
+	if _, err := fmt.Sscanf(token, "AT-%d", &n); err != nil {
+		return false
+	}
+	return n <= m.rejectTokensBefore
+}
+
+// buildCDC renders a CDCResponse for the requested entities, including only
+// records whose LastUpdatedTime is at or after changedSince.
+func (m *mockQuickBooks) buildCDC(entities []string, changedSince time.Time) []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var blocks []map[string]interface{}
+	sortedEntities := append([]string(nil), entities...)
+	sort.Strings(sortedEntities)
+	for _, e := range sortedEntities {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		var matched []utils.Dict
+		for _, rec := range m.datasets[e] {
+			lut := rec.FindOneString("MetaData/LastUpdatedTime")
+			ts, err := time.Parse(time.RFC3339, lut)
+			if err != nil || ts.Before(changedSince) {
+				continue
+			}
+			matched = append(matched, rec)
+		}
+		if len(matched) == 0 {
+			continue
+		}
+		blocks = append(blocks, map[string]interface{}{
+			e:               matched,
+			"startPosition": 1,
+			"maxResults":    len(matched),
+		})
+	}
+	if len(blocks) == 0 {
+		blocks = []map[string]interface{}{{}}
+	}
+
+	env := map[string]interface{}{
+		"CDCResponse": []map[string]interface{}{{"QueryResponse": blocks}},
+		"time":        "2026-05-12T14:10:00Z",
+	}
+	b, _ := json.Marshal(env)
+	return b
+}
+
+// --- realistic fixtures -----------------------------------------------------
+
+// realisticCustomer returns a record shaped like a real QBO Customer, with the
+// nested MetaData and a mix of scalar types.
+func realisticCustomer(id, lut string) utils.Dict {
+	return utils.Dict{
+		"Id":               id,
+		"SyncToken":        "0",
+		"DisplayName":      "Amy's Bird Sanctuary " + id,
+		"Active":           true,
+		"Balance":          239.0,
+		"PrimaryEmailAddr": utils.Dict{"Address": "amy@example.test"},
+		"MetaData": utils.Dict{
+			"CreateTime":      "2024-12-06T16:48:43-08:00",
+			"LastUpdatedTime": lut,
+		},
+	}
+}
+
+// realisticInvoice returns a record shaped like a real QBO Invoice with nested
+// Line items.
+func realisticInvoice(id, lut string) utils.Dict {
+	return utils.Dict{
+		"Id":          id,
+		"SyncToken":   "2",
+		"DocNumber":   "10" + id,
+		"TotalAmt":    362.07,
+		"CustomerRef": utils.Dict{"value": "1", "name": "Amy's Bird Sanctuary"},
+		"Line": []interface{}{
+			utils.Dict{"Id": "1", "Amount": 150.0, "DetailType": "SalesItemLineDetail"},
+			utils.Dict{"Id": "2", "Amount": 212.07, "DetailType": "SalesItemLineDetail"},
+		},
+		"MetaData": utils.Dict{
+			"CreateTime":      "2024-12-06T16:48:43-08:00",
+			"LastUpdatedTime": lut,
+		},
+	}
+}
+
+// deletedInvoice returns a record shaped like a CDC-reported deletion.
+func deletedInvoice(id, lut string) utils.Dict {
+	return utils.Dict{
+		"Id":        id,
+		"SyncToken": "3",
+		"status":    "Deleted",
+		"MetaData":  utils.Dict{"LastUpdatedTime": lut},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func mockConfig(t *testing.T, baseURL string) QuickBooksConfig {
+	t.Helper()
+	return QuickBooksConfig{
+		ClientOptions: testClientOptions(t),
+		ClientID:      mockClientID,
+		ClientSecret:  mockClientSecret,
+		RefreshToken:  mockRefreshToken,
+		RealmID:       mockRealmID,
+		BaseURL:       baseURL,
+		TokenURL:      baseURL + "/oauth2/v1/tokens/bearer",
+		// Reach back far enough that the seeded fixtures (dated in the recent
+		// past) fall inside the very first poll's window.
+		InitialLookback: 24 * time.Hour,
+		PollInterval:    40 * time.Millisecond,
+		Entities:        []string{"Customer", "Invoice"},
+	}
+}
+
+// recentTime renders a timestamp `ago` before now in RFC3339, so fixtures land
+// inside the adapter's change window regardless of when the test runs.
+func recentTime(ago time.Duration) string {
+	return time.Now().Add(-ago).UTC().Format(time.RFC3339)
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestMockCDCEndToEnd drives the adapter against the mock API and asserts the
+// exact events shipped: event type set to the entity type, timestamp parsed
+// from MetaData.LastUpdatedTime, and the payload preserved verbatim (nested
+// objects and arrays included).
+func TestMockCDCEndToEnd(t *testing.T) {
+	mock := newMockQuickBooks()
+	customers := []utils.Dict{
+		realisticCustomer("1", recentTime(50*time.Minute)),
+		realisticCustomer("2", recentTime(40*time.Minute)),
+	}
+	invoices := []utils.Dict{
+		realisticInvoice("130", recentTime(30*time.Minute)),
+	}
+	mock.setDataset("Customer", customers)
+	mock.setDataset("Invoice", invoices)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newQuickBooksAdapter(ctx, mockConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 changed entities to ship")
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "changes were re-shipped on a later poll")
+
+	byType := map[string]int{}
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		byType[msg.EventType]++
+		require.NotNil(t, msg.JsonPayload)
+		byID[msg.EventType+"/"+utils.Dict(msg.JsonPayload).FindOneString("Id")] = msg
+	}
+	assert.Equal(t, map[string]int{"Customer": 2, "Invoice": 1}, byType)
+
+	// Every fixture shipped verbatim, with its event time taken from MetaData.
+	for _, want := range append(append([]utils.Dict{}, customers...), invoices...) {
+		entityType := "Customer"
+		if _, ok := want["DocNumber"]; ok {
+			entityType = "Invoice"
+		}
+		msg := byID[entityType+"/"+want.FindOneString("Id")]
+		require.NotNil(t, msg, "record %s/%s not shipped", entityType, want.FindOneString("Id"))
+
+		ts, perr := time.Parse(time.RFC3339, want.FindOneString("MetaData/LastUpdatedTime"))
+		require.NoError(t, perr)
+		assert.Equal(t, uint64(ts.UnixMilli()), msg.TimestampMs,
+			"event time must come from MetaData.LastUpdatedTime")
+		assert.JSONEq(t, mustJSON(t, want), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original QBO entity")
+	}
+}
+
+// TestMockNewChangeShippedOnce verifies a change that appears mid-run is shipped
+// exactly once, and already-shipped changes are never re-sent.
+func TestMockNewChangeShippedOnce(t *testing.T) {
+	mock := newMockQuickBooks()
+	mock.setDataset("Customer", []utils.Dict{
+		realisticCustomer("1", recentTime(50*time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newQuickBooksAdapter(ctx, mockConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new change appears: a brand-new invoice.
+	mock.appendRecord("Invoice", realisticInvoice("200", recentTime(1*time.Second)))
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "the new change should ship")
+	require.Never(t, func() bool { return sink.count() > 2 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerKey := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerKey[msg.EventType+"/"+utils.Dict(msg.JsonPayload).FindOneString("Id")]++
+	}
+	assert.Equal(t, map[string]int{"Customer/1": 1, "Invoice/200": 1}, shippedPerKey,
+		"every change must ship exactly once")
+}
+
+// TestMockUpdatedEntityReship verifies that when an entity changes again (a new
+// MetaData.LastUpdatedTime), the new revision is shipped as a fresh event even
+// though the Id is unchanged.
+func TestMockUpdatedEntityReship(t *testing.T) {
+	mock := newMockQuickBooks()
+	mock.setDataset("Customer", []utils.Dict{
+		realisticCustomer("7", recentTime(50*time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newQuickBooksAdapter(ctx, mockConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond)
+
+	// Same Id, newer LastUpdatedTime: the customer was edited again.
+	mock.setDataset("Customer", []utils.Dict{
+		realisticCustomer("7", recentTime(1*time.Second)),
+	})
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "a new revision of the same entity should ship")
+
+	ids := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		ids[utils.Dict(msg.JsonPayload).FindOneString("Id")]++
+	}
+	assert.Equal(t, 2, ids["7"], "both revisions of customer 7 should ship")
+}
+
+// TestMockDeletedEntity verifies a CDC-reported deletion (status="Deleted") is
+// collected and shipped, tagged with its entity type.
+func TestMockDeletedEntity(t *testing.T) {
+	mock := newMockQuickBooks()
+	mock.setDataset("Invoice", []utils.Dict{
+		deletedInvoice("404", recentTime(10*time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newQuickBooksAdapter(ctx, mockConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the deletion should ship")
+
+	msg := sink.snapshot()[0]
+	assert.Equal(t, "Invoice", msg.EventType)
+	assert.Equal(t, "Deleted", utils.Dict(msg.JsonPayload).FindOneString("status"))
+	assert.Equal(t, "404", utils.Dict(msg.JsonPayload).FindOneString("Id"))
+}
+
+// TestMockAccessTokenRefreshOn401 verifies the adapter transparently re-mints
+// its access token when the API rejects it with a 401, then succeeds.
+func TestMockAccessTokenRefreshOn401(t *testing.T) {
+	mock := newMockQuickBooks()
+	// Reject the first issued token (AT-1) on CDC, forcing a refresh to AT-2.
+	mock.rejectTokensBefore = 1
+	mock.setDataset("Customer", []utils.Dict{
+		realisticCustomer("1", recentTime(10*time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, chStopped, err := newQuickBooksAdapter(ctx, mockConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the change should ship after a token refresh")
+
+	// The adapter must not have stopped: a 401 is recoverable via refresh.
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped on a recoverable 401 instead of refreshing")
+	default:
+	}
+
+	tokens, _ := mock.counts()
+	assert.GreaterOrEqual(t, tokens, 2, "expected at least an initial mint plus one refresh")
+}
+
+// TestMockBadCredentialsStops verifies the adapter stops, and ships nothing,
+// when the token endpoint permanently rejects the refresh token.
+func TestMockBadCredentialsStops(t *testing.T) {
+	mock := newMockQuickBooks()
+	mock.failTokenStatus = http.StatusBadRequest // invalid_grant
+	mock.setDataset("Customer", []utils.Dict{
+		realisticCustomer("1", recentTime(10*time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, chStopped, err := newQuickBooksAdapter(ctx, mockConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	select {
+	case <-chStopped:
+		// Expected: a dead refresh token stops the adapter.
+	case <-time.After(3 * time.Second):
+		t.Fatal("adapter should stop when the refresh token is rejected")
+	}
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	tokens, _ := mock.counts()
+	assert.GreaterOrEqual(t, tokens, 1, "the adapter should have attempted a token refresh")
+}
+
+// TestMockMultiPollNoGap verifies the rolling-window cursor advances and the
+// deduper keeps each change to exactly one shipment across many polls.
+func TestMockMultiPollNoGap(t *testing.T) {
+	mock := newMockQuickBooks()
+	mock.setDataset("Customer", []utils.Dict{
+		realisticCustomer("1", recentTime(30*time.Minute)),
+		realisticCustomer("2", recentTime(20*time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newQuickBooksAdapter(ctx, mockConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// Let several more polls run; the overlap re-fetches these records every
+	// poll, but the deduper must keep the total at 2.
+	require.Never(t, func() bool { return sink.count() != 2 },
+		500*time.Millisecond, 40*time.Millisecond, "overlapping polls must not re-ship")
+
+	_, cdc := mock.counts()
+	assert.GreaterOrEqual(t, cdc, 3, "several polls should have run")
+}


### PR DESCRIPTION
## Summary

Adds a new `quickbooks` USP adapter that collects change/activity data from a **QuickBooks Online** company via the Accounting API's **ChangeDataCapture (CDC)** operation, over OAuth 2.0.

### Important scoping note
QuickBooks Online's user-attributed **"Audit Log"** (the *Settings → Audit Log* UI feature showing who did what) is **not exposed through any public Intuit API** — Intuit confirms this repeatedly; it's an internal report only available in the web UI. The authoritative *programmatic* source of activity is **ChangeDataCapture**, which returns the full current state of every entity that changed since a timestamp, including deletions (`status: "Deleted"`). It tells you *what changed and when*, not the acting user or a field-level diff. The README is explicit about this so operators have correct expectations.

Authoritative sources used:
- [ChangeDataCapture API reference](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/changedatacapture)
- [CDC overview](https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/change-data-capture)
- [OAuth 2.0 docs](https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0)

## How it works
- **Auth:** OAuth 2.0 refresh-token grant (HTTP Basic client creds → token endpoint). Access tokens (1h) are refreshed transparently; a 401 triggers a one-shot refresh-and-retry; rotated refresh tokens are adopted in-memory; a permanently rejected refresh token stops the adapter with a clear credential error.
- **Polling:** one CDC request per poll over a rolling `[since - overlap, now]` window; the high-water mark advances only on success. An in-memory deduper keyed on `entityType|Id|LastUpdatedTime` gives exactly-once delivery across the overlap while still re-emitting when an object is edited again.
- **QBO constraints handled:** clamps to CDC's 30-day horizon (with a warning), warns on the 1000-object response cap, and retries 429/5xx with exponential backoff.
- **Config:** configurable entity set (sensible default of 15 core entities), `sandbox`/prod roots, minor-version pin, poll interval, overlap, initial lookback, dedupe TTL, retry tuning. Registered in `containers/conf/all.go` and `containers/general/tool.go`; usage is reflection-generated automatically.

## Tests
`go test ./quickbooks/` (also passing under `-race`):
- **Unit:** CDC response parsing (grouping, deletions, faults, empty/invalid bodies, big-int precision, deterministic ordering), dedupe keying (incl. re-ship on new revision and SyncToken/content-hash fallbacks), config validation/defaults, base/token URL resolution, transient-error classification (incl. `TokenError` wrapping).
- **End-to-end against a mock QBO server** (token + CDC endpoints): verbatim payload shipping with event type = entity type and event time from `MetaData.LastUpdatedTime`, exactly-once delivery, mid-run new change, updated-entity re-ship, deletion capture, transparent 401 token refresh, multi-poll overlap with no re-ship, and credential-failure shutdown.

## Notes for reviewers
- Pattern closely follows the existing `threatlocker` adapter (generic client + adapter + `uspSink` test seam + deduper).
- Draft: opening for review of the CDC-vs-AuditLog approach and the default entity list before finalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)