### PR TITLE
Add Gmail adapter (multi-mailbox email + BEC telemetry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,15 @@ be added purely through configuration. See [threatlocker/README.md](./threatlock
 
 ### Gmail
 
-Collects incoming email as telemetry from a Gmail mailbox via the Gmail REST
-API. It polls `users.messages.list` on a rolling window (default query
+Collects incoming email as telemetry from one or many Gmail mailboxes via the
+Gmail REST API. It polls `users.messages.list` on a rolling window (default query
 `in:inbox`), fetches each newly-seen message, and ships it as a `gmail_message`
-event. Supports both a single-mailbox OAuth refresh token and Google Workspace
-service-account domain-wide delegation. See [gmail/README.md](./gmail/README.md).
+event. It also has opt-in Business-Email-Compromise capabilities (filters,
+forwarding, send-as, delegates, IMAP/POP, vacation, history). Supports a
+single-mailbox OAuth refresh token, or Google Workspace service-account
+domain-wide delegation for one mailbox, an explicit list of mailboxes, or
+auto-discovery of the whole domain — each mailbox shipped to its own sensor. See
+[gmail/README.md](./gmail/README.md).
 
 ```
 ./general gmail client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=gmail client_id=$GMAIL_CLIENT_ID client_secret=$GMAIL_CLIENT_SECRET refresh_token=$GMAIL_REFRESH_TOKEN

--- a/README.md
+++ b/README.md
@@ -130,3 +130,15 @@ be added purely through configuration. See [threatlocker/README.md](./threatlock
 ```
 ./general threatlocker client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=threatlocker api_key=$THREATLOCKER_API_TOKEN instance=g
 ```
+
+### Gmail
+
+Collects incoming email as telemetry from a Gmail mailbox via the Gmail REST
+API. It polls `users.messages.list` on a rolling window (default query
+`in:inbox`), fetches each newly-seen message, and ships it as a `gmail_message`
+event. Supports both a single-mailbox OAuth refresh token and Google Workspace
+service-account domain-wide delegation. See [gmail/README.md](./gmail/README.md).
+
+```
+./general gmail client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=gmail client_id=$GMAIL_CLIENT_ID client_secret=$GMAIL_CLIENT_SECRET refresh_token=$GMAIL_REFRESH_TOKEN
+```

--- a/containers/conf/all.go
+++ b/containers/conf/all.go
@@ -16,6 +16,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/falconcloud"
 	"github.com/refractionPOINT/usp-adapters/file"
 	"github.com/refractionPOINT/usp-adapters/gcs"
+	"github.com/refractionPOINT/usp-adapters/gmail"
 	"github.com/refractionPOINT/usp-adapters/harmony"
 	"github.com/refractionPOINT/usp-adapters/hubspot"
 	"github.com/refractionPOINT/usp-adapters/imap"
@@ -77,6 +78,7 @@ type GeneralConfigs struct {
 	K8sPods           usp_k8s_pods.K8sPodsConfig                      `json:"k8s_pods" yaml:"k8s_pods"`
 	BigQuery          usp_bigquery.BigQueryConfig                     `json:"bigquery" yaml:"bigquery"`
 	Imap              usp_imap.ImapConfig                             `json:"imap" yaml:"imap"`
+	Gmail             usp_gmail.GmailConfig                           `json:"gmail" yaml:"gmail"`
 	HubSpot           usp_hubspot.HubSpotConfig                       `json:"hubspot" yaml:"hubspot"`
 	FalconCloud       usp_falconcloud.FalconCloudConfig               `json:"falconcloud" yaml:"falconcloud"`
 	Harmony           usp_harmony.HarmonyConfig                       `json:"harmony" yaml:"harmony"`

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -30,6 +30,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/falconcloud"
 	"github.com/refractionPOINT/usp-adapters/file"
 	"github.com/refractionPOINT/usp-adapters/gcs"
+	"github.com/refractionPOINT/usp-adapters/gmail"
 	"github.com/refractionPOINT/usp-adapters/harmony"
 	"github.com/refractionPOINT/usp-adapters/hubspot"
 	"github.com/refractionPOINT/usp-adapters/imap"
@@ -433,6 +434,11 @@ func runAdapter(ctx context.Context, method string, configs Configuration, showC
 		configs.Imap.ClientOptions.Architecture = "usp_adapter"
 		configToShow = configs.Imap
 		client, chRunning, err = usp_imap.NewImapAdapter(ctx, configs.Imap)
+	} else if method == "gmail" {
+		configs.Gmail.ClientOptions = applyLogging(configs.Gmail.ClientOptions)
+		configs.Gmail.ClientOptions.Architecture = "usp_adapter"
+		configToShow = configs.Gmail
+		client, chRunning, err = usp_gmail.NewGmailAdapter(ctx, configs.Gmail)
 	} else if method == "hubspot" {
 		configs.HubSpot.ClientOptions = applyLogging(configs.HubSpot.ClientOptions)
 		configs.HubSpot.ClientOptions.Architecture = "usp_adapter"

--- a/gmail/README.md
+++ b/gmail/README.md
@@ -1,0 +1,123 @@
+# Gmail Adapter
+
+Collects incoming email from a Gmail mailbox as telemetry, using the
+[Gmail REST API](https://developers.google.com/gmail/api/reference/rest). It
+polls [`users.messages.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list)
+on a rolling time window, fetches each newly-seen message with
+[`users.messages.get`](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/get),
+and ships it to LimaCharlie as a `gmail_message` event. The full message
+resource (the nested `payload` with headers, body, and parts) is forwarded
+verbatim.
+
+## How it works
+
+1. Each poll lists message ids matching the configured `query` (default
+   `in:inbox`), with an `after:<epoch>` time bound appended automatically so only
+   recent messages are listed. Listings are paginated.
+2. Each message is fetched at the configured `format` (default `full`).
+3. A deduper keyed on the immutable Gmail message id guarantees each message
+   ships **exactly once**, even though overlapping windows re-list recent ids.
+4. The event timestamp is taken from the message's `internalDate`
+   (epoch milliseconds).
+5. The high-water mark only advances after a fully-successful poll, so a failed
+   poll is re-covered on the next cycle with no gaps.
+
+## Authentication
+
+Choose **one** of two modes.
+
+### 1. OAuth 2.0 refresh token (a single mailbox)
+
+For collecting one user's mailbox. Create an OAuth client (Desktop or Web) in the
+Google Cloud console, enable the Gmail API, and complete the authorization-code
+flow once to obtain a refresh token for the `gmail.readonly` scope.
+
+| Field | Description |
+|-------|-------------|
+| `client_id` | OAuth client id |
+| `client_secret` | OAuth client secret |
+| `refresh_token` | Long-lived refresh token for the mailbox owner |
+
+### 2. Service account with domain-wide delegation (Google Workspace)
+
+For monitoring a Workspace mailbox without per-user consent. Create a service
+account, enable domain-wide delegation, and in the Workspace Admin console
+authorize its client id for the `https://www.googleapis.com/auth/gmail.readonly`
+scope. The adapter signs a JWT assertion impersonating the `subject`.
+
+| Field | Description |
+|-------|-------------|
+| `service_account_credentials` | The service account JSON key, inline |
+| `service_account_file` | Path to the service account JSON key file (alternative to the inline form) |
+| `subject` | The mailbox owner to impersonate, e.g. `user@yourdomain.com` (required) |
+
+## Configuration
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `user_id` | `me` | Mailbox to read (`me` or an email address) |
+| `query` | `in:inbox` | Gmail [search query](https://support.google.com/mail/answer/7190); a time bound is appended automatically — do not add one |
+| `scopes` | `gmail.readonly` | OAuth scopes to request |
+| `format` | `full` | Message detail: `minimal`, `full`, `raw`, or `metadata` |
+| `metadata_headers` | — | Headers to keep when `format` is `metadata` |
+| `label_ids` | — | Only list messages carrying all of these label ids |
+| `include_spam_trash` | `false` | Include SPAM and TRASH messages |
+| `max_results` | `100` | Page size for `messages.list` (max 500) |
+| `poll_interval` | `5m` | Wait between polls |
+| `overlap` | `2m` | Window backdating to avoid gaps from late-indexed mail; re-listed messages are deduped |
+| `initial_lookback` | `0` | On startup, reach back this far to backfill recent mail |
+| `dedupe_ttl` | `168h` (7d) | How long a message id is remembered to suppress re-shipping |
+| `retry_base_delay` | `5s` | Base backoff for transient API failures |
+| `max_retry_delay` | `30s` | Max backoff for transient API failures |
+| `max_retry_attempts` | `3` | Attempts per request before abandoning a poll |
+
+> **Note:** the `gmail.metadata` scope does not allow the `q` search parameter.
+> If you restrict the adapter to that scope, leave `query` empty and rely on
+> `label_ids` / `include_spam_trash` instead.
+
+## Examples
+
+Refresh-token flow (single mailbox), via CLI:
+
+```
+./general gmail \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$IK \
+  client_options.platform=json \
+  client_options.sensor_seed_key=gmail \
+  client_id=$GMAIL_CLIENT_ID \
+  client_secret=$GMAIL_CLIENT_SECRET \
+  refresh_token=$GMAIL_REFRESH_TOKEN \
+  query="in:inbox" \
+  poll_interval=5m
+```
+
+Service-account flow (Workspace), via YAML:
+
+```yaml
+gmail:
+  client_options:
+    identity:
+      oid: 11111111-1111-1111-1111-111111111111
+      installation_key: e9a3bcdf-efa2-47ae-b6df-579a02f3a54d
+    platform: json
+    sensor_seed_key: gmail
+  service_account_file: /secrets/gmail-collector.json
+  subject: soc-mailbox@yourdomain.com
+  user_id: me
+  query: "in:inbox"
+  initial_lookback: 24h
+  poll_interval: 5m
+```
+
+## Error handling
+
+- **401 Unauthorized** — the access token is transparently refreshed once and the
+  request retried.
+- **429 / 5xx / 403 rate-limit** — treated as transient and retried with
+  exponential backoff.
+- **Rejected credentials** (a dead refresh token, a bad service account key, or a
+  delegation/scope problem surfacing as a persistent 401/403) — the adapter stops,
+  since these need operator attention rather than endless retries.
+- **404 on a single message** (deleted between the list and the fetch) — skipped;
+  the poll continues.

--- a/gmail/README.md
+++ b/gmail/README.md
@@ -1,26 +1,78 @@
 # Gmail Adapter
 
-Collects incoming email from a Gmail mailbox as telemetry, using the
-[Gmail REST API](https://developers.google.com/gmail/api/reference/rest). It
-polls [`users.messages.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list)
-on a rolling time window, fetches each newly-seen message with
-[`users.messages.get`](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/get),
-and ships it to LimaCharlie as a `gmail_message` event. The full message
-resource (the nested `payload` with headers, body, and parts) is forwarded
-verbatim.
+Collects telemetry from a Gmail mailbox using the
+[Gmail REST API](https://developers.google.com/gmail/api/reference/rest). Beyond
+incoming-email telemetry, it can collect the mailbox configuration and change
+signals most relevant to **Business Email Compromise (BEC)** — the mail rules,
+forwarding, aliases, delegates, protocol access, and deletions an intruder uses
+to persist, exfiltrate mail, and cover their tracks.
+
+Each signal is an independent, opt-in **capability** that ships its own event
+type. They are all readable with the default `gmail.readonly` scope.
+
+## Capabilities
+
+Enable any combination with the `collect_*` flags below. **If you set none, the
+adapter defaults to message telemetry only** (`collect_messages`), preserving the
+original behavior.
+
+| Flag | Event type(s) | Gmail API | What it gives you / BEC relevance |
+|------|---------------|-----------|-----------------------------------|
+| `collect_messages` | `gmail_message` | [`messages.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list) + [`messages.get`](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/get) | Incoming email as telemetry (the original behavior). The raw signal for phishing/lure detection. |
+| `collect_filters` | `gmail_filter` | [`settings.filters.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.filters/list) | Mail rules. Attackers create rules that auto-delete or auto-forward, or move replies about invoices/wires out of the inbox so the victim never sees them. |
+| `collect_forwarding` | `gmail_forwarding_address`, `gmail_auto_forwarding` | [`settings.forwardingAddresses.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.forwardingAddresses/list), [`settings.getAutoForwarding`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getAutoForwarding) | Forwarding destinations and the account-wide auto-forward toggle. A classic mail-exfiltration vector. |
+| `collect_send_as` | `gmail_send_as` | [`settings.sendAs.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.sendAs/list) | Send-as / "from" identities. An added identity is an impersonation/persistence signal. |
+| `collect_delegates` | `gmail_delegate` | [`settings.delegates.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.delegates/list) | Mailbox delegates. Granting a delegate is persistence. **Workspace only** — see the note below. |
+| `collect_imap_pop` | `gmail_imap`, `gmail_pop` | [`settings.getImap`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getImap), [`settings.getPop`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getPop) | IMAP/POP access. Enabling these allows bulk mailbox download via a desktop client, bypassing browser-session controls. |
+| `collect_vacation` | `gmail_vacation` | [`settings.getVacation`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getVacation) | The vacation responder, occasionally abused for harvesting/social engineering. |
+| `collect_history` | `gmail_history` | [`users.history.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.history/list) | Mailbox changes: message **deletions** and **label changes** (marking a security alert read, trashing the fraud thread) — how an intruder covers their tracks. |
+
+> **Delegates are Workspace-only.** Google exposes
+> `settings.delegates.list` only to service-account clients with domain-wide
+> delegation. On a consumer account (or without delegation) it returns an error,
+> which the adapter logs and skips — it does **not** stop the adapter or affect
+> the other capabilities.
 
 ## How it works
+
+### Message telemetry (`collect_messages`)
 
 1. Each poll lists message ids matching the configured `query` (default
    `in:inbox`), with an `after:<epoch>` time bound appended automatically so only
    recent messages are listed. Listings are paginated.
-2. Each message is fetched at the configured `format` (default `full`).
+2. Each message is fetched at the configured `format` (default `full`). The full
+   message resource (nested `payload` with headers, body, and parts) is forwarded
+   verbatim.
 3. A deduper keyed on the immutable Gmail message id guarantees each message
    ships **exactly once**, even though overlapping windows re-list recent ids.
 4. The event timestamp is taken from the message's `internalDate`
    (epoch milliseconds).
 5. The high-water mark only advances after a fully-successful poll, so a failed
    poll is re-covered on the next cycle with no gaps.
+
+### Configuration-state capabilities (filters, forwarding, send-as, delegates, imap/pop, vacation)
+
+These are **change-only**: an item is shipped when it first appears or its
+content changes, and suppressed otherwise. Change detection reuses the deduper,
+keyed on a hash of the item's content, so the steady state is not re-shipped on
+every poll — what you see is the *appearance or modification* of a rule, address,
+alias, or delegate. They poll on the slower `settings_poll_interval` (default
+15m), since configuration changes rarely.
+
+> On adapter restart the in-memory deduper is empty, so the current state is
+> re-emitted once as a fresh baseline. Write detections against the state of these
+> events rather than treating every event as a brand-new change.
+
+### Mailbox history (`collect_history`)
+
+On the first run the adapter records a baseline `historyId` from the mailbox
+profile and ships nothing (there is no prior state to diff). Each later poll lists
+[`users.history.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.history/list)
+forward from the cursor — filtered to `messageDeleted`, `labelAdded`, and
+`labelRemoved` (new mail is already covered by `collect_messages`) — ships each
+record, and advances the cursor only after a fully-successful pass. Gmail retains
+history for roughly a week; if the cursor ages out (a 404), the adapter
+re-baselines and resumes rather than stopping.
 
 ## Authentication
 
@@ -53,6 +105,22 @@ scope. The adapter signs a JWT assertion impersonating the `subject`.
 
 ## Configuration
 
+### Capability toggles
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `collect_messages` | on when no capability is set | Ship incoming email as `gmail_message` |
+| `collect_filters` | `false` | Ship mail filters/rules as `gmail_filter` |
+| `collect_forwarding` | `false` | Ship `gmail_forwarding_address` + `gmail_auto_forwarding` |
+| `collect_send_as` | `false` | Ship send-as aliases as `gmail_send_as` |
+| `collect_delegates` | `false` | Ship delegates as `gmail_delegate` (Workspace only) |
+| `collect_imap_pop` | `false` | Ship IMAP/POP access as `gmail_imap` / `gmail_pop` |
+| `collect_vacation` | `false` | Ship the vacation responder as `gmail_vacation` |
+| `collect_history` | `false` | Ship deletions/label changes as `gmail_history` |
+| `settings_poll_interval` | `15m` | Cadence for the configuration-state capabilities (messages and history poll on `poll_interval`) |
+
+### Collection knobs
+
 | Field | Default | Description |
 |-------|---------|-------------|
 | `user_id` | `me` | Mailbox to read (`me` or an email address) |
@@ -73,7 +141,10 @@ scope. The adapter signs a JWT assertion impersonating the `subject`.
 
 > **Note:** the `gmail.metadata` scope does not allow the `q` search parameter.
 > If you restrict the adapter to that scope, leave `query` empty and rely on
-> `label_ids` / `include_spam_trash` instead.
+> `label_ids` / `include_spam_trash` instead. The default `gmail.readonly` scope
+> covers every capability, including all the settings/history reads; the narrower
+> `gmail.metadata` scope cannot read the settings sub-resources, so a capability
+> using them will be logged and skipped.
 
 ## Examples
 
@@ -110,6 +181,50 @@ gmail:
   poll_interval: 5m
 ```
 
+BEC monitoring of a Workspace mailbox — telemetry plus the persistence,
+exfiltration, and tamper signals, all on (delegates requires the service-account
+flow):
+
+```yaml
+gmail:
+  client_options:
+    identity:
+      oid: 11111111-1111-1111-1111-111111111111
+      installation_key: e9a3bcdf-efa2-47ae-b6df-579a02f3a54d
+    platform: json
+    sensor_seed_key: gmail
+  service_account_file: /secrets/gmail-collector.json
+  subject: soc-mailbox@yourdomain.com
+  collect_messages: true
+  collect_filters: true
+  collect_forwarding: true
+  collect_send_as: true
+  collect_delegates: true
+  collect_imap_pop: true
+  collect_vacation: true
+  collect_history: true
+  poll_interval: 5m
+  settings_poll_interval: 15m
+```
+
+BEC signals only (no message telemetry) for a single mailbox, via CLI — set the
+BEC flags and leave `collect_messages` unset/false:
+
+```
+./general gmail \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$IK \
+  client_options.platform=json \
+  client_options.sensor_seed_key=gmail \
+  client_id=$GMAIL_CLIENT_ID \
+  client_secret=$GMAIL_CLIENT_SECRET \
+  refresh_token=$GMAIL_REFRESH_TOKEN \
+  collect_filters=true \
+  collect_forwarding=true \
+  collect_send_as=true \
+  collect_history=true
+```
+
 ## Error handling
 
 - **401 Unauthorized** — the access token is transparently refreshed once and the
@@ -121,3 +236,11 @@ gmail:
   since these need operator attention rather than endless retries.
 - **404 on a single message** (deleted between the list and the fetch) — skipped;
   the poll continues.
+- **A BEC capability failing** (e.g. `delegates` on a consumer account, or a
+  settings sub-resource unreadable under the chosen scope) — logged as a warning
+  and skipped for that cycle. It does **not** stop the adapter or affect the other
+  capabilities. A genuine credential rejection (a 401 / dead token) still stops
+  the adapter, as it does for message collection.
+- **404 on `users.history.list`** (the cursor aged out of Gmail's ~1 week
+  retained history) — the adapter re-baselines from the current mailbox state and
+  resumes on the next cycle.

--- a/gmail/README.md
+++ b/gmail/README.md
@@ -143,7 +143,11 @@ Enumerate the Workspace domain's mailboxes via the Admin SDK
 [Directory API `users.list`](https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list),
 re-run on `discovery_interval` so newly-provisioned mailboxes are picked up and
 deprovisioned ones are dropped automatically (their collector is stopped and torn
-down). Suspended/archived accounts are skipped unless `include_suspended` is set.
+down). Suspended accounts are skipped unless `include_suspended` is set. If a
+discovery pass comes back empty or truncated while mailboxes are already being
+collected, the current set is **kept** (and a warning logged) rather than torn
+down — a safety net against a misconfigured `discovery_query` or a transient API
+blip.
 
 Discovery has **two extra requirements** beyond the Gmail collection itself:
 
@@ -161,7 +165,7 @@ gmail:
   admin_subject: admin@yourdomain.com
   # customer: my_customer        # default; or restrict to a single domain:
   # domain: yourdomain.com
-  # discovery_query: "orgUnitPath=/Finance"   # optional Directory user filter
+  # discovery_query: "orgUnitPath='/Finance'"   # optional Directory user filter (note the quoting)
   discovery_interval: 1h
 ```
 
@@ -180,7 +184,7 @@ or the explicitly-listed mailboxes.
 | `domain` | — | Restrict discovery to one domain of a multi-domain Workspace |
 | `discovery_query` | — | Optional Directory API user search filter |
 | `discovery_interval` | `1h` | How often discovery re-enumerates |
-| `include_suspended` | `false` | Also collect suspended/archived mailboxes |
+| `include_suspended` | `false` | Also collect suspended mailboxes |
 | `max_concurrent_polls` | `10` | Cap on how many mailboxes poll the Gmail API at once (protects the per-project quota) |
 
 ## Configuration

--- a/gmail/README.md
+++ b/gmail/README.md
@@ -1,6 +1,6 @@
 # Gmail Adapter
 
-Collects telemetry from a Gmail mailbox using the
+Collects telemetry from one or many Gmail mailboxes using the
 [Gmail REST API](https://developers.google.com/workspace/gmail/api/reference/rest). Beyond
 incoming-email telemetry, it can collect the mailbox configuration and change
 signals most relevant to **Business Email Compromise (BEC)** — the mail rules,
@@ -9,6 +9,11 @@ to persist, exfiltrate mail, and cover their tracks.
 
 Each signal is an independent, opt-in **capability** that ships its own event
 type. They are all readable with the default `gmail.readonly` scope.
+
+With the service-account flow the adapter can watch **many mailboxes at once** —
+an explicit list, or every mailbox in a Workspace domain via auto-discovery — and
+ships **each mailbox to its own LimaCharlie sensor**. See
+[Multiple mailboxes](#multiple-mailboxes).
 
 ## Capabilities
 
@@ -101,7 +106,82 @@ scope. The adapter signs a JWT assertion impersonating the `subject`.
 |-------|-------------|
 | `service_account_credentials` | The service account JSON key, inline |
 | `service_account_file` | Path to the service account JSON key file (alternative to the inline form) |
-| `subject` | The mailbox owner to impersonate, e.g. `user@yourdomain.com` (required) |
+| `subject` | A single mailbox owner to impersonate, e.g. `user@yourdomain.com` |
+
+Provide the mailbox(es) with `subject` (one), `subjects` (a list), and/or
+`discover_mailboxes` (the whole domain) — see [Multiple mailboxes](#multiple-mailboxes).
+At least one of these is required.
+
+## Multiple mailboxes
+
+The service-account flow can collect more than one mailbox. Each mailbox is
+impersonated independently and **shipped to its own sensor**: when more than one
+mailbox is collected, the sensor seed key is derived as
+`<client_options.sensor_seed_key>/<mailbox-address>` and the sensor hostname is
+set to the mailbox address. (A single explicit `subject` keeps the
+`sensor_seed_key`/hostname you configured, verbatim.)
+
+There are two ways to enumerate mailboxes, and they can be combined (the union is
+collected):
+
+### Static list (`subjects`)
+
+List the mailboxes explicitly. Good for a fixed set of high-value mailboxes.
+
+```yaml
+gmail:
+  service_account_file: /secrets/gmail-collector.json
+  subjects:
+    - ceo@yourdomain.com
+    - cfo@yourdomain.com
+    - ap@yourdomain.com
+```
+
+### Auto-discovery (`discover_mailboxes`)
+
+Enumerate the Workspace domain's mailboxes via the Admin SDK
+[Directory API `users.list`](https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list),
+re-run on `discovery_interval` so newly-provisioned mailboxes are picked up and
+deprovisioned ones are dropped automatically (their collector is stopped and torn
+down). Suspended/archived accounts are skipped unless `include_suspended` is set.
+
+Discovery has **two extra requirements** beyond the Gmail collection itself:
+
+1. **An admin to impersonate** — `admin_subject` must be a Workspace admin user
+   the service account impersonates for the Directory call (the Gmail collection
+   of each discovered mailbox still impersonates that mailbox).
+2. **An extra delegated scope** — in the Workspace Admin console, the service
+   account's client id must additionally be authorized for
+   `https://www.googleapis.com/auth/admin.directory.user.readonly`.
+
+```yaml
+gmail:
+  service_account_file: /secrets/gmail-collector.json
+  discover_mailboxes: true
+  admin_subject: admin@yourdomain.com
+  # customer: my_customer        # default; or restrict to a single domain:
+  # domain: yourdomain.com
+  # discovery_query: "orgUnitPath=/Finance"   # optional Directory user filter
+  discovery_interval: 1h
+```
+
+If a discovery pass fails (e.g. the directory scope is missing), it is logged and
+the current set of mailboxes keeps collecting — discovery never stops the adapter
+or the explicitly-listed mailboxes.
+
+### Multi-mailbox knobs
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `subjects` | — | Static list of mailboxes to impersonate (service-account flow) |
+| `discover_mailboxes` | `false` | Enumerate the domain's mailboxes via the Directory API |
+| `admin_subject` | — | Admin user to impersonate for the Directory API (required with `discover_mailboxes`) |
+| `customer` | `my_customer` | Directory API customer id (mutually exclusive with `domain`) |
+| `domain` | — | Restrict discovery to one domain of a multi-domain Workspace |
+| `discovery_query` | — | Optional Directory API user search filter |
+| `discovery_interval` | `1h` | How often discovery re-enumerates |
+| `include_suspended` | `false` | Also collect suspended/archived mailboxes |
+| `max_concurrent_polls` | `10` | Cap on how many mailboxes poll the Gmail API at once (protects the per-project quota) |
 
 ## Configuration
 
@@ -123,7 +203,7 @@ scope. The adapter signs a JWT assertion impersonating the `subject`.
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `user_id` | `me` | Mailbox to read (`me` or an email address) |
+| `user_id` | `me` | Mailbox path segment for the refresh-token flow (`me` or an email address). Ignored by the service-account flow, where each mailbox is reached as `me` under its own impersonation |
 | `query` | `in:inbox` | Gmail [search query](https://support.google.com/mail/answer/7190); a time bound is appended automatically — do not add one |
 | `scopes` | `gmail.readonly` | OAuth scopes to request |
 | `format` | `full` | Message detail: `minimal`, `full`, `raw`, or `metadata` |
@@ -232,8 +312,13 @@ BEC flags and leave `collect_messages` unset/false:
 - **429 / 5xx / 403 rate-limit** — treated as transient and retried with
   exponential backoff.
 - **Rejected credentials** (a dead refresh token, a bad service account key, or a
-  delegation/scope problem surfacing as a persistent 401/403) — the adapter stops,
-  since these need operator attention rather than endless retries.
+  delegation/scope problem surfacing as a persistent 401/403) — that **mailbox's**
+  collector stops, since it needs operator attention rather than endless retries.
+  Other mailboxes are unaffected (a rejected impersonation for one subject does
+  not imply the others are dead); if every mailbox fails, the adapter winds down.
+- **A discovery pass failing** (e.g. the admin lacks the directory scope) — logged
+  as a warning; the currently-collecting mailboxes (including the static ones)
+  keep running, and discovery retries on the next interval.
 - **404 on a single message** (deleted between the list and the fetch) — skipped;
   the poll continues.
 - **A BEC capability failing** (e.g. `delegates` on a consumer account, or a

--- a/gmail/README.md
+++ b/gmail/README.md
@@ -1,7 +1,7 @@
 # Gmail Adapter
 
 Collects telemetry from a Gmail mailbox using the
-[Gmail REST API](https://developers.google.com/gmail/api/reference/rest). Beyond
+[Gmail REST API](https://developers.google.com/workspace/gmail/api/reference/rest). Beyond
 incoming-email telemetry, it can collect the mailbox configuration and change
 signals most relevant to **Business Email Compromise (BEC)** — the mail rules,
 forwarding, aliases, delegates, protocol access, and deletions an intruder uses
@@ -18,14 +18,14 @@ original behavior.
 
 | Flag | Event type(s) | Gmail API | What it gives you / BEC relevance |
 |------|---------------|-----------|-----------------------------------|
-| `collect_messages` | `gmail_message` | [`messages.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list) + [`messages.get`](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/get) | Incoming email as telemetry (the original behavior). The raw signal for phishing/lure detection. |
-| `collect_filters` | `gmail_filter` | [`settings.filters.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.filters/list) | Mail rules. Attackers create rules that auto-delete or auto-forward, or move replies about invoices/wires out of the inbox so the victim never sees them. |
-| `collect_forwarding` | `gmail_forwarding_address`, `gmail_auto_forwarding` | [`settings.forwardingAddresses.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.forwardingAddresses/list), [`settings.getAutoForwarding`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getAutoForwarding) | Forwarding destinations and the account-wide auto-forward toggle. A classic mail-exfiltration vector. |
-| `collect_send_as` | `gmail_send_as` | [`settings.sendAs.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.sendAs/list) | Send-as / "from" identities. An added identity is an impersonation/persistence signal. |
-| `collect_delegates` | `gmail_delegate` | [`settings.delegates.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.delegates/list) | Mailbox delegates. Granting a delegate is persistence. **Workspace only** — see the note below. |
-| `collect_imap_pop` | `gmail_imap`, `gmail_pop` | [`settings.getImap`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getImap), [`settings.getPop`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getPop) | IMAP/POP access. Enabling these allows bulk mailbox download via a desktop client, bypassing browser-session controls. |
-| `collect_vacation` | `gmail_vacation` | [`settings.getVacation`](https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getVacation) | The vacation responder, occasionally abused for harvesting/social engineering. |
-| `collect_history` | `gmail_history` | [`users.history.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.history/list) | Mailbox changes: message **deletions** and **label changes** (marking a security alert read, trashing the fraud thread) — how an intruder covers their tracks. |
+| `collect_messages` | `gmail_message` | [`messages.list`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/list) + [`messages.get`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/get) | Incoming email as telemetry (the original behavior). The raw signal for phishing/lure detection. |
+| `collect_filters` | `gmail_filter` | [`settings.filters.list`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.filters/list) | Mail rules. Attackers create rules that auto-delete or auto-forward, or move replies about invoices/wires out of the inbox so the victim never sees them. |
+| `collect_forwarding` | `gmail_forwarding_address`, `gmail_auto_forwarding` | [`settings.forwardingAddresses.list`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.forwardingAddresses/list), [`settings.getAutoForwarding`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings/getAutoForwarding) | Forwarding destinations and the account-wide auto-forward toggle. A classic mail-exfiltration vector. |
+| `collect_send_as` | `gmail_send_as` | [`settings.sendAs.list`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.sendAs/list) | Send-as / "from" identities. An added identity is an impersonation/persistence signal. |
+| `collect_delegates` | `gmail_delegate` | [`settings.delegates.list`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.delegates/list) | Mailbox delegates. Granting a delegate is persistence. **Workspace only** — see the note below. |
+| `collect_imap_pop` | `gmail_imap`, `gmail_pop` | [`settings.getImap`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings/getImap), [`settings.getPop`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings/getPop) | IMAP/POP access. Enabling these allows bulk mailbox download via a desktop client, bypassing browser-session controls. |
+| `collect_vacation` | `gmail_vacation` | [`settings.getVacation`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings/getVacation) | The vacation responder, occasionally abused for harvesting/social engineering. |
+| `collect_history` | `gmail_history` | [`users.history.list`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.history/list) | Mailbox changes: message **deletions** and **label changes** (marking a security alert read, trashing the fraud thread) — how an intruder covers their tracks. |
 
 > **Delegates are Workspace-only.** Google exposes
 > `settings.delegates.list` only to service-account clients with domain-wide
@@ -67,7 +67,7 @@ alias, or delegate. They poll on the slower `settings_poll_interval` (default
 
 On the first run the adapter records a baseline `historyId` from the mailbox
 profile and ships nothing (there is no prior state to diff). Each later poll lists
-[`users.history.list`](https://developers.google.com/gmail/api/reference/rest/v1/users.history/list)
+[`users.history.list`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.history/list)
 forward from the cursor — filtered to `messageDeleted`, `labelAdded`, and
 `labelRemoved` (new mail is already covered by `collect_messages`) — ships each
 record, and advances the cursor only after a fully-successful pass. Gmail retains

--- a/gmail/api.go
+++ b/gmail/api.go
@@ -1,0 +1,188 @@
+package usp_gmail
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// gmailAPIBaseURL is the root of the Gmail REST API. It is overridable through
+// config (BaseURL) so tests can point the client at an httptest server.
+const gmailAPIBaseURL = "https://gmail.googleapis.com"
+
+// messageRef is one entry of a users.messages.list response: just the ids. The
+// full message must be fetched separately with users.messages.get.
+type messageRef struct {
+	ID       string `json:"id"`
+	ThreadID string `json:"threadId"`
+}
+
+// listMessagesResponse mirrors the users.messages.list response envelope.
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list
+type listMessagesResponse struct {
+	Messages           []messageRef `json:"messages"`
+	NextPageToken      string       `json:"nextPageToken"`
+	ResultSizeEstimate int64        `json:"resultSizeEstimate"`
+}
+
+// parseListMessages decodes a users.messages.list response body. An empty body
+// or one with no "messages" field (no matches) yields a zero-value response with
+// no error.
+func parseListMessages(raw []byte) (*listMessagesResponse, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return &listMessagesResponse{}, nil
+	}
+	var resp listMessagesResponse
+	if err := json.Unmarshal([]byte(trimmed), &resp); err != nil {
+		return nil, fmt.Errorf("invalid list JSON: %v", err)
+	}
+	return &resp, nil
+}
+
+// GmailClient is a thin wrapper over the Gmail REST API. It owns no token
+// lifecycle of its own -- it asks its tokenSource for a bearer token on each
+// request and, on a 401, forces a single refresh-and-retry so an access token
+// that expired between two polls does not surface as an error.
+type GmailClient struct {
+	baseURL    string
+	userID     string
+	ts         *tokenSource
+	httpClient *http.Client
+}
+
+// NewGmailClient builds a client. baseURL is the API root (e.g.
+// "https://gmail.googleapis.com"); userID is the mailbox to read ("me" for the
+// authenticated/impersonated user, or an email address).
+func NewGmailClient(baseURL, userID string, ts *tokenSource, httpClient *http.Client) *GmailClient {
+	return &GmailClient{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		userID:     userID,
+		ts:         ts,
+		httpClient: httpClient,
+	}
+}
+
+// listMessagesParams bundles the query knobs for ListMessages.
+type listMessagesParams struct {
+	query            string
+	pageToken        string
+	maxResults       int
+	includeSpamTrash bool
+	labelIDs         []string
+}
+
+// ListMessages issues a users.messages.list request and returns the raw
+// response body. The caller parses it (parseListMessages) so the request and
+// retry concerns stay separate from decoding.
+func (c *GmailClient) ListMessages(ctx context.Context, p listMessagesParams) ([]byte, error) {
+	q := url.Values{}
+	if p.query != "" {
+		q.Set("q", p.query)
+	}
+	if p.maxResults > 0 {
+		q.Set("maxResults", fmt.Sprintf("%d", p.maxResults))
+	}
+	if p.pageToken != "" {
+		q.Set("pageToken", p.pageToken)
+	}
+	if p.includeSpamTrash {
+		q.Set("includeSpamTrash", "true")
+	}
+	for _, l := range p.labelIDs {
+		q.Add("labelIds", l)
+	}
+
+	reqURL := fmt.Sprintf("%s/gmail/v1/users/%s/messages", c.baseURL, url.PathEscape(c.userID))
+	if encoded := q.Encode(); encoded != "" {
+		reqURL += "?" + encoded
+	}
+	return c.do(ctx, http.MethodGet, reqURL)
+}
+
+// GetMessage issues a users.messages.get request for one message id and returns
+// the raw response body. format is one of minimal/full/raw/metadata;
+// metadataHeaders restricts the headers returned when format is "metadata".
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.messages/get
+func (c *GmailClient) GetMessage(ctx context.Context, id, format string, metadataHeaders []string) ([]byte, error) {
+	q := url.Values{}
+	if format != "" {
+		q.Set("format", format)
+	}
+	for _, h := range metadataHeaders {
+		q.Add("metadataHeaders", h)
+	}
+
+	reqURL := fmt.Sprintf("%s/gmail/v1/users/%s/messages/%s",
+		c.baseURL, url.PathEscape(c.userID), url.PathEscape(id))
+	if encoded := q.Encode(); encoded != "" {
+		reqURL += "?" + encoded
+	}
+	return c.do(ctx, http.MethodGet, reqURL)
+}
+
+// do executes a request, transparently refreshing the access token once if the
+// API answers 401.
+func (c *GmailClient) do(ctx context.Context, method, reqURL string) ([]byte, error) {
+	body, err := c.doOnce(ctx, method, reqURL, false)
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized {
+		return c.doOnce(ctx, method, reqURL, true)
+	}
+	return body, err
+}
+
+func (c *GmailClient) doOnce(ctx context.Context, method, reqURL string, forceToken bool) ([]byte, error) {
+	token, err := c.ts.Token(ctx, forceToken)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request %q: %v", reqURL, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request %q: %v", reqURL, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response %q: %v", reqURL, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseHTTPError(resp.StatusCode, reqURL, string(respBody))
+	}
+	return respBody, nil
+}
+
+// Close releases idle connections held by the underlying transport.
+func (c *GmailClient) Close() {
+	c.httpClient.CloseIdleConnections()
+}
+
+// newAPIHTTPClient builds the HTTP client used for Gmail API requests.
+func newAPIHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 60 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{Timeout: 10 * time.Second}).Dial,
+		},
+	}
+}

--- a/gmail/api.go
+++ b/gmail/api.go
@@ -27,7 +27,7 @@ type messageRef struct {
 // listMessagesResponse mirrors the users.messages.list response envelope.
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/list
 type listMessagesResponse struct {
 	Messages           []messageRef `json:"messages"`
 	NextPageToken      string       `json:"nextPageToken"`
@@ -114,7 +114,7 @@ func (c *GmailClient) ListMessages(ctx context.Context, p listMessagesParams) ([
 // metadataHeaders restricts the headers returned when format is "metadata".
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.messages/get
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/get
 func (c *GmailClient) GetMessage(ctx context.Context, id, format string, metadataHeaders []string) ([]byte, error) {
 	q := url.Values{}
 	if format != "" {
@@ -146,7 +146,7 @@ func (c *GmailClient) settingsBaseURL() string {
 // ListFilters issues a users.settings.filters.list request.
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.settings.filters/list
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.filters/list
 func (c *GmailClient) ListFilters(ctx context.Context) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/filters")
 }
@@ -154,7 +154,7 @@ func (c *GmailClient) ListFilters(ctx context.Context) ([]byte, error) {
 // ListForwardingAddresses issues a users.settings.forwardingAddresses.list request.
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.settings.forwardingAddresses/list
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.forwardingAddresses/list
 func (c *GmailClient) ListForwardingAddresses(ctx context.Context) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/forwardingAddresses")
 }
@@ -162,7 +162,7 @@ func (c *GmailClient) ListForwardingAddresses(ctx context.Context) ([]byte, erro
 // GetAutoForwarding issues a users.settings.getAutoForwarding request.
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getAutoForwarding
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings/getAutoForwarding
 func (c *GmailClient) GetAutoForwarding(ctx context.Context) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/autoForwarding")
 }
@@ -170,7 +170,7 @@ func (c *GmailClient) GetAutoForwarding(ctx context.Context) ([]byte, error) {
 // ListSendAs issues a users.settings.sendAs.list request.
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.settings.sendAs/list
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.sendAs/list
 func (c *GmailClient) ListSendAs(ctx context.Context) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/sendAs")
 }
@@ -179,7 +179,7 @@ func (c *GmailClient) ListSendAs(ctx context.Context) ([]byte, error) {
 // this only to service accounts with domain-wide delegation (Workspace).
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.settings.delegates/list
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.delegates/list
 func (c *GmailClient) ListDelegates(ctx context.Context) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/delegates")
 }
@@ -187,7 +187,7 @@ func (c *GmailClient) ListDelegates(ctx context.Context) ([]byte, error) {
 // GetImap issues a users.settings.getImap request.
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getImap
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings/getImap
 func (c *GmailClient) GetImap(ctx context.Context) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/imap")
 }
@@ -195,7 +195,7 @@ func (c *GmailClient) GetImap(ctx context.Context) ([]byte, error) {
 // GetPop issues a users.settings.getPop request.
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getPop
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings/getPop
 func (c *GmailClient) GetPop(ctx context.Context) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/pop")
 }
@@ -203,7 +203,7 @@ func (c *GmailClient) GetPop(ctx context.Context) ([]byte, error) {
 // GetVacation issues a users.settings.getVacation request.
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getVacation
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings/getVacation
 func (c *GmailClient) GetVacation(ctx context.Context) ([]byte, error) {
 	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/vacation")
 }
@@ -212,7 +212,7 @@ func (c *GmailClient) GetVacation(ctx context.Context) ([]byte, error) {
 // historyId for incremental history collection.
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users/getProfile
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users/getProfile
 func (c *GmailClient) GetProfile(ctx context.Context) ([]byte, error) {
 	reqURL := fmt.Sprintf("%s/gmail/v1/users/%s/profile", c.baseURL, url.PathEscape(c.userID))
 	return c.do(ctx, http.MethodGet, reqURL)
@@ -231,7 +231,7 @@ type listHistoryParams struct {
 // body.
 //
 // Reference:
-// https://developers.google.com/gmail/api/reference/rest/v1/users.history/list
+// https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.history/list
 func (c *GmailClient) ListHistory(ctx context.Context, p listHistoryParams) ([]byte, error) {
 	q := url.Values{}
 	if p.startHistoryID != "" {

--- a/gmail/api.go
+++ b/gmail/api.go
@@ -132,6 +132,131 @@ func (c *GmailClient) GetMessage(ctx context.Context, id, format string, metadat
 	return c.do(ctx, http.MethodGet, reqURL)
 }
 
+// --- BEC capability endpoints ----------------------------------------------
+//
+// These read the mailbox's configuration state and change history. All are
+// readable with the default gmail.readonly scope. Each returns the raw response
+// body; the adapter parses and ships it.
+
+// settingsBaseURL is the root of the per-user settings sub-resources.
+func (c *GmailClient) settingsBaseURL() string {
+	return fmt.Sprintf("%s/gmail/v1/users/%s/settings", c.baseURL, url.PathEscape(c.userID))
+}
+
+// ListFilters issues a users.settings.filters.list request.
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.settings.filters/list
+func (c *GmailClient) ListFilters(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/filters")
+}
+
+// ListForwardingAddresses issues a users.settings.forwardingAddresses.list request.
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.settings.forwardingAddresses/list
+func (c *GmailClient) ListForwardingAddresses(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/forwardingAddresses")
+}
+
+// GetAutoForwarding issues a users.settings.getAutoForwarding request.
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getAutoForwarding
+func (c *GmailClient) GetAutoForwarding(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/autoForwarding")
+}
+
+// ListSendAs issues a users.settings.sendAs.list request.
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.settings.sendAs/list
+func (c *GmailClient) ListSendAs(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/sendAs")
+}
+
+// ListDelegates issues a users.settings.delegates.list request. Google exposes
+// this only to service accounts with domain-wide delegation (Workspace).
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.settings.delegates/list
+func (c *GmailClient) ListDelegates(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/delegates")
+}
+
+// GetImap issues a users.settings.getImap request.
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getImap
+func (c *GmailClient) GetImap(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/imap")
+}
+
+// GetPop issues a users.settings.getPop request.
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getPop
+func (c *GmailClient) GetPop(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/pop")
+}
+
+// GetVacation issues a users.settings.getVacation request.
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.settings/getVacation
+func (c *GmailClient) GetVacation(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, c.settingsBaseURL()+"/vacation")
+}
+
+// GetProfile issues a users.getProfile request, used to obtain a baseline
+// historyId for incremental history collection.
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users/getProfile
+func (c *GmailClient) GetProfile(ctx context.Context) ([]byte, error) {
+	reqURL := fmt.Sprintf("%s/gmail/v1/users/%s/profile", c.baseURL, url.PathEscape(c.userID))
+	return c.do(ctx, http.MethodGet, reqURL)
+}
+
+// listHistoryParams bundles the query knobs for ListHistory.
+type listHistoryParams struct {
+	startHistoryID string
+	pageToken      string
+	maxResults     int
+	historyTypes   []string
+	labelID        string
+}
+
+// ListHistory issues a users.history.list request and returns the raw response
+// body.
+//
+// Reference:
+// https://developers.google.com/gmail/api/reference/rest/v1/users.history/list
+func (c *GmailClient) ListHistory(ctx context.Context, p listHistoryParams) ([]byte, error) {
+	q := url.Values{}
+	if p.startHistoryID != "" {
+		q.Set("startHistoryId", p.startHistoryID)
+	}
+	if p.pageToken != "" {
+		q.Set("pageToken", p.pageToken)
+	}
+	if p.maxResults > 0 {
+		q.Set("maxResults", fmt.Sprintf("%d", p.maxResults))
+	}
+	for _, ht := range p.historyTypes {
+		q.Add("historyTypes", ht)
+	}
+	if p.labelID != "" {
+		q.Set("labelId", p.labelID)
+	}
+
+	reqURL := fmt.Sprintf("%s/gmail/v1/users/%s/history", c.baseURL, url.PathEscape(c.userID))
+	if encoded := q.Encode(); encoded != "" {
+		reqURL += "?" + encoded
+	}
+	return c.do(ctx, http.MethodGet, reqURL)
+}
+
 // do executes a request, transparently refreshing the access token once if the
 // API answers 401.
 func (c *GmailClient) do(ctx context.Context, method, reqURL string) ([]byte, error) {

--- a/gmail/auth.go
+++ b/gmail/auth.go
@@ -1,0 +1,376 @@
+package usp_gmail
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// Endpoints and OAuth constants for talking to Google's identity platform.
+const (
+	// googleTokenEndpoint is Google's OAuth 2.0 token endpoint, used for both
+	// the refresh-token grant and the service-account JWT-bearer grant.
+	googleTokenEndpoint = "https://oauth2.googleapis.com/token"
+
+	// jwtBearerGrantType is the RFC 7523 grant used by a service account to
+	// exchange a signed assertion for an access token.
+	jwtBearerGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+	// gmailReadonlyScope is the default OAuth scope: read-only access to the
+	// mailbox, which is all an email-telemetry collector needs.
+	gmailReadonlyScope = "https://www.googleapis.com/auth/gmail.readonly"
+
+	// tokenRefreshBuffer is how long before an access token's stated expiry the
+	// client proactively re-mints it, to avoid racing the boundary.
+	tokenRefreshBuffer = 2 * time.Minute
+
+	// accessTokenFallbackLifetime is assumed when the token endpoint omits
+	// expires_in. Google access tokens live for one hour.
+	accessTokenFallbackLifetime = time.Hour
+
+	// serviceAccountAssertionLifetime is the lifetime of the signed JWT the
+	// service-account flow presents. Google caps this at one hour.
+	serviceAccountAssertionLifetime = time.Hour
+)
+
+// HTTPError represents a non-2xx response from a Google endpoint (the Gmail API
+// or the OAuth token endpoint). It carries the status code and, when the body
+// is a Google API error envelope, the machine-readable reason -- so callers can
+// classify the error (retry vs. give up) without parsing free-text messages.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+	Body       string
+	// Reason is the Google error reason (e.g. "rateLimitExceeded",
+	// "authError"), extracted from the error envelope when present.
+	Reason string
+}
+
+func (e *HTTPError) Error() string {
+	body := e.Body
+	if len(body) > 512 {
+		body = body[:512] + "..."
+	}
+	if e.Reason != "" {
+		return fmt.Sprintf("unexpected status code %d (%s) for %q: %s", e.StatusCode, e.Reason, e.URL, body)
+	}
+	return fmt.Sprintf("unexpected status code %d for %q: %s", e.StatusCode, e.URL, body)
+}
+
+// TokenError wraps a failure to obtain an OAuth access token. It lets the
+// adapter tell a credential problem (fatal) apart from a data-request error,
+// while still allowing isTransientError to see through to the underlying cause
+// (a 5xx/network blip refreshing the token is retryable).
+type TokenError struct{ Err error }
+
+func (e *TokenError) Error() string { return "token request failed: " + e.Err.Error() }
+func (e *TokenError) Unwrap() error { return e.Err }
+
+// transientReasons are Google error reasons that indicate a temporary, ret-able
+// throttling/backend condition even when carried by a 403.
+var transientReasons = map[string]struct{}{
+	"rateLimitExceeded":     {},
+	"userRateLimitExceeded": {},
+	"backendError":          {},
+}
+
+// isTransientError reports whether an error is worth retrying.
+//
+// Transient (retry):
+//   - HTTP 5xx server errors
+//   - HTTP 429 Too Many Requests
+//   - HTTP 403 carrying a rate-limit / backend reason (Gmail signals throttling
+//     this way as well as via 429)
+//   - network errors (timeouts, connection refused, DNS failures, ...)
+//
+// Permanent (do not retry):
+//   - HTTP 4xx other than the above (400, 404, a plain 403 permission denial)
+//   - HTTP 401 is handled separately by the client (a token refresh + retry),
+//     so by the time it surfaces here it is non-transient.
+//   - context cancellation (intentional shutdown)
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 500 && httpErr.StatusCode <= 599 {
+			return true
+		}
+		if httpErr.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+		if httpErr.StatusCode == http.StatusForbidden {
+			_, ok := transientReasons[httpErr.Reason]
+			return ok
+		}
+		return false
+	}
+
+	// Context cancellation is an intentional shutdown, not a transient blip.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Anything that failed before we got a response (DNS, dial, timeout, ...)
+	// is wrapped with this prefix by the request helpers; treat it as transient.
+	if strings.Contains(err.Error(), "failed to execute request") {
+		return true
+	}
+
+	return false
+}
+
+// googleErrorEnvelope mirrors the shape of a Google API JSON error body:
+//
+//	{ "error": { "code": 403, "message": "...", "status": "PERMISSION_DENIED",
+//	             "errors": [ { "reason": "rateLimitExceeded", ... } ] } }
+//
+// The OAuth token endpoint instead returns a flat { "error": "invalid_grant",
+// "error_description": "..." }; parseHTTPError tolerates both.
+type googleErrorEnvelope struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+		Errors  []struct {
+			Reason string `json:"reason"`
+		} `json:"errors"`
+	} `json:"error"`
+}
+
+// parseHTTPError builds an *HTTPError, extracting the Google error reason from
+// the body when it is a structured error envelope.
+func parseHTTPError(statusCode int, reqURL, body string) *HTTPError {
+	e := &HTTPError{StatusCode: statusCode, URL: reqURL, Body: body}
+	var env googleErrorEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		if len(env.Error.Errors) > 0 && env.Error.Errors[0].Reason != "" {
+			e.Reason = env.Error.Errors[0].Reason
+		} else if env.Error.Status != "" {
+			e.Reason = env.Error.Status
+		}
+	}
+	return e
+}
+
+// tokenResponse is the JSON body returned by Google's OAuth 2.0 token endpoint.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"` // access token lifetime, seconds
+	Scope       string `json:"scope"`
+}
+
+// grantFunc returns the application/x-www-form-urlencoded body for a token
+// request. For the refresh-token flow it is constant; for the service-account
+// flow it mints a freshly signed assertion on every call (assertions expire).
+type grantFunc func(ctx context.Context) (url.Values, error)
+
+// tokenSource mints and caches OAuth access tokens. It owns the token lifecycle:
+// it fetches one on first use and silently re-mints it when it nears expiry (or
+// when forced after the API rejects it with a 401). It is safe for concurrent
+// use. The two supported grants -- refresh token and service-account JWT bearer
+// -- differ only in the grantFunc; everything else is shared.
+type tokenSource struct {
+	name       string
+	tokenURL   string
+	grant      grantFunc
+	httpClient *http.Client
+
+	mu     sync.Mutex
+	token  string
+	expiry time.Time
+}
+
+// Token returns a valid access token, minting one if it is missing, within
+// tokenRefreshBuffer of expiry, or when force is set (used after a 401).
+func (s *tokenSource) Token(ctx context.Context, force bool) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !force && s.token != "" && time.Now().Before(s.expiry.Add(-tokenRefreshBuffer)) {
+		return s.token, nil
+	}
+	if err := s.mint(ctx); err != nil {
+		return "", &TokenError{Err: err}
+	}
+	return s.token, nil
+}
+
+// mint performs one token request. The caller must hold s.mu.
+func (s *tokenSource) mint(ctx context.Context) error {
+	form, err := s.grant(ctx)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create token request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request %q: %v", s.tokenURL, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read token response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return parseHTTPError(resp.StatusCode, s.tokenURL, string(respBody))
+	}
+
+	var tok tokenResponse
+	if err := json.Unmarshal(respBody, &tok); err != nil {
+		return fmt.Errorf("failed to parse token response: %v", err)
+	}
+	if tok.AccessToken == "" {
+		return errors.New("token endpoint returned an empty access_token")
+	}
+
+	s.token = tok.AccessToken
+	lifetime := time.Duration(tok.ExpiresIn) * time.Second
+	if lifetime <= 0 {
+		lifetime = accessTokenFallbackLifetime
+	}
+	s.expiry = time.Now().Add(lifetime)
+	return nil
+}
+
+// Close releases idle connections held by the token source's transport.
+func (s *tokenSource) Close() {
+	if s.httpClient != nil {
+		s.httpClient.CloseIdleConnections()
+	}
+}
+
+// newRefreshTokenSource builds a token source for the OAuth 2.0 installed-app /
+// web flow: a long-lived refresh token exchanged for short-lived access tokens.
+// This is the flow for collecting a single user's mailbox.
+func newRefreshTokenSource(tokenURL, clientID, clientSecret, refreshToken string, httpClient *http.Client) *tokenSource {
+	return &tokenSource{
+		name:       "oauth-refresh-token",
+		tokenURL:   tokenURL,
+		httpClient: httpClient,
+		grant: func(context.Context) (url.Values, error) {
+			form := url.Values{}
+			form.Set("grant_type", "refresh_token")
+			form.Set("client_id", clientID)
+			form.Set("client_secret", clientSecret)
+			form.Set("refresh_token", refreshToken)
+			return form, nil
+		},
+	}
+}
+
+// serviceAccountKey holds the fields we use from a Google service-account JSON
+// key file.
+type serviceAccountKey struct {
+	Type         string `json:"type"`
+	ProjectID    string `json:"project_id"`
+	PrivateKeyID string `json:"private_key_id"`
+	PrivateKey   string `json:"private_key"`
+	ClientEmail  string `json:"client_email"`
+	ClientID     string `json:"client_id"`
+	TokenURI     string `json:"token_uri"`
+}
+
+// parseServiceAccountKey decodes a service-account JSON key and its RSA private
+// key.
+func parseServiceAccountKey(raw []byte) (*serviceAccountKey, *rsa.PrivateKey, error) {
+	var k serviceAccountKey
+	if err := json.Unmarshal(raw, &k); err != nil {
+		return nil, nil, fmt.Errorf("invalid service account JSON: %v", err)
+	}
+	if k.ClientEmail == "" {
+		return nil, nil, errors.New("service account JSON is missing client_email")
+	}
+	if k.PrivateKey == "" {
+		return nil, nil, errors.New("service account JSON is missing private_key")
+	}
+	rsaKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(k.PrivateKey))
+	if err != nil {
+		return nil, nil, fmt.Errorf("service account private_key is not a valid RSA PEM key: %v", err)
+	}
+	return &k, rsaKey, nil
+}
+
+// newServiceAccountSource builds a token source for Google Workspace
+// domain-wide delegation: the service account signs a JWT asserting the right to
+// act as `subject` (the mailbox owner) for the requested `scopes`, and exchanges
+// it for an access token. `audience` is the token endpoint the assertion targets.
+func newServiceAccountSource(key *serviceAccountKey, rsaKey *rsa.PrivateKey, subject string, scopes []string, tokenURL string, httpClient *http.Client) *tokenSource {
+	audience := tokenURL
+	return &tokenSource{
+		name:       "service-account-jwt",
+		tokenURL:   tokenURL,
+		httpClient: httpClient,
+		grant: func(context.Context) (url.Values, error) {
+			assertion, err := signServiceAccountAssertion(key, rsaKey, subject, scopes, audience)
+			if err != nil {
+				return nil, err
+			}
+			form := url.Values{}
+			form.Set("grant_type", jwtBearerGrantType)
+			form.Set("assertion", assertion)
+			return form, nil
+		},
+	}
+}
+
+// signServiceAccountAssertion builds and RS256-signs the JWT a service account
+// presents to the token endpoint. `subject`, when set, is the user the service
+// account impersonates via domain-wide delegation.
+//
+// Reference:
+// https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority
+func signServiceAccountAssertion(key *serviceAccountKey, rsaKey *rsa.PrivateKey, subject string, scopes []string, audience string) (string, error) {
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss":   key.ClientEmail,
+		"scope": strings.Join(scopes, " "),
+		"aud":   audience,
+		"iat":   now.Unix(),
+		"exp":   now.Add(serviceAccountAssertionLifetime).Unix(),
+	}
+	if subject != "" {
+		claims["sub"] = subject
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	if key.PrivateKeyID != "" {
+		tok.Header["kid"] = key.PrivateKeyID
+	}
+	signed, err := tok.SignedString(rsaKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign service account assertion: %v", err)
+	}
+	return signed, nil
+}
+
+// newAuthHTTPClient builds the HTTP client used for token requests.
+func newAuthHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{Timeout: 10 * time.Second}).Dial,
+		},
+	}
+}

--- a/gmail/auth_test.go
+++ b/gmail/auth_test.go
@@ -1,0 +1,176 @@
+package usp_gmail
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- service account key parsing --------------------------------------------
+
+func TestParseServiceAccountKey(t *testing.T) {
+	validJSON, _ := generateServiceAccount(t)
+
+	t.Run("parses a valid key and its RSA private key", func(t *testing.T) {
+		key, rsaKey, err := parseServiceAccountKey([]byte(validJSON))
+		require.NoError(t, err)
+		assert.Equal(t, "collector@test-project.iam.gserviceaccount.com", key.ClientEmail)
+		assert.Equal(t, "kid-123", key.PrivateKeyID)
+		require.NotNil(t, rsaKey)
+		require.NoError(t, rsaKey.Validate())
+	})
+
+	t.Run("rejects invalid JSON", func(t *testing.T) {
+		_, _, err := parseServiceAccountKey([]byte("not json"))
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects a key missing client_email", func(t *testing.T) {
+		_, _, err := parseServiceAccountKey([]byte(`{"private_key":"x"}`))
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects a key missing private_key", func(t *testing.T) {
+		_, _, err := parseServiceAccountKey([]byte(`{"client_email":"x@y.test"}`))
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects a non-PEM private_key", func(t *testing.T) {
+		_, _, err := parseServiceAccountKey([]byte(`{"client_email":"x@y.test","private_key":"-----BEGIN PRIVATE KEY-----\nnope\n-----END PRIVATE KEY-----"}`))
+		assert.Error(t, err)
+	})
+}
+
+// --- service account assertion signing --------------------------------------
+
+func TestSignServiceAccountAssertion(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+	key, rsaKey, err := parseServiceAccountKey([]byte(saJSON))
+	require.NoError(t, err)
+
+	verify := func(assertion string) jwt.MapClaims {
+		claims := jwt.MapClaims{}
+		tok, err := jwt.ParseWithClaims(assertion, claims, func(*jwt.Token) (interface{}, error) {
+			return pub, nil
+		})
+		require.NoError(t, err)
+		require.True(t, tok.Valid)
+		return claims
+	}
+
+	t.Run("signs an RS256 assertion carrying the delegation claims", func(t *testing.T) {
+		assertion, err := signServiceAccountAssertion(key, rsaKey, "victim@example.test",
+			[]string{gmailReadonlyScope}, "https://oauth2.googleapis.com/token")
+		require.NoError(t, err)
+
+		claims := verify(assertion)
+		assert.Equal(t, key.ClientEmail, claims["iss"])
+		assert.Equal(t, "victim@example.test", claims["sub"])
+		assert.Equal(t, gmailReadonlyScope, claims["scope"])
+		assert.Equal(t, "https://oauth2.googleapis.com/token", claims["aud"])
+		assert.Contains(t, claims, "iat")
+		assert.Contains(t, claims, "exp")
+
+		// The key id is advertised in the JWT header.
+		parts, _, err := jwt.NewParser().ParseUnverified(assertion, jwt.MapClaims{})
+		require.NoError(t, err)
+		assert.Equal(t, "kid-123", parts.Header["kid"])
+		assert.Equal(t, "RS256", parts.Header["alg"])
+	})
+
+	t.Run("omits the sub claim when no subject is set", func(t *testing.T) {
+		assertion, err := signServiceAccountAssertion(key, rsaKey, "",
+			[]string{gmailReadonlyScope}, "https://oauth2.googleapis.com/token")
+		require.NoError(t, err)
+		claims := verify(assertion)
+		assert.NotContains(t, claims, "sub")
+	})
+}
+
+// --- refresh-token token source ---------------------------------------------
+
+// TestRefreshTokenSource verifies the source posts a well-formed refresh_token
+// grant, caches the access token, and re-mints it on a forced refresh.
+func TestRefreshTokenSource(t *testing.T) {
+	var mu sync.Mutex
+	var gotGrant, gotClientID, gotClientSecret, gotRefresh string
+	hits := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		mu.Lock()
+		hits++
+		gotGrant = r.Form.Get("grant_type")
+		gotClientID = r.Form.Get("client_id")
+		gotClientSecret = r.Form.Get("client_secret")
+		gotRefresh = r.Form.Get("refresh_token")
+		n := hits
+		mu.Unlock()
+		writeJSON(w, http.StatusOK,
+			fmt.Sprintf(`{"access_token":"AT-%d","token_type":"Bearer","expires_in":3600}`, n))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ts := newRefreshTokenSource(server.URL+"/token", "cid", "csec", "rtok", newAuthHTTPClient())
+	defer ts.Close()
+	ctx := context.Background()
+
+	tok, err := ts.Token(ctx, false)
+	require.NoError(t, err)
+	assert.Equal(t, "AT-1", tok)
+
+	mu.Lock()
+	assert.Equal(t, "refresh_token", gotGrant)
+	assert.Equal(t, "cid", gotClientID)
+	assert.Equal(t, "csec", gotClientSecret)
+	assert.Equal(t, "rtok", gotRefresh)
+	mu.Unlock()
+
+	// A second non-forced call is served from cache: no new mint.
+	_, err = ts.Token(ctx, false)
+	require.NoError(t, err)
+	mu.Lock()
+	assert.Equal(t, 1, hits, "cached token must not trigger a new mint")
+	mu.Unlock()
+
+	// A forced call re-mints.
+	_, err = ts.Token(ctx, true)
+	require.NoError(t, err)
+	mu.Lock()
+	assert.Equal(t, 2, hits, "forced refresh must mint a new token")
+	mu.Unlock()
+}
+
+// TestTokenSourceErrorsAreWrapped verifies a non-2xx token response surfaces as
+// a TokenError wrapping an HTTPError, so callers can classify it.
+func TestTokenSourceErrorsAreWrapped(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusBadRequest, `{"error":"invalid_grant"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ts := newRefreshTokenSource(server.URL+"/token", "cid", "csec", "rtok", newAuthHTTPClient())
+	defer ts.Close()
+
+	_, err := ts.Token(context.Background(), false)
+	require.Error(t, err)
+
+	var tokenErr *TokenError
+	require.ErrorAs(t, err, &tokenErr)
+	var httpErr *HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+	// A bad-grant token failure must be classified non-transient (do not retry).
+	assert.False(t, isTransientError(err))
+}

--- a/gmail/bec_test.go
+++ b/gmail/bec_test.go
@@ -1,0 +1,461 @@
+package usp_gmail
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the BEC capabilities: the configuration-state collectors
+// (filters, forwarding, send-as, delegates, imap/pop, vacation) and the mailbox
+// history collector. It extends the mock Gmail API in mock_test.go with the
+// settings, profile and history endpoints.
+
+// --- mock handlers for the BEC endpoints ------------------------------------
+
+// capListHandler serves a settings list endpoint of the shape {"<field>": [...]},
+// honoring any configured status override.
+func (m *mockGmail) capListHandler(pathKey, field string, get func() []utils.Dict) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !m.authorize(w, r) {
+			return
+		}
+		m.mu.Lock()
+		m.capabilityRequests[pathKey]++
+		status := m.statusOverride[pathKey]
+		items := append([]utils.Dict(nil), get()...)
+		m.mu.Unlock()
+
+		if status != 0 {
+			writeJSON(w, status, capErrorBody(status))
+			return
+		}
+		resp := map[string]any{}
+		if len(items) > 0 {
+			resp[field] = items
+		}
+		writeJSON(w, http.StatusOK, mustJSONString(resp))
+	}
+}
+
+// capObjectHandler serves a singleton settings endpoint (the whole body is the
+// resource), honoring any configured status override.
+func (m *mockGmail) capObjectHandler(pathKey string, get func() utils.Dict) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !m.authorize(w, r) {
+			return
+		}
+		m.mu.Lock()
+		m.capabilityRequests[pathKey]++
+		status := m.statusOverride[pathKey]
+		obj := get()
+		m.mu.Unlock()
+
+		if status != 0 {
+			writeJSON(w, status, capErrorBody(status))
+			return
+		}
+		if obj == nil {
+			obj = utils.Dict{}
+		}
+		writeJSON(w, http.StatusOK, mustJSONString(obj))
+	}
+}
+
+// profileHandler serves users.getProfile, reporting the current historyId.
+func (m *mockGmail) profileHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !m.authorize(w, r) {
+			return
+		}
+		m.mu.Lock()
+		m.capabilityRequests["profile"]++
+		hid := m.profileHistoryID
+		m.mu.Unlock()
+		writeJSON(w, http.StatusOK, fmt.Sprintf(
+			`{"emailAddress":%q,"messagesTotal":10,"threadsTotal":8,"historyId":%q}`, mockSubject, hid))
+	}
+}
+
+// historyHandler serves users.history.list, returning the records whose id is
+// strictly greater than startHistoryId, with a top-level historyId that advances
+// the cursor monotonically.
+func (m *mockGmail) historyHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !m.authorize(w, r) {
+			return
+		}
+		startN, _ := strconv.ParseUint(r.URL.Query().Get("startHistoryId"), 10, 64)
+
+		m.mu.Lock()
+		m.capabilityRequests["history"]++
+		status := m.statusOverride["history"]
+		var recs []utils.Dict
+		maxID := startN
+		for _, rec := range m.history {
+			idN, _ := strconv.ParseUint(rec.FindOneString("id"), 10, 64)
+			if idN > startN {
+				recs = append(recs, rec)
+			}
+			if idN > maxID {
+				maxID = idN
+			}
+		}
+		m.mu.Unlock()
+
+		if status != 0 {
+			writeJSON(w, status, capErrorBody(status))
+			return
+		}
+		resp := map[string]any{"historyId": strconv.FormatUint(maxID, 10)}
+		if len(recs) > 0 {
+			resp["history"] = recs
+		}
+		writeJSON(w, http.StatusOK, mustJSONString(resp))
+	}
+}
+
+func capErrorBody(status int) string {
+	return fmt.Sprintf(
+		`{"error":{"code":%d,"message":"simulated","errors":[{"reason":"simulated"}],"status":"ERROR"}}`, status)
+}
+
+func mustJSONString(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// --- mock mutators (used by tests; all lock m.mu) ---------------------------
+
+func (m *mockGmail) setFilters(f ...utils.Dict) { m.mu.Lock(); m.filters = f; m.mu.Unlock() }
+func (m *mockGmail) setForwarding(f ...utils.Dict) {
+	m.mu.Lock()
+	m.forwardingAddresses = f
+	m.mu.Unlock()
+}
+func (m *mockGmail) setSendAs(s ...utils.Dict)      { m.mu.Lock(); m.sendAs = s; m.mu.Unlock() }
+func (m *mockGmail) setDelegates(d ...utils.Dict)   { m.mu.Lock(); m.delegates = d; m.mu.Unlock() }
+func (m *mockGmail) setAutoForwarding(d utils.Dict) { m.mu.Lock(); m.autoForwarding = d; m.mu.Unlock() }
+func (m *mockGmail) setImap(d utils.Dict)           { m.mu.Lock(); m.imap = d; m.mu.Unlock() }
+func (m *mockGmail) setPop(d utils.Dict)            { m.mu.Lock(); m.pop = d; m.mu.Unlock() }
+func (m *mockGmail) setVacation(d utils.Dict)       { m.mu.Lock(); m.vacation = d; m.mu.Unlock() }
+func (m *mockGmail) setProfileHistoryID(id string) {
+	m.mu.Lock()
+	m.profileHistoryID = id
+	m.mu.Unlock()
+}
+func (m *mockGmail) addHistory(recs ...utils.Dict) {
+	m.mu.Lock()
+	m.history = append(m.history, recs...)
+	m.mu.Unlock()
+}
+func (m *mockGmail) overrideStatus(key string, s int) {
+	m.mu.Lock()
+	m.statusOverride[key] = s
+	m.mu.Unlock()
+}
+
+// --- test helpers -----------------------------------------------------------
+
+// becConfig is a refresh-token config pointed at the mock with message
+// collection OFF and fast settings/poll cadences, so a test can enable just the
+// capabilities it exercises. The caller flips the Collect* flags it wants.
+func becConfig(t *testing.T, baseURL string) GmailConfig {
+	t.Helper()
+	c := refreshConfig(t, baseURL)
+	c.CollectMessages = false
+	c.SettingsPollInterval = 25 * time.Millisecond
+	return c
+}
+
+// eventsByType returns the JSON payloads of all shipped events of a given type.
+func eventsByType(msgs []*protocol.DataMessage, evtType string) []utils.Dict {
+	var out []utils.Dict
+	for _, m := range msgs {
+		if m.EventType == evtType {
+			out = append(out, utils.Dict(m.JsonPayload))
+		}
+	}
+	return out
+}
+
+func countByType(sink *captureSink, evtType string) int {
+	return len(eventsByType(sink.snapshot(), evtType))
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestFiltersChangeOnly verifies a mail filter ships once when first seen, is not
+// re-shipped while unchanged, a newly-added filter ships, and an edited filter
+// re-ships (change detection).
+func TestFiltersChangeOnly(t *testing.T) {
+	mock := newMockGmail()
+	f1 := utils.Dict{
+		"id":       "f1",
+		"criteria": utils.Dict{"from": "ceo@company.test"},
+		"action":   utils.Dict{"forward": "attacker@evil.test", "removeLabelIds": []any{"INBOX"}},
+	}
+	mock.setFilters(f1)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := becConfig(t, server.URL)
+	conf.CollectFilters = true
+	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return countByType(sink, eventTypeFilter) == 1 },
+		5*time.Second, 20*time.Millisecond, "the filter should ship once")
+	require.Never(t, func() bool { return countByType(sink, eventTypeFilter) != 1 },
+		300*time.Millisecond, 30*time.Millisecond, "an unchanged filter must not re-ship")
+
+	got := eventsByType(sink.snapshot(), eventTypeFilter)[0]
+	assert.Equal(t, "attacker@evil.test", got.FindOneString("action/forward"),
+		"the filter payload must be preserved verbatim")
+
+	// A second filter appears -> ships (total 2), the first still not re-shipped.
+	f2 := utils.Dict{"id": "f2", "criteria": utils.Dict{"subject": "wire"}, "action": utils.Dict{"addLabelIds": []any{"TRASH"}}}
+	mock.setFilters(f1, f2)
+	require.Eventually(t, func() bool { return countByType(sink, eventTypeFilter) == 2 },
+		5*time.Second, 20*time.Millisecond, "the new filter should ship")
+
+	// The first filter is edited -> its content changed, so it re-ships (total 3).
+	f1edited := utils.Dict{
+		"id":       "f1",
+		"criteria": utils.Dict{"from": "ceo@company.test"},
+		"action":   utils.Dict{"forward": "attacker2@evil.test", "removeLabelIds": []any{"INBOX"}},
+	}
+	mock.setFilters(f1edited, f2)
+	require.Eventually(t, func() bool { return countByType(sink, eventTypeFilter) == 3 },
+		5*time.Second, 20*time.Millisecond, "the edited filter should re-ship")
+	require.Never(t, func() bool { return countByType(sink, eventTypeFilter) > 3 },
+		300*time.Millisecond, 30*time.Millisecond)
+}
+
+// TestForwardingCapability verifies forwarding addresses and the account-wide
+// auto-forwarding setting are both collected under their distinct event types.
+func TestForwardingCapability(t *testing.T) {
+	mock := newMockGmail()
+	mock.setForwarding(utils.Dict{"forwardingEmail": "exfil@evil.test", "verificationStatus": "accepted"})
+	mock.setAutoForwarding(utils.Dict{"enabled": true, "emailAddress": "exfil@evil.test", "disposition": "archive"})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := becConfig(t, server.URL)
+	conf.CollectForwarding = true
+	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		return countByType(sink, eventTypeForwardingAddress) == 1 && countByType(sink, eventTypeAutoForwarding) == 1
+	}, 5*time.Second, 20*time.Millisecond, "forwarding address and auto-forwarding should ship")
+	require.Never(t, func() bool {
+		return countByType(sink, eventTypeForwardingAddress) > 1 || countByType(sink, eventTypeAutoForwarding) > 1
+	}, 300*time.Millisecond, 30*time.Millisecond, "unchanged forwarding state must not re-ship")
+
+	fa := eventsByType(sink.snapshot(), eventTypeForwardingAddress)[0]
+	assert.Equal(t, "exfil@evil.test", fa.FindOneString("forwardingEmail"))
+}
+
+// TestSendAsAndImapPopVacation verifies the send-as, imap, pop and vacation
+// capabilities each ship their resource once.
+func TestSendAsAndImapPopVacation(t *testing.T) {
+	mock := newMockGmail()
+	mock.setSendAs(utils.Dict{"sendAsEmail": "ceo@company.test", "displayName": "CEO", "verificationStatus": "accepted"})
+	mock.setImap(utils.Dict{"enabled": true})
+	mock.setPop(utils.Dict{"accessWindow": "allMail"})
+	mock.setVacation(utils.Dict{"enableAutoReply": false})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := becConfig(t, server.URL)
+	conf.CollectSendAs = true
+	conf.CollectImapPop = true
+	conf.CollectVacation = true
+	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		return countByType(sink, eventTypeSendAs) == 1 &&
+			countByType(sink, eventTypeImap) == 1 &&
+			countByType(sink, eventTypePop) == 1 &&
+			countByType(sink, eventTypeVacation) == 1
+	}, 5*time.Second, 20*time.Millisecond, "send-as, imap, pop and vacation should each ship once")
+
+	sa := eventsByType(sink.snapshot(), eventTypeSendAs)[0]
+	assert.Equal(t, "ceo@company.test", sa.FindOneString("sendAsEmail"))
+}
+
+// TestDelegatesCollection verifies a mailbox delegate is collected once under
+// its event type.
+func TestDelegatesCollection(t *testing.T) {
+	mock := newMockGmail()
+	mock.setDelegates(utils.Dict{"delegateEmail": "attacker@evil.test", "verificationStatus": "accepted"})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := becConfig(t, server.URL)
+	conf.CollectDelegates = true
+	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return countByType(sink, eventTypeDelegate) == 1 },
+		5*time.Second, 20*time.Millisecond, "the delegate should ship once")
+	require.Never(t, func() bool { return countByType(sink, eventTypeDelegate) != 1 },
+		300*time.Millisecond, 30*time.Millisecond, "an unchanged delegate must not re-ship")
+
+	d := eventsByType(sink.snapshot(), eventTypeDelegate)[0]
+	assert.Equal(t, "attacker@evil.test", d.FindOneString("delegateEmail"))
+}
+
+// TestDelegateUnavailableIsNonFatal verifies that a delegates endpoint that
+// answers 403 (the feature is unavailable for the account type) is skipped
+// without stopping the adapter -- a sibling capability keeps collecting.
+func TestDelegateUnavailableIsNonFatal(t *testing.T) {
+	mock := newMockGmail()
+	mock.overrideStatus("settings/delegates", http.StatusForbidden)
+	mock.setFilters(utils.Dict{"id": "f1", "action": utils.Dict{"forward": "x@evil.test"}})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := becConfig(t, server.URL)
+	conf.CollectFilters = true
+	conf.CollectDelegates = true
+	adapter, chStopped, err := newGmailAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return countByType(sink, eventTypeFilter) == 1 },
+		5*time.Second, 20*time.Millisecond, "the filter capability should keep working")
+
+	select {
+	case <-chStopped:
+		t.Fatal("a 403 on the delegates capability must not stop the adapter")
+	case <-time.After(300 * time.Millisecond):
+	}
+	assert.Equal(t, 0, countByType(sink, eventTypeDelegate), "no delegate should ship when the endpoint 403s")
+}
+
+// TestHistoryCollection verifies history baselines silently on first run, then
+// ships deletion/label-change records that occur after the baseline, exactly once.
+func TestHistoryCollection(t *testing.T) {
+	mock := newMockGmail()
+	mock.setProfileHistoryID("1000") // baseline cursor
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := becConfig(t, server.URL)
+	conf.CollectHistory = true
+	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// Let the baseline get established; nothing should ship yet.
+	require.Never(t, func() bool { return countByType(sink, eventTypeHistory) > 0 },
+		300*time.Millisecond, 30*time.Millisecond, "the baseline run must ship no history")
+
+	// An attacker deletes the fraud thread and marks an alert read, after baseline.
+	mock.addHistory(
+		utils.Dict{"id": "1001", "messagesDeleted": []any{utils.Dict{"message": utils.Dict{"id": "m-fraud"}}}},
+		utils.Dict{"id": "1002", "labelsRemoved": []any{utils.Dict{"message": utils.Dict{"id": "m-alert"}, "labelIds": []any{"UNREAD"}}}},
+	)
+
+	require.Eventually(t, func() bool { return countByType(sink, eventTypeHistory) == 2 },
+		5*time.Second, 20*time.Millisecond, "the two post-baseline history records should ship")
+	require.Never(t, func() bool { return countByType(sink, eventTypeHistory) != 2 },
+		300*time.Millisecond, 30*time.Millisecond, "advancing the cursor must prevent re-shipping")
+
+	recs := eventsByType(sink.snapshot(), eventTypeHistory)
+	ids := map[string]bool{}
+	for _, r := range recs {
+		ids[r.FindOneString("id")] = true
+	}
+	assert.True(t, ids["1001"] && ids["1002"], "both history records should be present")
+}
+
+// TestHistoryCursorExpiryReBaselines verifies that a 404 from history.list (the
+// cursor aged out of Gmail's retained history) makes the adapter re-baseline
+// rather than stop.
+func TestHistoryCursorExpiryReBaselines(t *testing.T) {
+	mock := newMockGmail()
+	mock.setProfileHistoryID("1000")
+	mock.overrideStatus("history", http.StatusNotFound)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := becConfig(t, server.URL)
+	conf.CollectHistory = true
+	adapter, chStopped, err := newGmailAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// First cycle baselines (cursor=1000). Add a record so the next list is
+	// attempted; it 404s, the adapter forgets the cursor and re-baselines. It
+	// must stay alive throughout.
+	mock.addHistory(utils.Dict{"id": "1001", "messagesDeleted": []any{utils.Dict{"message": utils.Dict{"id": "m1"}}}})
+
+	select {
+	case <-chStopped:
+		t.Fatal("a 404 (expired cursor) must not stop the adapter")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// Clear the override; after re-baselining, new records ship again.
+	mock.overrideStatus("history", 0)
+	mock.setProfileHistoryID("2000")
+	mock.addHistory(utils.Dict{"id": "2001", "messagesDeleted": []any{utils.Dict{"message": utils.Dict{"id": "m2"}}}})
+	require.Eventually(t, func() bool { return countByType(sink, eventTypeHistory) >= 1 },
+		5*time.Second, 20*time.Millisecond, "history collection should resume after re-baselining")
+}

--- a/gmail/bec_test.go
+++ b/gmail/bec_test.go
@@ -219,7 +219,7 @@ func TestFiltersChangeOnly(t *testing.T) {
 
 	conf := becConfig(t, server.URL)
 	conf.CollectFilters = true
-	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	adapter, _, err := newGmailAdapter(ctx, conf, staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -267,7 +267,7 @@ func TestForwardingCapability(t *testing.T) {
 
 	conf := becConfig(t, server.URL)
 	conf.CollectForwarding = true
-	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	adapter, _, err := newGmailAdapter(ctx, conf, staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -302,7 +302,7 @@ func TestSendAsAndImapPopVacation(t *testing.T) {
 	conf.CollectSendAs = true
 	conf.CollectImapPop = true
 	conf.CollectVacation = true
-	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	adapter, _, err := newGmailAdapter(ctx, conf, staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -332,7 +332,7 @@ func TestDelegatesCollection(t *testing.T) {
 
 	conf := becConfig(t, server.URL)
 	conf.CollectDelegates = true
-	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	adapter, _, err := newGmailAdapter(ctx, conf, staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -363,7 +363,7 @@ func TestDelegateUnavailableIsNonFatal(t *testing.T) {
 	conf := becConfig(t, server.URL)
 	conf.CollectFilters = true
 	conf.CollectDelegates = true
-	adapter, chStopped, err := newGmailAdapter(ctx, conf, sink)
+	adapter, chStopped, err := newGmailAdapter(ctx, conf, staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -393,7 +393,7 @@ func TestHistoryCollection(t *testing.T) {
 
 	conf := becConfig(t, server.URL)
 	conf.CollectHistory = true
-	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	adapter, _, err := newGmailAdapter(ctx, conf, staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -437,7 +437,7 @@ func TestHistoryCursorExpiryReBaselines(t *testing.T) {
 
 	conf := becConfig(t, server.URL)
 	conf.CollectHistory = true
-	adapter, chStopped, err := newGmailAdapter(ctx, conf, sink)
+	adapter, chStopped, err := newGmailAdapter(ctx, conf, staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 

--- a/gmail/capabilities.go
+++ b/gmail/capabilities.go
@@ -1,0 +1,283 @@
+package usp_gmail
+
+// This file implements the BEC (Business Email Compromise) capabilities: the
+// configuration-state collectors (mail filters, forwarding addresses, send-as
+// aliases, delegates, IMAP/POP, vacation responder) and the mailbox change
+// history collector. These complement the message-telemetry collector in
+// client.go.
+//
+// The configuration-state collectors are change-only: an item is shipped when it
+// first appears or its content changes, and suppressed otherwise. This is what
+// surfaces the persistence and exfiltration changes typical of BEC -- an attacker
+// adding an auto-forward rule, a forwarding address, a send-as identity, or a
+// delegate -- without flooding the stream with the steady state on every poll.
+// Change detection reuses the adapter's deduper, keyed on a hash of each item's
+// content, so an unchanged item maps to a key already seen.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	// historyMaxResults is the page size for users.history.list.
+	historyMaxResults = 500
+)
+
+// historyChangeTypes restricts users.history.list to the change kinds that
+// matter for BEC investigation/response: messages permanently deleted, and
+// labels added/removed (e.g. marking a security alert read, or trashing the
+// fraud thread). New-message arrivals are intentionally excluded -- the message
+// telemetry capability already covers those.
+var historyChangeTypes = []string{"messageDeleted", "labelAdded", "labelRemoved"}
+
+// pollSettings runs each enabled configuration-state capability once. A single
+// capability failing (e.g. delegates on a consumer account) does not abort the
+// others.
+func (a *GmailAdapter) pollSettings() {
+	if a.conf.CollectFilters {
+		a.pollListCapability("filters", eventTypeFilter, "filter", "filter", a.client.ListFilters)
+	}
+	if a.doStop.IsSet() {
+		return
+	}
+	if a.conf.CollectForwarding {
+		a.pollListCapability("forwardingAddresses", eventTypeForwardingAddress,
+			"forwardingAddresses", "forwarding", a.client.ListForwardingAddresses)
+		if a.doStop.IsSet() {
+			return
+		}
+		a.pollSingletonCapability("autoForwarding", eventTypeAutoForwarding,
+			"autoforwarding", a.client.GetAutoForwarding)
+	}
+	if a.doStop.IsSet() {
+		return
+	}
+	if a.conf.CollectSendAs {
+		a.pollListCapability("sendAs", eventTypeSendAs, "sendAs", "sendas", a.client.ListSendAs)
+	}
+	if a.doStop.IsSet() {
+		return
+	}
+	if a.conf.CollectDelegates {
+		a.pollListCapability("delegates", eventTypeDelegate, "delegates", "delegate", a.client.ListDelegates)
+	}
+	if a.doStop.IsSet() {
+		return
+	}
+	if a.conf.CollectImapPop {
+		a.pollSingletonCapability("imap", eventTypeImap, "imap", a.client.GetImap)
+		if a.doStop.IsSet() {
+			return
+		}
+		a.pollSingletonCapability("pop", eventTypePop, "pop", a.client.GetPop)
+	}
+	if a.doStop.IsSet() {
+		return
+	}
+	if a.conf.CollectVacation {
+		a.pollSingletonCapability("vacation", eventTypeVacation, "vacation", a.client.GetVacation)
+	}
+}
+
+// pollListCapability runs one list-shaped configuration-state capability: fetch
+// the list, then change-ship each item. listField is the JSON array field in the
+// response (e.g. "filter", "sendAs"); keyPrefix namespaces the dedupe keys.
+func (a *GmailAdapter) pollListCapability(label, evtType, listField, keyPrefix string, fetch func(context.Context) ([]byte, error)) {
+	d, ok := a.fetchCapability(label, fetch)
+	if !ok {
+		return
+	}
+	items, _ := d.GetListOfDict(listField)
+	for _, item := range items {
+		if a.doStop.IsSet() {
+			return
+		}
+		if !a.shipState(evtType, keyPrefix, item) {
+			return
+		}
+	}
+}
+
+// pollSingletonCapability runs one object-shaped configuration-state capability:
+// fetch the single settings object and change-ship it as a whole.
+func (a *GmailAdapter) pollSingletonCapability(label, evtType, keyPrefix string, fetch func(context.Context) ([]byte, error)) {
+	d, ok := a.fetchCapability(label, fetch)
+	if !ok {
+		return
+	}
+	a.shipState(evtType, keyPrefix, d)
+}
+
+// fetchCapability fetches and parses one capability's response, applying the
+// transient-retry backoff and the non-fatal capability error handling. ok is
+// false when the capability should be skipped this cycle.
+func (a *GmailAdapter) fetchCapability(label string, fetch func(context.Context) ([]byte, error)) (utils.Dict, bool) {
+	raw, err := a.withRetry(label, func() ([]byte, error) { return fetch(a.ctx) })
+	if err != nil {
+		a.handleCapabilityError(label, err)
+		return nil, false
+	}
+	parsed, err := utils.UnmarshalCleanJSON(string(raw))
+	if err != nil {
+		a.conf.ClientOptions.OnError(fmt.Errorf("gmail: %s parse error: %v", label, err))
+		return nil, false
+	}
+	return utils.Dict(parsed), true
+}
+
+// shipState ships a configuration-state item under evtType, but only when it is
+// new or its content changed since it was last seen. The dedupe key is keyPrefix
+// plus a hash of the item's content, so an unchanged item on a later poll maps to
+// a key already in the deduper and is suppressed, while any change yields a new
+// key and re-ships. Returns false if the adapter should stop.
+func (a *GmailAdapter) shipState(evtType, keyPrefix string, payload utils.Dict) bool {
+	key := keyPrefix + ":" + contentHash(payload)
+	if a.deduper.CheckAndAdd(key) {
+		return true // unchanged since a recent poll; already shipped
+	}
+	return a.shipEvent(evtType, payload, uint64(time.Now().UnixMilli()))
+}
+
+// contentHash is a stable hash of a decoded JSON object. encoding/json sorts map
+// keys, so two equal objects hash identically regardless of field order.
+func contentHash(d utils.Dict) string {
+	b, err := json.Marshal(d)
+	if err != nil {
+		b = []byte(fmt.Sprintf("%v", d))
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// handleCapabilityError classifies an error from a BEC capability. A genuine
+// authentication failure (a token error, or a 401) stops the adapter, exactly as
+// it does for the message poller -- the credentials need operator attention.
+// Everything else is logged and the capability is skipped for this cycle, leaving
+// the other capabilities running: a feature unavailable for this account type
+// (delegates on a consumer account surfaces as 400/403), a settings scope the
+// token lacks, or a transient blip that outlived its retries.
+func (a *GmailAdapter) handleCapabilityError(label string, err error) {
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+	var tokenErr *TokenError
+	var httpErr *HTTPError
+	if errors.As(err, &tokenErr) ||
+		(errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized) {
+		a.conf.ClientOptions.OnError(fmt.Errorf("gmail: %s failed (credentials rejected): %v", label, err))
+		a.doStop.Set()
+		return
+	}
+	a.conf.ClientOptions.OnWarning(fmt.Sprintf("gmail: %s unavailable, skipping this cycle: %v", label, err))
+}
+
+// pollHistory collects mailbox change records (deletions and label changes) via
+// users.history.list. On the first run it establishes a baseline historyId from
+// the profile and ships nothing -- there is no prior state to diff against. Each
+// later run lists history forward from the cursor, shipping each record, and
+// advances the cursor only after a fully-successful pass (the deduper prevents
+// re-shipping if a pass is re-covered). A 404 means the cursor aged out (Gmail
+// keeps history for roughly a week); the adapter re-baselines and resumes.
+func (a *GmailAdapter) pollHistory() {
+	if a.lastHistoryID == "" {
+		if id, ok := a.fetchHistoryBaseline(); ok {
+			a.lastHistoryID = id
+			a.conf.ClientOptions.DebugLog("gmail: history baseline established at " + id)
+		}
+		return
+	}
+
+	pageToken := ""
+	newCursor := a.lastHistoryID
+	nShipped := 0
+	for page := 0; page < maxPagesPerPoll; page++ {
+		if a.doStop.IsSet() {
+			return
+		}
+
+		raw, err := a.withRetry("history.list", func() ([]byte, error) {
+			return a.client.ListHistory(a.ctx, listHistoryParams{
+				startHistoryID: a.lastHistoryID,
+				pageToken:      pageToken,
+				maxResults:     historyMaxResults,
+				historyTypes:   historyChangeTypes,
+			})
+		})
+		if err != nil {
+			var httpErr *HTTPError
+			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+				// The cursor aged out of Gmail's retained history. Forget it so
+				// the next cycle re-baselines from the current profile.
+				a.conf.ClientOptions.OnWarning("gmail: history cursor expired; re-baselining next cycle")
+				a.lastHistoryID = ""
+				return
+			}
+			a.handleCapabilityError("history.list", err)
+			return
+		}
+
+		parsed, err := utils.UnmarshalCleanJSON(string(raw))
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("gmail: history parse error: %v", err))
+			return
+		}
+		d := utils.Dict(parsed)
+
+		// The top-level historyId is the mailbox's current id; advance the cursor
+		// to it so the next poll starts where this one ended.
+		if hid := d.FindOneString("historyId"); hid != "" {
+			newCursor = hid
+		}
+
+		records, _ := d.GetListOfDict("history")
+		for _, rec := range records {
+			if a.doStop.IsSet() {
+				return
+			}
+			id := rec.FindOneString("id")
+			if id == "" {
+				continue
+			}
+			if a.deduper.CheckAndAdd("history:" + id) {
+				continue
+			}
+			if !a.shipEvent(eventTypeHistory, rec, uint64(time.Now().UnixMilli())) {
+				return
+			}
+			nShipped++
+		}
+
+		pageToken = d.FindOneString("nextPageToken")
+		if pageToken == "" {
+			break
+		}
+	}
+
+	a.lastHistoryID = newCursor
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"gmail: history poll complete (shipped=%d) cursor=%s", nShipped, a.lastHistoryID))
+}
+
+// fetchHistoryBaseline reads the mailbox profile for its current historyId, used
+// as the starting cursor for incremental history collection.
+func (a *GmailAdapter) fetchHistoryBaseline() (string, bool) {
+	d, ok := a.fetchCapability("getProfile", a.client.GetProfile)
+	if !ok {
+		return "", false
+	}
+	id := d.FindOneString("historyId")
+	if id == "" {
+		a.conf.ClientOptions.OnWarning("gmail: profile returned no historyId; will retry next cycle")
+		return "", false
+	}
+	return id, true
+}

--- a/gmail/capabilities.go
+++ b/gmail/capabilities.go
@@ -122,7 +122,7 @@ func (c *mailboxCollector) pollSingletonCapability(label, evtType, keyPrefix str
 // transient-retry backoff and the non-fatal capability error handling. ok is
 // false when the capability should be skipped this cycle.
 func (c *mailboxCollector) fetchCapability(label string, fetch func(context.Context) ([]byte, error)) (utils.Dict, bool) {
-	raw, err := c.withRetry(label, func() ([]byte, error) { return fetch(c.a.ctx) })
+	raw, err := c.withRetry(label, func() ([]byte, error) { return fetch(c.apiCtx) })
 	if err != nil {
 		c.handleCapabilityError(label, err)
 		return nil, false
@@ -207,7 +207,7 @@ func (c *mailboxCollector) pollHistory() {
 		}
 
 		raw, err := c.withRetry("history.list", func() ([]byte, error) {
-			return c.client.ListHistory(c.a.ctx, listHistoryParams{
+			return c.client.ListHistory(c.apiCtx, listHistoryParams{
 				startHistoryID: c.lastHistoryID,
 				pageToken:      pageToken,
 				maxResults:     historyMaxResults,

--- a/gmail/capabilities.go
+++ b/gmail/capabilities.go
@@ -3,16 +3,17 @@ package usp_gmail
 // This file implements the BEC (Business Email Compromise) capabilities: the
 // configuration-state collectors (mail filters, forwarding addresses, send-as
 // aliases, delegates, IMAP/POP, vacation responder) and the mailbox change
-// history collector. These complement the message-telemetry collector in
-// client.go.
+// history collector. They run per mailbox, as methods on mailboxCollector, and
+// complement the message-telemetry collector in collector.go.
 //
 // The configuration-state collectors are change-only: an item is shipped when it
 // first appears or its content changes, and suppressed otherwise. This is what
 // surfaces the persistence and exfiltration changes typical of BEC -- an attacker
 // adding an auto-forward rule, a forwarding address, a send-as identity, or a
 // delegate -- without flooding the stream with the steady state on every poll.
-// Change detection reuses the adapter's deduper, keyed on a hash of each item's
-// content, so an unchanged item maps to a key already seen.
+// Change detection reuses the collector's deduper, keyed on a hash of each item's
+// content (namespaced by mailbox), so an unchanged item maps to a key already
+// seen.
 
 import (
 	"context"
@@ -42,66 +43,66 @@ var historyChangeTypes = []string{"messageDeleted", "labelAdded", "labelRemoved"
 // pollSettings runs each enabled configuration-state capability once. A single
 // capability failing (e.g. delegates on a consumer account) does not abort the
 // others.
-func (a *GmailAdapter) pollSettings() {
-	if a.conf.CollectFilters {
-		a.pollListCapability("filters", eventTypeFilter, "filter", "filter", a.client.ListFilters)
+func (c *mailboxCollector) pollSettings() {
+	if c.a.conf.CollectFilters {
+		c.pollListCapability("filters", eventTypeFilter, "filter", "filter", c.client.ListFilters)
 	}
-	if a.doStop.IsSet() {
+	if c.stop.IsSet() {
 		return
 	}
-	if a.conf.CollectForwarding {
-		a.pollListCapability("forwardingAddresses", eventTypeForwardingAddress,
-			"forwardingAddresses", "forwarding", a.client.ListForwardingAddresses)
-		if a.doStop.IsSet() {
+	if c.a.conf.CollectForwarding {
+		c.pollListCapability("forwardingAddresses", eventTypeForwardingAddress,
+			"forwardingAddresses", "forwarding", c.client.ListForwardingAddresses)
+		if c.stop.IsSet() {
 			return
 		}
-		a.pollSingletonCapability("autoForwarding", eventTypeAutoForwarding,
-			"autoforwarding", a.client.GetAutoForwarding)
+		c.pollSingletonCapability("autoForwarding", eventTypeAutoForwarding,
+			"autoforwarding", c.client.GetAutoForwarding)
 	}
-	if a.doStop.IsSet() {
+	if c.stop.IsSet() {
 		return
 	}
-	if a.conf.CollectSendAs {
-		a.pollListCapability("sendAs", eventTypeSendAs, "sendAs", "sendas", a.client.ListSendAs)
+	if c.a.conf.CollectSendAs {
+		c.pollListCapability("sendAs", eventTypeSendAs, "sendAs", "sendas", c.client.ListSendAs)
 	}
-	if a.doStop.IsSet() {
+	if c.stop.IsSet() {
 		return
 	}
-	if a.conf.CollectDelegates {
-		a.pollListCapability("delegates", eventTypeDelegate, "delegates", "delegate", a.client.ListDelegates)
+	if c.a.conf.CollectDelegates {
+		c.pollListCapability("delegates", eventTypeDelegate, "delegates", "delegate", c.client.ListDelegates)
 	}
-	if a.doStop.IsSet() {
+	if c.stop.IsSet() {
 		return
 	}
-	if a.conf.CollectImapPop {
-		a.pollSingletonCapability("imap", eventTypeImap, "imap", a.client.GetImap)
-		if a.doStop.IsSet() {
+	if c.a.conf.CollectImapPop {
+		c.pollSingletonCapability("imap", eventTypeImap, "imap", c.client.GetImap)
+		if c.stop.IsSet() {
 			return
 		}
-		a.pollSingletonCapability("pop", eventTypePop, "pop", a.client.GetPop)
+		c.pollSingletonCapability("pop", eventTypePop, "pop", c.client.GetPop)
 	}
-	if a.doStop.IsSet() {
+	if c.stop.IsSet() {
 		return
 	}
-	if a.conf.CollectVacation {
-		a.pollSingletonCapability("vacation", eventTypeVacation, "vacation", a.client.GetVacation)
+	if c.a.conf.CollectVacation {
+		c.pollSingletonCapability("vacation", eventTypeVacation, "vacation", c.client.GetVacation)
 	}
 }
 
 // pollListCapability runs one list-shaped configuration-state capability: fetch
 // the list, then change-ship each item. listField is the JSON array field in the
 // response (e.g. "filter", "sendAs"); keyPrefix namespaces the dedupe keys.
-func (a *GmailAdapter) pollListCapability(label, evtType, listField, keyPrefix string, fetch func(context.Context) ([]byte, error)) {
-	d, ok := a.fetchCapability(label, fetch)
+func (c *mailboxCollector) pollListCapability(label, evtType, listField, keyPrefix string, fetch func(context.Context) ([]byte, error)) {
+	d, ok := c.fetchCapability(label, fetch)
 	if !ok {
 		return
 	}
 	items, _ := d.GetListOfDict(listField)
 	for _, item := range items {
-		if a.doStop.IsSet() {
+		if c.stop.IsSet() {
 			return
 		}
-		if !a.shipState(evtType, keyPrefix, item) {
+		if !c.shipState(evtType, keyPrefix, item) {
 			return
 		}
 	}
@@ -109,42 +110,43 @@ func (a *GmailAdapter) pollListCapability(label, evtType, listField, keyPrefix s
 
 // pollSingletonCapability runs one object-shaped configuration-state capability:
 // fetch the single settings object and change-ship it as a whole.
-func (a *GmailAdapter) pollSingletonCapability(label, evtType, keyPrefix string, fetch func(context.Context) ([]byte, error)) {
-	d, ok := a.fetchCapability(label, fetch)
+func (c *mailboxCollector) pollSingletonCapability(label, evtType, keyPrefix string, fetch func(context.Context) ([]byte, error)) {
+	d, ok := c.fetchCapability(label, fetch)
 	if !ok {
 		return
 	}
-	a.shipState(evtType, keyPrefix, d)
+	c.shipState(evtType, keyPrefix, d)
 }
 
 // fetchCapability fetches and parses one capability's response, applying the
 // transient-retry backoff and the non-fatal capability error handling. ok is
 // false when the capability should be skipped this cycle.
-func (a *GmailAdapter) fetchCapability(label string, fetch func(context.Context) ([]byte, error)) (utils.Dict, bool) {
-	raw, err := a.withRetry(label, func() ([]byte, error) { return fetch(a.ctx) })
+func (c *mailboxCollector) fetchCapability(label string, fetch func(context.Context) ([]byte, error)) (utils.Dict, bool) {
+	raw, err := c.withRetry(label, func() ([]byte, error) { return fetch(c.a.ctx) })
 	if err != nil {
-		a.handleCapabilityError(label, err)
+		c.handleCapabilityError(label, err)
 		return nil, false
 	}
 	parsed, err := utils.UnmarshalCleanJSON(string(raw))
 	if err != nil {
-		a.conf.ClientOptions.OnError(fmt.Errorf("gmail: %s parse error: %v", label, err))
+		c.a.conf.ClientOptions.OnError(fmt.Errorf("%s: %s parse error: %v", c.tag, label, err))
 		return nil, false
 	}
 	return utils.Dict(parsed), true
 }
 
 // shipState ships a configuration-state item under evtType, but only when it is
-// new or its content changed since it was last seen. The dedupe key is keyPrefix
-// plus a hash of the item's content, so an unchanged item on a later poll maps to
-// a key already in the deduper and is suppressed, while any change yields a new
-// key and re-ships. Returns false if the adapter should stop.
-func (a *GmailAdapter) shipState(evtType, keyPrefix string, payload utils.Dict) bool {
-	key := keyPrefix + ":" + contentHash(payload)
-	if a.deduper.CheckAndAdd(key) {
+// new or its content changed since it was last seen. The dedupe key is the
+// mailbox plus keyPrefix plus a hash of the item's content, so an unchanged item
+// on a later poll maps to a key already in the deduper and is suppressed, while
+// any change yields a new key and re-ships. Returns false if the collector
+// should stop.
+func (c *mailboxCollector) shipState(evtType, keyPrefix string, payload utils.Dict) bool {
+	key := c.dkey(keyPrefix, contentHash(payload))
+	if c.deduper.CheckAndAdd(key) {
 		return true // unchanged since a recent poll; already shipped
 	}
-	return a.shipEvent(evtType, payload, uint64(time.Now().UnixMilli()))
+	return c.shipEvent(evtType, payload, uint64(time.Now().UnixMilli()))
 }
 
 // contentHash is a stable hash of a decoded JSON object. encoding/json sorts map
@@ -159,13 +161,13 @@ func contentHash(d utils.Dict) string {
 }
 
 // handleCapabilityError classifies an error from a BEC capability. A genuine
-// authentication failure (a token error, or a 401) stops the adapter, exactly as
-// it does for the message poller -- the credentials need operator attention.
-// Everything else is logged and the capability is skipped for this cycle, leaving
-// the other capabilities running: a feature unavailable for this account type
-// (delegates on a consumer account surfaces as 400/403), a settings scope the
-// token lacks, or a transient blip that outlived its retries.
-func (a *GmailAdapter) handleCapabilityError(label string, err error) {
+// authentication failure (a token error, or a 401) stops this collector, exactly
+// as it does for the message poller -- the credentials for this mailbox need
+// operator attention. Everything else is logged and the capability is skipped
+// for this cycle, leaving the other capabilities running: a feature unavailable
+// for this account type (delegates on a consumer account surfaces as 400/403), a
+// settings scope the token lacks, or a transient blip that outlived its retries.
+func (c *mailboxCollector) handleCapabilityError(label string, err error) {
 	if errors.Is(err, context.Canceled) {
 		return
 	}
@@ -173,11 +175,11 @@ func (a *GmailAdapter) handleCapabilityError(label string, err error) {
 	var httpErr *HTTPError
 	if errors.As(err, &tokenErr) ||
 		(errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized) {
-		a.conf.ClientOptions.OnError(fmt.Errorf("gmail: %s failed (credentials rejected): %v", label, err))
-		a.doStop.Set()
+		c.a.conf.ClientOptions.OnError(fmt.Errorf("%s: %s failed (credentials rejected): %v", c.tag, label, err))
+		c.requestStop()
 		return
 	}
-	a.conf.ClientOptions.OnWarning(fmt.Sprintf("gmail: %s unavailable, skipping this cycle: %v", label, err))
+	c.a.conf.ClientOptions.OnWarning(fmt.Sprintf("%s: %s unavailable, skipping this cycle: %v", c.tag, label, err))
 }
 
 // pollHistory collects mailbox change records (deletions and label changes) via
@@ -186,27 +188,27 @@ func (a *GmailAdapter) handleCapabilityError(label string, err error) {
 // later run lists history forward from the cursor, shipping each record, and
 // advances the cursor only after a fully-successful pass (the deduper prevents
 // re-shipping if a pass is re-covered). A 404 means the cursor aged out (Gmail
-// keeps history for roughly a week); the adapter re-baselines and resumes.
-func (a *GmailAdapter) pollHistory() {
-	if a.lastHistoryID == "" {
-		if id, ok := a.fetchHistoryBaseline(); ok {
-			a.lastHistoryID = id
-			a.conf.ClientOptions.DebugLog("gmail: history baseline established at " + id)
+// keeps history for roughly a week); the collector re-baselines and resumes.
+func (c *mailboxCollector) pollHistory() {
+	if c.lastHistoryID == "" {
+		if id, ok := c.fetchHistoryBaseline(); ok {
+			c.lastHistoryID = id
+			c.a.conf.ClientOptions.DebugLog(c.tag + ": history baseline established at " + id)
 		}
 		return
 	}
 
 	pageToken := ""
-	newCursor := a.lastHistoryID
+	newCursor := c.lastHistoryID
 	nShipped := 0
 	for page := 0; page < maxPagesPerPoll; page++ {
-		if a.doStop.IsSet() {
+		if c.stop.IsSet() {
 			return
 		}
 
-		raw, err := a.withRetry("history.list", func() ([]byte, error) {
-			return a.client.ListHistory(a.ctx, listHistoryParams{
-				startHistoryID: a.lastHistoryID,
+		raw, err := c.withRetry("history.list", func() ([]byte, error) {
+			return c.client.ListHistory(c.a.ctx, listHistoryParams{
+				startHistoryID: c.lastHistoryID,
 				pageToken:      pageToken,
 				maxResults:     historyMaxResults,
 				historyTypes:   historyChangeTypes,
@@ -217,17 +219,17 @@ func (a *GmailAdapter) pollHistory() {
 			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
 				// The cursor aged out of Gmail's retained history. Forget it so
 				// the next cycle re-baselines from the current profile.
-				a.conf.ClientOptions.OnWarning("gmail: history cursor expired; re-baselining next cycle")
-				a.lastHistoryID = ""
+				c.a.conf.ClientOptions.OnWarning(c.tag + ": history cursor expired; re-baselining next cycle")
+				c.lastHistoryID = ""
 				return
 			}
-			a.handleCapabilityError("history.list", err)
+			c.handleCapabilityError("history.list", err)
 			return
 		}
 
 		parsed, err := utils.UnmarshalCleanJSON(string(raw))
 		if err != nil {
-			a.conf.ClientOptions.OnError(fmt.Errorf("gmail: history parse error: %v", err))
+			c.a.conf.ClientOptions.OnError(fmt.Errorf("%s: history parse error: %v", c.tag, err))
 			return
 		}
 		d := utils.Dict(parsed)
@@ -240,17 +242,17 @@ func (a *GmailAdapter) pollHistory() {
 
 		records, _ := d.GetListOfDict("history")
 		for _, rec := range records {
-			if a.doStop.IsSet() {
+			if c.stop.IsSet() {
 				return
 			}
 			id := rec.FindOneString("id")
 			if id == "" {
 				continue
 			}
-			if a.deduper.CheckAndAdd("history:" + id) {
+			if c.deduper.CheckAndAdd(c.dkey(dedupeKindHistory, id)) {
 				continue
 			}
-			if !a.shipEvent(eventTypeHistory, rec, uint64(time.Now().UnixMilli())) {
+			if !c.shipEvent(eventTypeHistory, rec, uint64(time.Now().UnixMilli())) {
 				return
 			}
 			nShipped++
@@ -262,21 +264,21 @@ func (a *GmailAdapter) pollHistory() {
 		}
 	}
 
-	a.lastHistoryID = newCursor
-	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
-		"gmail: history poll complete (shipped=%d) cursor=%s", nShipped, a.lastHistoryID))
+	c.lastHistoryID = newCursor
+	c.a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"%s: history poll complete (shipped=%d) cursor=%s", c.tag, nShipped, c.lastHistoryID))
 }
 
 // fetchHistoryBaseline reads the mailbox profile for its current historyId, used
 // as the starting cursor for incremental history collection.
-func (a *GmailAdapter) fetchHistoryBaseline() (string, bool) {
-	d, ok := a.fetchCapability("getProfile", a.client.GetProfile)
+func (c *mailboxCollector) fetchHistoryBaseline() (string, bool) {
+	d, ok := c.fetchCapability("getProfile", c.client.GetProfile)
 	if !ok {
 		return "", false
 	}
 	id := d.FindOneString("historyId")
 	if id == "" {
-		a.conf.ClientOptions.OnWarning("gmail: profile returned no historyId; will retry next cycle")
+		c.a.conf.ClientOptions.OnWarning(c.tag + ": profile returned no historyId; will retry next cycle")
 		return "", false
 	}
 	return id, true

--- a/gmail/client.go
+++ b/gmail/client.go
@@ -39,15 +39,16 @@ import (
 )
 
 const (
-	defaultUserID       = "me"
-	defaultQuery        = "in:inbox"
-	defaultFormat       = "full"
-	defaultMaxResults   = 100
-	maxAllowedResults   = 500 // Gmail's per-page ceiling for messages.list.
-	defaultPollInterval = 5 * time.Minute
-	defaultOverlap      = 2 * time.Minute
-	defaultDedupeTTL    = 7 * 24 * time.Hour
-	dedupeBucketWindow  = 1 * time.Hour
+	defaultUserID               = "me"
+	defaultQuery                = "in:inbox"
+	defaultFormat               = "full"
+	defaultMaxResults           = 100
+	maxAllowedResults           = 500 // Gmail's per-page ceiling for messages.list.
+	defaultPollInterval         = 5 * time.Minute
+	defaultSettingsPollInterval = 15 * time.Minute
+	defaultOverlap              = 2 * time.Minute
+	defaultDedupeTTL            = 7 * 24 * time.Hour
+	dedupeBucketWindow          = 1 * time.Hour
 
 	defaultMaxRetryAttempts = 3
 	defaultRetryBaseDelay   = 5 * time.Second
@@ -59,8 +60,18 @@ const (
 	// safety net against a misbehaving nextPageToken that never empties.
 	maxPagesPerPoll = 10000
 
-	// eventType tags every shipped message.
-	eventType = "gmail_message"
+	// Event types. Each capability ships under its own type so detections can be
+	// written against the specific signal.
+	eventTypeMessage           = "gmail_message"            // incoming-mail telemetry
+	eventTypeFilter            = "gmail_filter"             // a mail filter / rule
+	eventTypeForwardingAddress = "gmail_forwarding_address" // a verified forwarding destination
+	eventTypeAutoForwarding    = "gmail_auto_forwarding"    // account-wide auto-forward setting
+	eventTypeSendAs            = "gmail_send_as"            // a send-as alias / "from" identity
+	eventTypeDelegate          = "gmail_delegate"           // a mailbox delegate (Workspace only)
+	eventTypeImap              = "gmail_imap"               // IMAP access setting
+	eventTypePop               = "gmail_pop"                // POP access setting
+	eventTypeVacation          = "gmail_vacation"           // vacation responder setting
+	eventTypeHistory           = "gmail_history"            // a mailbox change record (deletions, label changes)
 )
 
 // validFormats is the set of accepted users.messages.get format values.
@@ -99,6 +110,60 @@ type GmailConfig struct {
 	// domain-wide delegation (e.g. "user@yourdomain.com"). Required for the
 	// service-account flow.
 	Subject string `json:"subject" yaml:"subject"`
+
+	// --- Capabilities ------------------------------------------------------
+	//
+	// Each capability is an independent collector that ships its own event type.
+	// They are opt-in: if NONE of these are set, the adapter defaults to message
+	// telemetry only (CollectMessages), preserving the original behavior. The
+	// configuration-state capabilities (filters, forwarding, send-as, delegates,
+	// imap/pop, vacation) emit change-only events -- an item is shipped when it
+	// first appears or its content changes, suppressed otherwise -- which surfaces
+	// the persistence/exfiltration changes typical of Business Email Compromise.
+
+	// CollectMessages ships incoming email as "gmail_message" telemetry. This is
+	// the original behavior and the default when no capability is selected.
+	CollectMessages bool `json:"collect_messages" yaml:"collect_messages"`
+
+	// CollectFilters ships mail filters/rules as "gmail_filter". BEC actors create
+	// rules that auto-delete or auto-forward mail, or hide replies about
+	// invoices/wires so the victim never sees them.
+	CollectFilters bool `json:"collect_filters" yaml:"collect_filters"`
+
+	// CollectForwarding ships forwarding addresses ("gmail_forwarding_address")
+	// and the account-wide auto-forwarding setting ("gmail_auto_forwarding"). A
+	// classic mail-exfiltration vector.
+	CollectForwarding bool `json:"collect_forwarding" yaml:"collect_forwarding"`
+
+	// CollectSendAs ships send-as aliases as "gmail_send_as". An added "from"
+	// identity is an impersonation/persistence signal.
+	CollectSendAs bool `json:"collect_send_as" yaml:"collect_send_as"`
+
+	// CollectDelegates ships mailbox delegates as "gmail_delegate". Granting a
+	// delegate is a persistence mechanism. Google exposes this only to service
+	// accounts with domain-wide delegation (Workspace); it is unavailable on
+	// consumer accounts and such failures are logged and skipped, not fatal.
+	CollectDelegates bool `json:"collect_delegates" yaml:"collect_delegates"`
+
+	// CollectImapPop ships the IMAP ("gmail_imap") and POP ("gmail_pop") access
+	// settings. Enabling these allows bulk mailbox download via a desktop client,
+	// bypassing browser-session controls.
+	CollectImapPop bool `json:"collect_imap_pop" yaml:"collect_imap_pop"`
+
+	// CollectVacation ships the vacation-responder setting as "gmail_vacation".
+	CollectVacation bool `json:"collect_vacation" yaml:"collect_vacation"`
+
+	// CollectHistory ships mailbox change records as "gmail_history": message
+	// deletions and label changes (e.g. marking security alerts read or trashing
+	// the fraud thread), which is how an intruder covers their tracks. Uses
+	// users.history.list, whose history is retained for roughly a week.
+	CollectHistory bool `json:"collect_history" yaml:"collect_history"`
+
+	// SettingsPollInterval is the cadence for the configuration-state capabilities
+	// (filters, forwarding, send-as, delegates, imap/pop, vacation). These change
+	// rarely, so they poll on a slower clock than messages. Default 15 minutes.
+	// History and messages poll on PollInterval.
+	SettingsPollInterval time.Duration `json:"settings_poll_interval" yaml:"settings_poll_interval"`
 
 	// --- Collection knobs --------------------------------------------------
 
@@ -170,6 +235,19 @@ func (c *GmailConfig) usesServiceAccount() bool {
 	return c.ServiceAccountCredentials != "" || c.ServiceAccountFile != ""
 }
 
+// anyCapabilityEnabled reports whether the operator turned on at least one
+// collector.
+func (c *GmailConfig) anyCapabilityEnabled() bool {
+	return c.CollectMessages || c.CollectHistory || c.anySettingsCapabilityEnabled()
+}
+
+// anySettingsCapabilityEnabled reports whether any configuration-state capability
+// (the ones that poll on SettingsPollInterval) is enabled.
+func (c *GmailConfig) anySettingsCapabilityEnabled() bool {
+	return c.CollectFilters || c.CollectForwarding || c.CollectSendAs ||
+		c.CollectDelegates || c.CollectImapPop || c.CollectVacation
+}
+
 func (c *GmailConfig) Validate() error {
 	if err := c.ClientOptions.Validate(); err != nil {
 		return fmt.Errorf("client_options: %v", err)
@@ -202,6 +280,12 @@ func (c *GmailConfig) Validate() error {
 		return errors.New("missing credentials: set either a refresh token (client_id, client_secret, refresh_token) or a service account (service_account_credentials/service_account_file + subject)")
 	}
 
+	// Capabilities are opt-in. If the operator selected none, fall back to the
+	// original behavior: message telemetry only.
+	if !c.anyCapabilityEnabled() {
+		c.CollectMessages = true
+	}
+
 	if c.UserID == "" {
 		c.UserID = defaultUserID
 	}
@@ -225,6 +309,9 @@ func (c *GmailConfig) Validate() error {
 	}
 	if c.PollInterval <= 0 {
 		c.PollInterval = defaultPollInterval
+	}
+	if c.SettingsPollInterval <= 0 {
+		c.SettingsPollInterval = defaultSettingsPollInterval
 	}
 	if c.Overlap < 0 {
 		c.Overlap = 0
@@ -268,9 +355,17 @@ type GmailAdapter struct {
 	deduper     utils.Deduper
 	ownsDeduper bool
 
-	// since is the high-water mark of the collection window. It advances to the
-	// poll's end time after every fully-successful poll.
+	// since is the high-water mark of the message collection window. It advances
+	// to the poll's end time after every fully-successful message poll.
 	since time.Time
+
+	// lastSettings is when the configuration-state capabilities last ran; they
+	// poll on the slower SettingsPollInterval clock. Zero means "never" (due).
+	lastSettings time.Time
+
+	// lastHistoryID is the users.history.list cursor: history is collected from
+	// this id forward. Empty until a baseline is established from the profile.
+	lastHistoryID string
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -430,15 +525,43 @@ func (a *GmailAdapter) run() {
 	isFirstRun := true
 	for isFirstRun || !a.doStop.WaitFor(a.conf.PollInterval) {
 		isFirstRun = false
-		a.poll()
+		a.runCycle()
 	}
 }
 
-// poll performs one collection cycle over the rolling window: list message ids,
-// fetch each not-yet-seen message, and ship it. On success the window's
-// high-water mark advances; on any error it does not, so the next poll re-covers
-// the same range (the deduper prevents re-shipping).
-func (a *GmailAdapter) poll() {
+// runCycle runs one tick of every enabled capability. Messages and history poll
+// every cycle; the configuration-state capabilities poll on their slower
+// SettingsPollInterval clock. A capability failing does not abort the others.
+func (a *GmailAdapter) runCycle() {
+	if a.conf.CollectMessages {
+		a.pollMessages()
+	}
+	if a.doStop.IsSet() {
+		return
+	}
+	if a.conf.CollectHistory {
+		a.pollHistory()
+	}
+	if a.doStop.IsSet() {
+		return
+	}
+	if a.conf.anySettingsCapabilityEnabled() && a.settingsDue(time.Now()) {
+		a.pollSettings()
+		a.lastSettings = time.Now()
+	}
+}
+
+// settingsDue reports whether the configuration-state capabilities should run
+// this cycle: always on the first pass, then once per SettingsPollInterval.
+func (a *GmailAdapter) settingsDue(now time.Time) bool {
+	return a.lastSettings.IsZero() || now.Sub(a.lastSettings) >= a.conf.SettingsPollInterval
+}
+
+// pollMessages performs one message collection cycle over the rolling window:
+// list message ids, fetch each not-yet-seen message, and ship it. On success the
+// window's high-water mark advances; on any error it does not, so the next poll
+// re-covers the same range (the deduper prevents re-shipping).
+func (a *GmailAdapter) pollMessages() {
 	end := time.Now()
 	start := a.since.Add(-a.conf.Overlap)
 	query := buildQuery(a.conf.Query, start)
@@ -618,13 +741,19 @@ func (a *GmailAdapter) handlePermanent(label string, err error) {
 	a.conf.ClientOptions.OnError(fmt.Errorf("gmail: %s failed: %v", label, err))
 }
 
-// ship forwards a single message to LimaCharlie. It returns false if the adapter
-// should stop (an unrecoverable shipping error).
+// ship forwards a single incoming message to LimaCharlie. It returns false if
+// the adapter should stop (an unrecoverable shipping error).
 func (a *GmailAdapter) ship(id string, msg utils.Dict) bool {
+	return a.shipEvent(eventTypeMessage, msg, eventTime(msg))
+}
+
+// shipEvent forwards one event of the given type to LimaCharlie. It returns
+// false if the adapter should stop (an unrecoverable shipping error).
+func (a *GmailAdapter) shipEvent(evtType string, payload utils.Dict, tsMs uint64) bool {
 	dataMsg := &protocol.DataMessage{
-		JsonPayload: msg,
-		EventType:   eventType,
-		TimestampMs: eventTime(msg),
+		JsonPayload: payload,
+		EventType:   evtType,
+		TimestampMs: tsMs,
 	}
 	if err := a.uspClient.Ship(dataMsg, shipTimeout); err != nil {
 		if err == uspclient.ErrorBufferFull {

--- a/gmail/client.go
+++ b/gmail/client.go
@@ -1,39 +1,48 @@
-// Package usp_gmail implements a USP adapter that collects incoming email as
-// telemetry from a Gmail mailbox via the Gmail REST API.
+// Package usp_gmail implements a USP adapter that collects incoming email and
+// Business-Email-Compromise signals from one or many Gmail mailboxes via the
+// Gmail REST API.
 //
-// It polls users.messages.list on a rolling time window (default query
-// "in:inbox"), fetches each newly-seen message with users.messages.get, and
-// ships it to LimaCharlie tagged as a "gmail_message" event. A deduper keyed on
-// the immutable Gmail message id guarantees each message ships exactly once even
-// though overlapping windows re-list recent messages.
+// Each mailbox is collected independently and shipped to its own LimaCharlie
+// sensor (the sensor seed key and hostname are derived from the mailbox address).
+// The adapter polls users.messages.list on a rolling time window (default query
+// "in:inbox"), fetches each newly-seen message with users.messages.get, and ships
+// it tagged as a "gmail_message" event. A deduper keyed on the immutable Gmail
+// message id (namespaced by mailbox) guarantees each message ships exactly once
+// even though overlapping windows re-list recent messages.
 //
-// Two authentication modes are supported:
+// Authentication:
 //
-//   - OAuth 2.0 refresh token: for collecting a single user's mailbox. Provide
-//     client_id, client_secret and refresh_token.
-//   - Service account with domain-wide delegation: for a Google Workspace, where
-//     a service account impersonates a mailbox owner. Provide the service
-//     account JSON (inline or via a file) and the subject to impersonate.
+//   - OAuth 2.0 refresh token: a single mailbox. Provide client_id,
+//     client_secret and refresh_token.
+//   - Service account with domain-wide delegation: one or many Google Workspace
+//     mailboxes. Provide the service account JSON (inline or via a file) and the
+//     mailbox(es) to impersonate, as either:
+//   - subject:  a single mailbox, or
+//   - subjects: an explicit static list of mailboxes, and/or
+//   - discover_mailboxes: enumerate the domain's mailboxes via the Admin SDK
+//     Directory API (requires admin_subject and the
+//     admin.directory.user.readonly scope in the delegation).
 //
 // References:
 //   - messages.list: https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/list
 //   - messages.get:  https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/get
+//   - directory:     https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list
 //   - search syntax: https://support.google.com/mail/answer/7190
 //   - OAuth/service accounts: https://developers.google.com/identity/protocols/oauth2/service-account
 package usp_gmail
 
 import (
 	"context"
+	"crypto/rsa"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/refractionPOINT/go-uspclient"
+	uspclient "github.com/refractionPOINT/go-uspclient"
 	"github.com/refractionPOINT/go-uspclient/protocol"
 	"github.com/refractionPOINT/usp-adapters/utils"
 )
@@ -59,6 +68,22 @@ const (
 	// maxPagesPerPoll caps the number of list pages walked in a single poll, a
 	// safety net against a misbehaving nextPageToken that never empties.
 	maxPagesPerPoll = 10000
+
+	// defaultMaxConcurrentPolls bounds how many mailboxes hit the Gmail API at
+	// the same instant, so a large domain does not blow the per-project quota.
+	defaultMaxConcurrentPolls = 10
+
+	// defaultDiscoveryInterval is how often the Directory API is re-enumerated to
+	// pick up newly-provisioned (or deprovisioned) mailboxes.
+	defaultDiscoveryInterval = 1 * time.Hour
+
+	// defaultCustomer is the Directory API customer alias for "the account that
+	// made the request".
+	defaultCustomer = "my_customer"
+
+	// adminDirectoryUserReadonlyScope is the delegated scope the discovery flow
+	// needs to enumerate the domain's mailboxes.
+	adminDirectoryUserReadonlyScope = "https://www.googleapis.com/auth/admin.directory.user.readonly"
 
 	// Event types. Each capability ships under its own type so detections can be
 	// written against the specific signal.
@@ -106,23 +131,59 @@ type GmailConfig struct {
 	// when ServiceAccountCredentials is empty.
 	ServiceAccountFile string `json:"service_account_file" yaml:"service_account_file"`
 
-	// Subject is the mailbox owner the service account impersonates via
-	// domain-wide delegation (e.g. "user@yourdomain.com"). Required for the
-	// service-account flow.
+	// Subject is a single mailbox owner the service account impersonates via
+	// domain-wide delegation (e.g. "user@yourdomain.com").
 	Subject string `json:"subject" yaml:"subject"`
+
+	// --- Multi-mailbox (service-account flow only) -------------------------
+
+	// Subjects is an explicit static list of mailboxes to collect, each
+	// impersonated independently and shipped to its own sensor. May be combined
+	// with Subject and with DiscoverMailboxes (the union is collected).
+	Subjects []string `json:"subjects" yaml:"subjects"`
+
+	// DiscoverMailboxes enables automatic enumeration of the Workspace domain's
+	// mailboxes via the Admin SDK Directory API, re-run on DiscoveryInterval so
+	// newly-provisioned mailboxes are picked up and deprovisioned ones dropped.
+	// Requires AdminSubject and that domain-wide delegation grants the
+	// admin.directory.user.readonly scope.
+	DiscoverMailboxes bool `json:"discover_mailboxes" yaml:"discover_mailboxes"`
+
+	// AdminSubject is the admin user the service account impersonates for the
+	// Directory API enumeration (the Gmail collection still impersonates each
+	// discovered mailbox). Required when DiscoverMailboxes is set.
+	AdminSubject string `json:"admin_subject" yaml:"admin_subject"`
+
+	// Customer is the Directory API customer id (default "my_customer"). Mutually
+	// exclusive with Domain.
+	Customer string `json:"customer" yaml:"customer"`
+
+	// Domain restricts discovery to a single domain of a multi-domain Workspace.
+	Domain string `json:"domain" yaml:"domain"`
+
+	// DiscoveryQuery is an optional Directory API user search filter (e.g.
+	// "orgUnitPath=/Sales"); see the Directory API users.list "query" parameter.
+	DiscoveryQuery string `json:"discovery_query" yaml:"discovery_query"`
+
+	// DiscoveryInterval is how often discovery re-enumerates. Default 1 hour.
+	DiscoveryInterval time.Duration `json:"discovery_interval" yaml:"discovery_interval"`
+
+	// IncludeSuspended collects suspended mailboxes too. By default discovery
+	// skips suspended accounts.
+	IncludeSuspended bool `json:"include_suspended" yaml:"include_suspended"`
 
 	// --- Capabilities ------------------------------------------------------
 	//
 	// Each capability is an independent collector that ships its own event type.
 	// They are opt-in: if NONE of these are set, the adapter defaults to message
-	// telemetry only (CollectMessages), preserving the original behavior. The
-	// configuration-state capabilities (filters, forwarding, send-as, delegates,
-	// imap/pop, vacation) emit change-only events -- an item is shipped when it
-	// first appears or its content changes, suppressed otherwise -- which surfaces
-	// the persistence/exfiltration changes typical of Business Email Compromise.
+	// telemetry only (CollectMessages). The configuration-state capabilities
+	// (filters, forwarding, send-as, delegates, imap/pop, vacation) emit
+	// change-only events -- an item is shipped when it first appears or its
+	// content changes, suppressed otherwise -- which surfaces the
+	// persistence/exfiltration changes typical of Business Email Compromise.
 
 	// CollectMessages ships incoming email as "gmail_message" telemetry. This is
-	// the original behavior and the default when no capability is selected.
+	// the default when no capability is selected.
 	CollectMessages bool `json:"collect_messages" yaml:"collect_messages"`
 
 	// CollectFilters ships mail filters/rules as "gmail_filter". BEC actors create
@@ -167,8 +228,9 @@ type GmailConfig struct {
 
 	// --- Collection knobs --------------------------------------------------
 
-	// UserID is the mailbox to read. Default "me" (the authenticated or
-	// impersonated user). May be an email address.
+	// UserID is the mailbox path segment for the refresh-token flow. Default "me"
+	// (the authenticated user). Ignored for the service-account flow, where each
+	// mailbox is reached as "me" under its own impersonation.
 	UserID string `json:"user_id" yaml:"user_id"`
 
 	// Query is the Gmail search query selecting which messages to collect.
@@ -176,7 +238,9 @@ type GmailConfig struct {
 	// per poll; do not include one here.
 	Query string `json:"query" yaml:"query"`
 
-	// Scopes overrides the OAuth scopes requested. Default: gmail.readonly.
+	// Scopes overrides the OAuth scopes requested for Gmail collection. Default:
+	// gmail.readonly. (Discovery uses the admin.directory.user.readonly scope
+	// separately.)
 	Scopes []string `json:"scopes" yaml:"scopes"`
 
 	// Format selects how much of each message to fetch: minimal, full, raw or
@@ -198,6 +262,10 @@ type GmailConfig struct {
 	// PollInterval is the wait between list polls. Default 5 minutes.
 	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
 
+	// MaxConcurrentPolls bounds how many mailboxes poll the Gmail API at once.
+	// Default 10. Only meaningful with many mailboxes.
+	MaxConcurrentPolls int `json:"max_concurrent_polls" yaml:"max_concurrent_polls"`
+
 	// Overlap extends each poll's window backwards past the previous poll so a
 	// slipped cycle or a late-indexed message leaves no gap; the deduper
 	// suppresses the resulting re-listing. Default 2 minutes.
@@ -205,7 +273,7 @@ type GmailConfig struct {
 
 	// InitialLookback, when > 0, makes the first poll reach back this far to
 	// backfill recent mail on startup. Default 0: collection starts from the
-	// moment the adapter launches (minus Overlap).
+	// moment the mailbox's collector launches (minus Overlap).
 	InitialLookback time.Duration `json:"initial_lookback" yaml:"initial_lookback"`
 
 	// DedupeTTL is how long a message id is remembered to suppress re-shipping
@@ -225,14 +293,31 @@ type GmailConfig struct {
 	// TokenURL overrides the OAuth token endpoint (e.g. for testing).
 	TokenURL string `json:"token_url" yaml:"token_url"`
 
-	// Deduper, when set, replaces the built-in in-memory deduper. Not settable
-	// through a config file; it is a seam for tests and embedders.
+	// DirectoryBaseURL overrides the Admin SDK Directory API root (e.g. for
+	// testing).
+	DirectoryBaseURL string `json:"directory_base_url" yaml:"directory_base_url"`
+
+	// Deduper, when set, replaces the built-in in-memory deduper. Shared across
+	// all mailboxes (keys are mailbox-namespaced). Not settable through a config
+	// file; it is a seam for tests and embedders.
 	Deduper utils.Deduper `json:"-" yaml:"-"`
 }
 
 // usesServiceAccount reports whether the config selects the service-account flow.
 func (c *GmailConfig) usesServiceAccount() bool {
 	return c.ServiceAccountCredentials != "" || c.ServiceAccountFile != ""
+}
+
+// usesDiscovery reports whether Directory-API mailbox discovery is enabled.
+func (c *GmailConfig) usesDiscovery() bool {
+	return c.DiscoverMailboxes
+}
+
+// isMultiMailbox reports whether more than one mailbox may be collected, in which
+// case each mailbox gets a per-mailbox-derived sensor identity. A single explicit
+// mailbox keeps the operator's configured sensor identity verbatim.
+func (c *GmailConfig) isMultiMailbox() bool {
+	return len(c.Subjects) > 0 || c.DiscoverMailboxes
 }
 
 // anyCapabilityEnabled reports whether the operator turned on at least one
@@ -263,8 +348,15 @@ func (c *GmailConfig) Validate() error {
 		if c.ServiceAccountCredentials != "" && c.ServiceAccountFile != "" {
 			return errors.New("provide service_account_credentials or service_account_file, not both")
 		}
-		if strings.TrimSpace(c.Subject) == "" {
-			return errors.New("service account flow requires subject (the mailbox user to impersonate via domain-wide delegation)")
+		if c.Customer != "" && c.Domain != "" {
+			return errors.New("provide customer or domain, not both")
+		}
+		hasSubjects := strings.TrimSpace(c.Subject) != "" || len(nonEmpty(c.Subjects)) > 0
+		if !hasSubjects && !c.DiscoverMailboxes {
+			return errors.New("service account flow requires at least one mailbox: set subject, subjects, or enable discover_mailboxes")
+		}
+		if c.DiscoverMailboxes && strings.TrimSpace(c.AdminSubject) == "" {
+			return errors.New("discover_mailboxes requires admin_subject (an admin user to impersonate for the Directory API)")
 		}
 	case hasRefresh:
 		if c.ClientID == "" {
@@ -276,12 +368,15 @@ func (c *GmailConfig) Validate() error {
 		if c.RefreshToken == "" {
 			return errors.New("missing refresh_token")
 		}
+		if c.isMultiMailbox() || strings.TrimSpace(c.AdminSubject) != "" {
+			return errors.New("multi-mailbox (subjects / discover_mailboxes / admin_subject) requires the service-account flow")
+		}
 	default:
-		return errors.New("missing credentials: set either a refresh token (client_id, client_secret, refresh_token) or a service account (service_account_credentials/service_account_file + subject)")
+		return errors.New("missing credentials: set either a refresh token (client_id, client_secret, refresh_token) or a service account (service_account_credentials/service_account_file + subject/subjects/discover_mailboxes)")
 	}
 
-	// Capabilities are opt-in. If the operator selected none, fall back to the
-	// original behavior: message telemetry only.
+	// Capabilities are opt-in. If the operator selected none, fall back to
+	// message telemetry only.
 	if !c.anyCapabilityEnabled() {
 		c.CollectMessages = true
 	}
@@ -312,6 +407,15 @@ func (c *GmailConfig) Validate() error {
 	}
 	if c.SettingsPollInterval <= 0 {
 		c.SettingsPollInterval = defaultSettingsPollInterval
+	}
+	if c.MaxConcurrentPolls <= 0 {
+		c.MaxConcurrentPolls = defaultMaxConcurrentPolls
+	}
+	if c.DiscoveryInterval <= 0 {
+		c.DiscoveryInterval = defaultDiscoveryInterval
+	}
+	if c.DiscoverMailboxes && c.Customer == "" && c.Domain == "" {
+		c.Customer = defaultCustomer
 	}
 	if c.Overlap < 0 {
 		c.Overlap = 0
@@ -346,106 +450,124 @@ type uspSink interface {
 	Close() ([]*protocol.DataMessage, error)
 }
 
-// GmailAdapter polls a Gmail mailbox and ships incoming messages to LimaCharlie.
+// sinkFactory builds the LimaCharlie sink (sensor) for one mailbox. Production
+// uses defaultSinkFactory; tests inject a capturing factory.
+type sinkFactory func(ctx context.Context, opts uspclient.ClientOptions, mailbox string) (uspSink, error)
+
+func defaultSinkFactory(ctx context.Context, opts uspclient.ClientOptions, _ string) (uspSink, error) {
+	return uspclient.NewClient(ctx, opts)
+}
+
+// mailboxTarget identifies one mailbox to collect and how to reach it.
+type mailboxTarget struct {
+	address string // mailbox address; identifies the sensor and namespaces dedupe keys
+	subject string // service-account subject to impersonate; "" for the refresh-token flow
+	userID  string // Gmail API path userId
+}
+
+// GmailAdapter orchestrates per-mailbox collectors and (optionally) Directory-API
+// mailbox discovery.
 type GmailAdapter struct {
-	conf        GmailConfig
-	uspClient   uspSink
-	client      *GmailClient
-	ts          *tokenSource
-	deduper     utils.Deduper
-	ownsDeduper bool
+	conf GmailConfig
+	ctx  context.Context
 
-	// since is the high-water mark of the message collection window. It advances
-	// to the poll's end time after every fully-successful message poll.
-	since time.Time
+	usesSA bool
+	saKey  *serviceAccountKey
+	saRSA  *rsa.PrivateKey
 
-	// lastSettings is when the configuration-state capabilities last ran; they
-	// poll on the slower SettingsPollInterval clock. Zero means "never" (due).
-	lastSettings time.Time
+	baseURL  string
+	tokenURL string
 
-	// lastHistoryID is the users.history.list cursor: history is collected from
-	// this id forward. Empty until a baseline is established from the profile.
-	lastHistoryID string
+	authHTTP *http.Client // shared by all token sources
+	apiHTTP  *http.Client // shared by all Gmail clients
 
-	chStopped chan struct{}
+	newSink   sinkFactory
+	pollSlots chan struct{} // bounded poll-concurrency across all mailboxes
+
+	directory *directoryClient // nil unless discovery is enabled
+
+	mu          sync.Mutex
+	collectors  map[string]*mailboxCollector // keyed by mailbox address
+	staticAddrs map[string]bool              // mailboxes from config; discovery never removes these
+
+	doStop    *utils.Event // stops the discovery loop; gates Close
 	wgSenders sync.WaitGroup
-	doStop    *utils.Event
+	chStopped chan struct{}
 
 	closeOnce sync.Once
 	closeErr  error
-
-	ctx context.Context
 }
 
 // NewGmailAdapter creates a Gmail adapter wired to LimaCharlie.
 func NewGmailAdapter(ctx context.Context, conf GmailConfig) (*GmailAdapter, chan struct{}, error) {
-	return newGmailAdapter(ctx, conf, nil)
+	return newGmailAdapter(ctx, conf, defaultSinkFactory)
 }
 
-// newGmailAdapter is the implementation behind NewGmailAdapter. When sink is
-// non-nil it is used in place of a real LimaCharlie client -- the seam tests use
-// to capture shipped events.
-func newGmailAdapter(ctx context.Context, conf GmailConfig, sink uspSink) (*GmailAdapter, chan struct{}, error) {
+// newGmailAdapter is the implementation behind NewGmailAdapter. newSink is the
+// seam tests use to capture shipped events per mailbox.
+func newGmailAdapter(ctx context.Context, conf GmailConfig, newSink sinkFactory) (*GmailAdapter, chan struct{}, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, nil, err
 	}
 
 	a := &GmailAdapter{
-		conf:   conf,
-		ctx:    ctx,
-		doStop: utils.NewEvent(),
+		conf:       conf,
+		ctx:        ctx,
+		usesSA:     conf.usesServiceAccount(),
+		baseURL:    resolveBaseURL(conf),
+		tokenURL:   resolveTokenURL(conf),
+		authHTTP:   newAuthHTTPClient(),
+		apiHTTP:    newAPIHTTPClient(),
+		newSink:    newSink,
+		pollSlots:  make(chan struct{}, conf.MaxConcurrentPolls),
+		collectors: map[string]*mailboxCollector{},
+		doStop:     utils.NewEvent(),
+		chStopped:  make(chan struct{}),
 	}
 
-	now := time.Now()
-	a.since = now
-	if conf.InitialLookback > 0 {
-		a.since = now.Add(-conf.InitialLookback)
-	}
-
-	// Overlapping windows re-list recent messages, so a deduper is required to
-	// ship each message exactly once.
-	a.deduper = conf.Deduper
-	if a.deduper == nil {
-		window := dedupeBucketWindow
-		if window > conf.DedupeTTL {
-			window = conf.DedupeTTL
-		}
-		deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
+	if a.usesSA {
+		key, rsaKey, err := a.parseServiceAccount()
 		if err != nil {
-			return nil, nil, fmt.Errorf("gmail: deduper: %v", err)
-		}
-		a.deduper = deduper
-		a.ownsDeduper = true
-	}
-
-	ts, err := buildTokenSource(conf)
-	if err != nil {
-		if a.ownsDeduper {
-			a.deduper.Close()
-		}
-		return nil, nil, err
-	}
-	a.ts = ts
-
-	if sink != nil {
-		a.uspClient = sink
-	} else {
-		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
-		if err != nil {
-			if a.ownsDeduper {
-				a.deduper.Close()
-			}
-			a.ts.Close()
 			return nil, nil, err
 		}
-		a.uspClient = uspClient
+		a.saKey, a.saRSA = key, rsaKey
 	}
 
-	a.client = NewGmailClient(resolveBaseURL(conf), conf.UserID, a.ts, newAPIHTTPClient())
+	// Start the static mailboxes (the single refresh-token mailbox, or the
+	// explicit service-account subject/subjects). Spread their first polls across
+	// one PollInterval so they do not all fire together.
+	static := a.staticTargets()
+	a.staticAddrs = make(map[string]bool, len(static))
+	for _, t := range static {
+		a.staticAddrs[t.address] = true
+	}
+	for i, t := range static {
+		var delay time.Duration
+		if len(static) > 1 {
+			delay = time.Duration(i) * (conf.PollInterval / time.Duration(len(static)))
+		}
+		if err := a.startCollector(t, delay); err != nil {
+			a.shutdownStartedCollectors()
+			a.apiHTTP.CloseIdleConnections()
+			a.authHTTP.CloseIdleConnections()
+			return nil, nil, err
+		}
+	}
 
-	a.chStopped = make(chan struct{})
-	a.wgSenders.Add(1)
-	go a.run()
+	// Discovery runs as a sender so the wait group never drains to zero while it
+	// is still looking for mailboxes.
+	if a.conf.usesDiscovery() {
+		dir, err := a.newDirectoryClient()
+		if err != nil {
+			a.shutdownStartedCollectors()
+			a.apiHTTP.CloseIdleConnections()
+			a.authHTTP.CloseIdleConnections()
+			return nil, nil, err
+		}
+		a.directory = dir
+		a.wgSenders.Add(1)
+		go a.runDiscovery()
+	}
 
 	go func() {
 		a.wgSenders.Wait()
@@ -455,48 +577,222 @@ func newGmailAdapter(ctx context.Context, conf GmailConfig, sink uspSink) (*Gmai
 	return a, a.chStopped, nil
 }
 
-// buildTokenSource constructs the token source for the configured auth flow.
-func buildTokenSource(conf GmailConfig) (*tokenSource, error) {
-	tokenURL := resolveTokenURL(conf)
-	httpClient := newAuthHTTPClient()
-
-	if conf.usesServiceAccount() {
-		raw := []byte(conf.ServiceAccountCredentials)
-		if len(raw) == 0 {
-			data, err := os.ReadFile(conf.ServiceAccountFile)
-			if err != nil {
-				return nil, fmt.Errorf("gmail: failed to read service_account_file %q: %v", conf.ServiceAccountFile, err)
-			}
-			raw = data
-		}
-		key, rsaKey, err := parseServiceAccountKey(raw)
-		if err != nil {
-			return nil, fmt.Errorf("gmail: %v", err)
-		}
-		return newServiceAccountSource(key, rsaKey, conf.Subject, conf.Scopes, tokenURL, httpClient), nil
+// staticTargets enumerates the mailboxes known at startup (before discovery).
+func (a *GmailAdapter) staticTargets() []mailboxTarget {
+	if !a.usesSA {
+		return []mailboxTarget{{address: a.conf.UserID, subject: "", userID: a.conf.UserID}}
 	}
-
-	return newRefreshTokenSource(tokenURL, conf.ClientID, conf.ClientSecret, conf.RefreshToken, httpClient), nil
+	seen := map[string]bool{}
+	var out []mailboxTarget
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			return
+		}
+		seen[s] = true
+		out = append(out, mailboxTarget{address: s, subject: s, userID: defaultUserID})
+	}
+	add(a.conf.Subject)
+	for _, s := range a.conf.Subjects {
+		add(s)
+	}
+	return out
 }
 
-// Close stops the adapter. It is idempotent.
+// parseServiceAccount loads and parses the configured service-account key.
+func (a *GmailAdapter) parseServiceAccount() (*serviceAccountKey, *rsa.PrivateKey, error) {
+	raw := []byte(a.conf.ServiceAccountCredentials)
+	if len(raw) == 0 {
+		data, err := os.ReadFile(a.conf.ServiceAccountFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("gmail: failed to read service_account_file %q: %v", a.conf.ServiceAccountFile, err)
+		}
+		raw = data
+	}
+	key, rsaKey, err := parseServiceAccountKey(raw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gmail: %v", err)
+	}
+	return key, rsaKey, nil
+}
+
+// tokenSourceForGmail builds a token source for collecting one mailbox.
+func (a *GmailAdapter) tokenSourceForGmail(t mailboxTarget) *tokenSource {
+	if a.usesSA {
+		return newServiceAccountSource(a.saKey, a.saRSA, t.subject, a.conf.Scopes, a.tokenURL, a.authHTTP)
+	}
+	return newRefreshTokenSource(a.tokenURL, a.conf.ClientID, a.conf.ClientSecret, a.conf.RefreshToken, a.authHTTP)
+}
+
+// sensorOptions derives the LimaCharlie ClientOptions for one mailbox. In
+// multi-mailbox mode the sensor seed key and hostname are derived from the
+// mailbox address so each mailbox maps to its own sensor; for a single explicit
+// mailbox the operator's configured identity is used verbatim.
+func (a *GmailAdapter) sensorOptions(mailbox string) uspclient.ClientOptions {
+	opts := a.conf.ClientOptions
+	if a.conf.isMultiMailbox() {
+		opts.SensorSeedKey = mailboxSeedKey(a.conf.ClientOptions.SensorSeedKey, mailbox)
+		opts.Hostname = mailbox
+	}
+	return opts
+}
+
+// mailboxSeedKey derives a stable, per-mailbox sensor seed key.
+func mailboxSeedKey(base, mailbox string) string {
+	if base == "" {
+		return mailbox
+	}
+	return base + "/" + mailbox
+}
+
+// startCollector creates and starts a collector for one mailbox, if not already
+// running. It is safe for concurrent use (discovery calls it).
+func (a *GmailAdapter) startCollector(t mailboxTarget, startDelay time.Duration) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.doStop.IsSet() {
+		return nil // adapter is closing; do not spin up new work
+	}
+	if _, exists := a.collectors[t.address]; exists {
+		return nil
+	}
+
+	ts := a.tokenSourceForGmail(t)
+	client := NewGmailClient(a.baseURL, t.userID, ts, a.apiHTTP)
+
+	sink, err := a.newSink(a.ctx, a.sensorOptions(t.address), t.address)
+	if err != nil {
+		return fmt.Errorf("gmail: sensor init for mailbox %q: %v", t.address, err)
+	}
+
+	deduper := a.conf.Deduper
+	ownsDeduper := false
+	if deduper == nil {
+		window := dedupeBucketWindow
+		if window > a.conf.DedupeTTL {
+			window = a.conf.DedupeTTL
+		}
+		d, derr := utils.NewLocalDeduper(window, a.conf.DedupeTTL)
+		if derr != nil {
+			_ = sink.Drain(time.Second)
+			_, _ = sink.Close()
+			return fmt.Errorf("gmail: deduper for mailbox %q: %v", t.address, derr)
+		}
+		deduper = d
+		ownsDeduper = true
+	}
+
+	now := time.Now()
+	since := now
+	if a.conf.InitialLookback > 0 {
+		since = now.Add(-a.conf.InitialLookback)
+	}
+
+	c := &mailboxCollector{
+		a:           a,
+		mailbox:     t.address,
+		tag:         "gmail[" + t.address + "]",
+		client:      client,
+		ts:          ts,
+		uspClient:   sink,
+		deduper:     deduper,
+		ownsDeduper: ownsDeduper,
+		since:       since,
+		startDelay:  startDelay,
+		stop:        utils.NewEvent(),
+		stopCh:      make(chan struct{}),
+		stopped:     make(chan struct{}),
+	}
+	a.collectors[t.address] = c
+	a.wgSenders.Add(1)
+	go c.run()
+	return nil
+}
+
+// removeCollector stops and tears down the collector for a mailbox that is no
+// longer present (deprovisioned). It blocks until the collector's loop has
+// exited and its sensor has drained.
+func (a *GmailAdapter) removeCollector(address string) {
+	a.mu.Lock()
+	c, ok := a.collectors[address]
+	if ok {
+		delete(a.collectors, address)
+	}
+	a.mu.Unlock()
+	if !ok {
+		return
+	}
+	c.requestStop()
+	<-c.stopped
+	if err := c.cleanup(); err != nil {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf("gmail: draining sensor for %q: %v", address, err))
+	}
+	a.conf.ClientOptions.DebugLog("gmail: stopped collecting deprovisioned mailbox " + address)
+}
+
+// activeMailboxes returns the set of mailboxes currently being collected.
+func (a *GmailAdapter) activeMailboxes() map[string]bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make(map[string]bool, len(a.collectors))
+	for addr := range a.collectors {
+		out[addr] = true
+	}
+	return out
+}
+
+// shutdownStartedCollectors stops and tears down every collector started so far.
+// Used to unwind a partially-constructed adapter.
+func (a *GmailAdapter) shutdownStartedCollectors() {
+	a.mu.Lock()
+	cs := make([]*mailboxCollector, 0, len(a.collectors))
+	for _, c := range a.collectors {
+		cs = append(cs, c)
+	}
+	a.collectors = map[string]*mailboxCollector{}
+	a.mu.Unlock()
+
+	for _, c := range cs {
+		c.requestStop()
+	}
+	for _, c := range cs {
+		<-c.stopped
+		_ = c.cleanup()
+	}
+}
+
+// Close stops the adapter and all mailbox collectors. It is idempotent.
 func (a *GmailAdapter) Close() error {
 	a.closeOnce.Do(func() {
 		a.conf.ClientOptions.DebugLog("gmail: closing")
-		a.doStop.Set()
-		a.wgSenders.Wait()
-		err1 := a.uspClient.Drain(1 * time.Minute)
-		_, err2 := a.uspClient.Close()
-		a.client.Close()
-		a.ts.Close()
-		if a.ownsDeduper {
-			a.deduper.Close()
+		a.doStop.Set() // stop the discovery loop
+
+		a.mu.Lock()
+		cs := make([]*mailboxCollector, 0, len(a.collectors))
+		for _, c := range a.collectors {
+			cs = append(cs, c)
 		}
-		if err1 != nil {
-			a.closeErr = err1
-		} else {
-			a.closeErr = err2
+		a.mu.Unlock()
+
+		for _, c := range cs {
+			c.requestStop()
 		}
+		a.wgSenders.Wait() // all collector loops and the discovery loop have exited
+
+		var firstErr error
+		for _, c := range cs {
+			if err := c.cleanup(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+
+		if a.directory != nil {
+			a.directory.Close()
+		}
+		a.apiHTTP.CloseIdleConnections()
+		a.authHTTP.CloseIdleConnections()
+		a.closeErr = firstErr
 	})
 	return a.closeErr
 }
@@ -517,278 +813,13 @@ func resolveTokenURL(conf GmailConfig) string {
 	return googleTokenEndpoint
 }
 
-// run polls Gmail forever, until the adapter is asked to stop.
-func (a *GmailAdapter) run() {
-	defer a.wgSenders.Done()
-	defer a.conf.ClientOptions.DebugLog("gmail: collection stopped")
-
-	isFirstRun := true
-	for isFirstRun || !a.doStop.WaitFor(a.conf.PollInterval) {
-		isFirstRun = false
-		a.runCycle()
-	}
-}
-
-// runCycle runs one tick of every enabled capability. Messages and history poll
-// every cycle; the configuration-state capabilities poll on their slower
-// SettingsPollInterval clock. A capability failing does not abort the others.
-func (a *GmailAdapter) runCycle() {
-	if a.conf.CollectMessages {
-		a.pollMessages()
-	}
-	if a.doStop.IsSet() {
-		return
-	}
-	if a.conf.CollectHistory {
-		a.pollHistory()
-	}
-	if a.doStop.IsSet() {
-		return
-	}
-	if a.conf.anySettingsCapabilityEnabled() && a.settingsDue(time.Now()) {
-		a.pollSettings()
-		a.lastSettings = time.Now()
-	}
-}
-
-// settingsDue reports whether the configuration-state capabilities should run
-// this cycle: always on the first pass, then once per SettingsPollInterval.
-func (a *GmailAdapter) settingsDue(now time.Time) bool {
-	return a.lastSettings.IsZero() || now.Sub(a.lastSettings) >= a.conf.SettingsPollInterval
-}
-
-// pollMessages performs one message collection cycle over the rolling window:
-// list message ids, fetch each not-yet-seen message, and ship it. On success the
-// window's high-water mark advances; on any error it does not, so the next poll
-// re-covers the same range (the deduper prevents re-shipping).
-func (a *GmailAdapter) pollMessages() {
-	end := time.Now()
-	start := a.since.Add(-a.conf.Overlap)
-	query := buildQuery(a.conf.Query, start)
-
-	pageToken := ""
-	nFetched, nShipped := 0, 0
-	for page := 0; page < maxPagesPerPoll; page++ {
-		if a.doStop.IsSet() {
-			return
-		}
-
-		raw, ok := a.list(query, pageToken)
-		if !ok {
-			return
-		}
-		list, err := parseListMessages(raw)
-		if err != nil {
-			a.conf.ClientOptions.OnError(fmt.Errorf("gmail: list parse error: %v", err))
-			return
-		}
-
-		for _, ref := range list.Messages {
-			if a.doStop.IsSet() {
-				return
-			}
-			if ref.ID == "" {
-				continue
-			}
-
-			// Fetch before consulting the deduper: a fetch can fail and we must
-			// not mark a message seen unless it actually shipped. The overlap
-			// re-lists at most a couple of minutes of recent ids, so the
-			// redundant fetches are bounded.
-			msg, status := a.fetch(ref.ID)
-			switch status {
-			case fetchSkip:
-				continue
-			case fetchAbort:
-				return
-			}
-			nFetched++
-
-			if a.deduper.CheckAndAdd(ref.ID) {
-				continue
-			}
-			if !a.ship(ref.ID, msg) {
-				return
-			}
-			nShipped++
-		}
-
-		if list.NextPageToken == "" {
-			break
-		}
-		pageToken = list.NextPageToken
-	}
-
-	// Only advance the high-water mark once the poll fully succeeded.
-	a.since = end
-	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
-		"gmail: poll complete (fetched=%d shipped=%d) up to %s",
-		nFetched, nShipped, end.UTC().Format(time.RFC3339)))
-}
-
-// list issues one messages.list request with transient-retry backoff. The bool
-// is false when the poll should be abandoned (a permanent error, or the adapter
-// is stopping).
-func (a *GmailAdapter) list(query, pageToken string) ([]byte, bool) {
-	raw, err := a.withRetry("messages.list", func() ([]byte, error) {
-		return a.client.ListMessages(a.ctx, listMessagesParams{
-			query:            query,
-			pageToken:        pageToken,
-			maxResults:       a.conf.MaxResults,
-			includeSpamTrash: a.conf.IncludeSpamTrash,
-			labelIDs:         a.conf.LabelIDs,
-		})
-	})
-	if err != nil {
-		a.handlePermanent("messages.list", err)
-		return nil, false
-	}
-	return raw, true
-}
-
-// fetchResult tells poll what to do after a messages.get attempt.
-type fetchResult int
-
-const (
-	fetchOK    fetchResult = iota // message fetched, proceed to dedupe/ship
-	fetchSkip                     // message gone (404); skip it, keep polling
-	fetchAbort                    // unrecoverable; abandon this poll
-)
-
-// fetch retrieves one message with transient-retry backoff and classifies the
-// outcome. A 404 (the message was deleted between the list and the get) is
-// benign and skipped; auth/permission failures abort and stop the adapter.
-func (a *GmailAdapter) fetch(id string) (utils.Dict, fetchResult) {
-	raw, err := a.withRetry("messages.get", func() ([]byte, error) {
-		return a.client.GetMessage(a.ctx, id, a.conf.Format, a.conf.MetadataHeaders)
-	})
-	if err != nil {
-		var httpErr *HTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			a.conf.ClientOptions.DebugLog(fmt.Sprintf("gmail: message %s vanished before fetch; skipping", id))
-			return nil, fetchSkip
-		}
-		a.handlePermanent("messages.get", err)
-		return nil, fetchAbort
-	}
-
-	msg, err := utils.UnmarshalCleanJSON(string(raw))
-	if err != nil {
-		a.conf.ClientOptions.OnError(fmt.Errorf("gmail: failed to parse message %s: %v", id, err))
-		return nil, fetchAbort
-	}
-	return utils.Dict(msg), fetchOK
-}
-
-// withRetry runs fn, retrying transient errors with exponential backoff. It
-// returns the final result, or the final (non-transient or attempts-exhausted)
-// error for the caller to classify. It does not set doStop.
-func (a *GmailAdapter) withRetry(label string, fn func() ([]byte, error)) ([]byte, error) {
-	var raw []byte
-	var err error
-	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
-		if a.doStop.IsSet() {
-			return nil, context.Canceled
-		}
-
-		raw, err = fn()
-		if err == nil {
-			return raw, nil
-		}
-		if !isTransientError(err) {
-			return nil, err
-		}
-		if attempt+1 >= a.conf.MaxRetryAttempts {
-			break
-		}
-		delay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
-		if delay > a.conf.MaxRetryDelay {
-			delay = a.conf.MaxRetryDelay
-		}
-		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
-			"gmail: %s transient error (attempt %d/%d), retrying in %v: %v",
-			label, attempt+1, a.conf.MaxRetryAttempts, delay, err))
-		if a.doStop.WaitFor(delay) {
-			return nil, context.Canceled
+// nonEmpty returns the input with blank entries removed.
+func nonEmpty(in []string) []string {
+	var out []string
+	for _, s := range in {
+		if strings.TrimSpace(s) != "" {
+			out = append(out, s)
 		}
 	}
-	return nil, fmt.Errorf("%s failed after %d attempts: %w", label, a.conf.MaxRetryAttempts, err)
-}
-
-// handlePermanent logs a non-recoverable error and, when it is a credential
-// failure, stops the adapter so it does not spin uselessly every interval. A
-// credential problem needs operator attention; other permanent errors (e.g. a
-// bad query) abandon this poll but keep the adapter alive to retry next interval.
-func (a *GmailAdapter) handlePermanent(label string, err error) {
-	if errors.Is(err, context.Canceled) {
-		// Adapter is stopping; not an error to surface.
-		return
-	}
-
-	var tokenErr *TokenError
-	var httpErr *HTTPError
-	if errors.As(err, &tokenErr) ||
-		(errors.As(err, &httpErr) &&
-			(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden)) {
-		a.conf.ClientOptions.OnError(fmt.Errorf("gmail: %s failed: %v", label, err))
-		a.conf.ClientOptions.OnError(fmt.Errorf(
-			"gmail: credentials rejected. Verify the OAuth client / refresh token (or service "+
-				"account key and that domain-wide delegation grants the %q scope for subject %q), "+
-				"and that the Gmail API is enabled for the project", strings.Join(a.conf.Scopes, ","), a.conf.Subject))
-		a.doStop.Set()
-		return
-	}
-	a.conf.ClientOptions.OnError(fmt.Errorf("gmail: %s failed: %v", label, err))
-}
-
-// ship forwards a single incoming message to LimaCharlie. It returns false if
-// the adapter should stop (an unrecoverable shipping error).
-func (a *GmailAdapter) ship(id string, msg utils.Dict) bool {
-	return a.shipEvent(eventTypeMessage, msg, eventTime(msg))
-}
-
-// shipEvent forwards one event of the given type to LimaCharlie. It returns
-// false if the adapter should stop (an unrecoverable shipping error).
-func (a *GmailAdapter) shipEvent(evtType string, payload utils.Dict, tsMs uint64) bool {
-	dataMsg := &protocol.DataMessage{
-		JsonPayload: payload,
-		EventType:   evtType,
-		TimestampMs: tsMs,
-	}
-	if err := a.uspClient.Ship(dataMsg, shipTimeout); err != nil {
-		if err == uspclient.ErrorBufferFull {
-			a.conf.ClientOptions.OnWarning("gmail: stream falling behind")
-			err = a.uspClient.Ship(dataMsg, 1*time.Hour)
-		}
-		if err != nil {
-			a.conf.ClientOptions.OnError(fmt.Errorf("gmail: Ship(): %v", err))
-			a.doStop.Set()
-			return false
-		}
-	}
-	return true
-}
-
-// buildQuery appends a time bound to the configured search query so each poll
-// only lists messages received at or after `start`. Gmail's `after:` operator
-// accepts an epoch-seconds value for second-level precision.
-func buildQuery(base string, start time.Time) string {
-	bound := fmt.Sprintf("after:%d", start.Unix())
-	base = strings.TrimSpace(base)
-	if base == "" {
-		return bound
-	}
-	return base + " " + bound
-}
-
-// eventTime extracts the message's event time from its internalDate (epoch
-// milliseconds, as a string), falling back to now when it is absent or
-// unparseable.
-func eventTime(msg utils.Dict) uint64 {
-	if raw := msg.FindOneString("internalDate"); raw != "" {
-		if ms, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); err == nil && ms > 0 {
-			return uint64(ms)
-		}
-	}
-	return uint64(time.Now().UnixMilli())
+	return out
 }

--- a/gmail/client.go
+++ b/gmail/client.go
@@ -16,8 +16,8 @@
 //     account JSON (inline or via a file) and the subject to impersonate.
 //
 // References:
-//   - messages.list: https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list
-//   - messages.get:  https://developers.google.com/gmail/api/reference/rest/v1/users.messages/get
+//   - messages.list: https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/list
+//   - messages.get:  https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/get
 //   - search syntax: https://support.google.com/mail/answer/7190
 //   - OAuth/service accounts: https://developers.google.com/identity/protocols/oauth2/service-account
 package usp_gmail

--- a/gmail/client.go
+++ b/gmail/client.go
@@ -1,0 +1,665 @@
+// Package usp_gmail implements a USP adapter that collects incoming email as
+// telemetry from a Gmail mailbox via the Gmail REST API.
+//
+// It polls users.messages.list on a rolling time window (default query
+// "in:inbox"), fetches each newly-seen message with users.messages.get, and
+// ships it to LimaCharlie tagged as a "gmail_message" event. A deduper keyed on
+// the immutable Gmail message id guarantees each message ships exactly once even
+// though overlapping windows re-list recent messages.
+//
+// Two authentication modes are supported:
+//
+//   - OAuth 2.0 refresh token: for collecting a single user's mailbox. Provide
+//     client_id, client_secret and refresh_token.
+//   - Service account with domain-wide delegation: for a Google Workspace, where
+//     a service account impersonates a mailbox owner. Provide the service
+//     account JSON (inline or via a file) and the subject to impersonate.
+//
+// References:
+//   - messages.list: https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list
+//   - messages.get:  https://developers.google.com/gmail/api/reference/rest/v1/users.messages/get
+//   - search syntax: https://support.google.com/mail/answer/7190
+//   - OAuth/service accounts: https://developers.google.com/identity/protocols/oauth2/service-account
+package usp_gmail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	defaultUserID       = "me"
+	defaultQuery        = "in:inbox"
+	defaultFormat       = "full"
+	defaultMaxResults   = 100
+	maxAllowedResults   = 500 // Gmail's per-page ceiling for messages.list.
+	defaultPollInterval = 5 * time.Minute
+	defaultOverlap      = 2 * time.Minute
+	defaultDedupeTTL    = 7 * 24 * time.Hour
+	dedupeBucketWindow  = 1 * time.Hour
+
+	defaultMaxRetryAttempts = 3
+	defaultRetryBaseDelay   = 5 * time.Second
+	defaultMaxRetryDelay    = 30 * time.Second
+
+	shipTimeout = 10 * time.Second
+
+	// maxPagesPerPoll caps the number of list pages walked in a single poll, a
+	// safety net against a misbehaving nextPageToken that never empties.
+	maxPagesPerPoll = 10000
+
+	// eventType tags every shipped message.
+	eventType = "gmail_message"
+)
+
+// validFormats is the set of accepted users.messages.get format values.
+var validFormats = map[string]struct{}{
+	"minimal":  {},
+	"full":     {},
+	"raw":      {},
+	"metadata": {},
+}
+
+// GmailConfig is the adapter configuration.
+type GmailConfig struct {
+	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+	// --- Authentication: refresh-token flow (single mailbox) ---------------
+
+	// ClientID and ClientSecret identify the OAuth application (Google Cloud
+	// console > APIs & Services > Credentials).
+	ClientID     string `json:"client_id" yaml:"client_id"`
+	ClientSecret string `json:"client_secret" yaml:"client_secret"`
+
+	// RefreshToken is a long-lived OAuth 2.0 refresh token for the mailbox
+	// owner, obtained from the authorization-code flow.
+	RefreshToken string `json:"refresh_token" yaml:"refresh_token"`
+
+	// --- Authentication: service-account flow (Workspace delegation) -------
+
+	// ServiceAccountCredentials is the service account JSON key, inline.
+	ServiceAccountCredentials string `json:"service_account_credentials" yaml:"service_account_credentials"`
+
+	// ServiceAccountFile is a path to the service account JSON key file. Used
+	// when ServiceAccountCredentials is empty.
+	ServiceAccountFile string `json:"service_account_file" yaml:"service_account_file"`
+
+	// Subject is the mailbox owner the service account impersonates via
+	// domain-wide delegation (e.g. "user@yourdomain.com"). Required for the
+	// service-account flow.
+	Subject string `json:"subject" yaml:"subject"`
+
+	// --- Collection knobs --------------------------------------------------
+
+	// UserID is the mailbox to read. Default "me" (the authenticated or
+	// impersonated user). May be an email address.
+	UserID string `json:"user_id" yaml:"user_id"`
+
+	// Query is the Gmail search query selecting which messages to collect.
+	// Default "in:inbox". A time bound (after:<epoch>) is appended automatically
+	// per poll; do not include one here.
+	Query string `json:"query" yaml:"query"`
+
+	// Scopes overrides the OAuth scopes requested. Default: gmail.readonly.
+	Scopes []string `json:"scopes" yaml:"scopes"`
+
+	// Format selects how much of each message to fetch: minimal, full, raw or
+	// metadata. Default "full".
+	Format string `json:"format" yaml:"format"`
+
+	// MetadataHeaders restricts the headers returned when Format is "metadata".
+	MetadataHeaders []string `json:"metadata_headers" yaml:"metadata_headers"`
+
+	// LabelIDs restricts the listing to messages carrying all of these labels.
+	LabelIDs []string `json:"label_ids" yaml:"label_ids"`
+
+	// IncludeSpamTrash includes SPAM and TRASH messages in the listing.
+	IncludeSpamTrash bool `json:"include_spam_trash" yaml:"include_spam_trash"`
+
+	// MaxResults is the page size for messages.list. Default 100, capped at 500.
+	MaxResults int `json:"max_results" yaml:"max_results"`
+
+	// PollInterval is the wait between list polls. Default 5 minutes.
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+
+	// Overlap extends each poll's window backwards past the previous poll so a
+	// slipped cycle or a late-indexed message leaves no gap; the deduper
+	// suppresses the resulting re-listing. Default 2 minutes.
+	Overlap time.Duration `json:"overlap" yaml:"overlap"`
+
+	// InitialLookback, when > 0, makes the first poll reach back this far to
+	// backfill recent mail on startup. Default 0: collection starts from the
+	// moment the adapter launches (minus Overlap).
+	InitialLookback time.Duration `json:"initial_lookback" yaml:"initial_lookback"`
+
+	// DedupeTTL is how long a message id is remembered to suppress re-shipping
+	// across overlapping windows. Default 7 days.
+	DedupeTTL time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
+
+	// Retry tuning for transient API failures.
+	RetryBaseDelay   time.Duration `json:"retry_base_delay" yaml:"retry_base_delay"`
+	MaxRetryDelay    time.Duration `json:"max_retry_delay" yaml:"max_retry_delay"`
+	MaxRetryAttempts int           `json:"max_retry_attempts" yaml:"max_retry_attempts"`
+
+	// --- Test / embedder seams ---------------------------------------------
+
+	// BaseURL fully overrides the Gmail API root (e.g. for testing).
+	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// TokenURL overrides the OAuth token endpoint (e.g. for testing).
+	TokenURL string `json:"token_url" yaml:"token_url"`
+
+	// Deduper, when set, replaces the built-in in-memory deduper. Not settable
+	// through a config file; it is a seam for tests and embedders.
+	Deduper utils.Deduper `json:"-" yaml:"-"`
+}
+
+// usesServiceAccount reports whether the config selects the service-account flow.
+func (c *GmailConfig) usesServiceAccount() bool {
+	return c.ServiceAccountCredentials != "" || c.ServiceAccountFile != ""
+}
+
+func (c *GmailConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+
+	hasRefresh := c.ClientID != "" || c.ClientSecret != "" || c.RefreshToken != ""
+	hasServiceAccount := c.usesServiceAccount()
+
+	switch {
+	case hasServiceAccount && hasRefresh:
+		return errors.New("provide either the service-account credentials or the refresh-token credentials, not both")
+	case hasServiceAccount:
+		if c.ServiceAccountCredentials != "" && c.ServiceAccountFile != "" {
+			return errors.New("provide service_account_credentials or service_account_file, not both")
+		}
+		if strings.TrimSpace(c.Subject) == "" {
+			return errors.New("service account flow requires subject (the mailbox user to impersonate via domain-wide delegation)")
+		}
+	case hasRefresh:
+		if c.ClientID == "" {
+			return errors.New("missing client_id")
+		}
+		if c.ClientSecret == "" {
+			return errors.New("missing client_secret")
+		}
+		if c.RefreshToken == "" {
+			return errors.New("missing refresh_token")
+		}
+	default:
+		return errors.New("missing credentials: set either a refresh token (client_id, client_secret, refresh_token) or a service account (service_account_credentials/service_account_file + subject)")
+	}
+
+	if c.UserID == "" {
+		c.UserID = defaultUserID
+	}
+	if c.Query == "" {
+		c.Query = defaultQuery
+	}
+	if len(c.Scopes) == 0 {
+		c.Scopes = []string{gmailReadonlyScope}
+	}
+	if c.Format == "" {
+		c.Format = defaultFormat
+	}
+	if _, ok := validFormats[c.Format]; !ok {
+		return fmt.Errorf("invalid format %q (want one of minimal, full, raw, metadata)", c.Format)
+	}
+	if c.MaxResults <= 0 {
+		c.MaxResults = defaultMaxResults
+	}
+	if c.MaxResults > maxAllowedResults {
+		c.MaxResults = maxAllowedResults
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
+	if c.Overlap < 0 {
+		c.Overlap = 0
+	}
+	if c.Overlap == 0 {
+		c.Overlap = defaultOverlap
+	}
+	if c.InitialLookback < 0 {
+		c.InitialLookback = 0
+	}
+	if c.DedupeTTL <= 0 {
+		c.DedupeTTL = defaultDedupeTTL
+	}
+	if c.RetryBaseDelay <= 0 {
+		c.RetryBaseDelay = defaultRetryBaseDelay
+	}
+	if c.MaxRetryDelay <= 0 {
+		c.MaxRetryDelay = defaultMaxRetryDelay
+	}
+	if c.MaxRetryAttempts <= 0 {
+		c.MaxRetryAttempts = defaultMaxRetryAttempts
+	}
+	return nil
+}
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink; *uspclient.Client
+// satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
+// GmailAdapter polls a Gmail mailbox and ships incoming messages to LimaCharlie.
+type GmailAdapter struct {
+	conf        GmailConfig
+	uspClient   uspSink
+	client      *GmailClient
+	ts          *tokenSource
+	deduper     utils.Deduper
+	ownsDeduper bool
+
+	// since is the high-water mark of the collection window. It advances to the
+	// poll's end time after every fully-successful poll.
+	since time.Time
+
+	chStopped chan struct{}
+	wgSenders sync.WaitGroup
+	doStop    *utils.Event
+
+	closeOnce sync.Once
+	closeErr  error
+
+	ctx context.Context
+}
+
+// NewGmailAdapter creates a Gmail adapter wired to LimaCharlie.
+func NewGmailAdapter(ctx context.Context, conf GmailConfig) (*GmailAdapter, chan struct{}, error) {
+	return newGmailAdapter(ctx, conf, nil)
+}
+
+// newGmailAdapter is the implementation behind NewGmailAdapter. When sink is
+// non-nil it is used in place of a real LimaCharlie client -- the seam tests use
+// to capture shipped events.
+func newGmailAdapter(ctx context.Context, conf GmailConfig, sink uspSink) (*GmailAdapter, chan struct{}, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	a := &GmailAdapter{
+		conf:   conf,
+		ctx:    ctx,
+		doStop: utils.NewEvent(),
+	}
+
+	now := time.Now()
+	a.since = now
+	if conf.InitialLookback > 0 {
+		a.since = now.Add(-conf.InitialLookback)
+	}
+
+	// Overlapping windows re-list recent messages, so a deduper is required to
+	// ship each message exactly once.
+	a.deduper = conf.Deduper
+	if a.deduper == nil {
+		window := dedupeBucketWindow
+		if window > conf.DedupeTTL {
+			window = conf.DedupeTTL
+		}
+		deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("gmail: deduper: %v", err)
+		}
+		a.deduper = deduper
+		a.ownsDeduper = true
+	}
+
+	ts, err := buildTokenSource(conf)
+	if err != nil {
+		if a.ownsDeduper {
+			a.deduper.Close()
+		}
+		return nil, nil, err
+	}
+	a.ts = ts
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			if a.ownsDeduper {
+				a.deduper.Close()
+			}
+			a.ts.Close()
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
+	}
+
+	a.client = NewGmailClient(resolveBaseURL(conf), conf.UserID, a.ts, newAPIHTTPClient())
+
+	a.chStopped = make(chan struct{})
+	a.wgSenders.Add(1)
+	go a.run()
+
+	go func() {
+		a.wgSenders.Wait()
+		close(a.chStopped)
+	}()
+
+	return a, a.chStopped, nil
+}
+
+// buildTokenSource constructs the token source for the configured auth flow.
+func buildTokenSource(conf GmailConfig) (*tokenSource, error) {
+	tokenURL := resolveTokenURL(conf)
+	httpClient := newAuthHTTPClient()
+
+	if conf.usesServiceAccount() {
+		raw := []byte(conf.ServiceAccountCredentials)
+		if len(raw) == 0 {
+			data, err := os.ReadFile(conf.ServiceAccountFile)
+			if err != nil {
+				return nil, fmt.Errorf("gmail: failed to read service_account_file %q: %v", conf.ServiceAccountFile, err)
+			}
+			raw = data
+		}
+		key, rsaKey, err := parseServiceAccountKey(raw)
+		if err != nil {
+			return nil, fmt.Errorf("gmail: %v", err)
+		}
+		return newServiceAccountSource(key, rsaKey, conf.Subject, conf.Scopes, tokenURL, httpClient), nil
+	}
+
+	return newRefreshTokenSource(tokenURL, conf.ClientID, conf.ClientSecret, conf.RefreshToken, httpClient), nil
+}
+
+// Close stops the adapter. It is idempotent.
+func (a *GmailAdapter) Close() error {
+	a.closeOnce.Do(func() {
+		a.conf.ClientOptions.DebugLog("gmail: closing")
+		a.doStop.Set()
+		a.wgSenders.Wait()
+		err1 := a.uspClient.Drain(1 * time.Minute)
+		_, err2 := a.uspClient.Close()
+		a.client.Close()
+		a.ts.Close()
+		if a.ownsDeduper {
+			a.deduper.Close()
+		}
+		if err1 != nil {
+			a.closeErr = err1
+		} else {
+			a.closeErr = err2
+		}
+	})
+	return a.closeErr
+}
+
+// resolveBaseURL computes the Gmail API root from the config.
+func resolveBaseURL(conf GmailConfig) string {
+	if conf.BaseURL != "" {
+		return strings.TrimRight(conf.BaseURL, "/")
+	}
+	return gmailAPIBaseURL
+}
+
+// resolveTokenURL computes the OAuth token endpoint from the config.
+func resolveTokenURL(conf GmailConfig) string {
+	if conf.TokenURL != "" {
+		return conf.TokenURL
+	}
+	return googleTokenEndpoint
+}
+
+// run polls Gmail forever, until the adapter is asked to stop.
+func (a *GmailAdapter) run() {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog("gmail: collection stopped")
+
+	isFirstRun := true
+	for isFirstRun || !a.doStop.WaitFor(a.conf.PollInterval) {
+		isFirstRun = false
+		a.poll()
+	}
+}
+
+// poll performs one collection cycle over the rolling window: list message ids,
+// fetch each not-yet-seen message, and ship it. On success the window's
+// high-water mark advances; on any error it does not, so the next poll re-covers
+// the same range (the deduper prevents re-shipping).
+func (a *GmailAdapter) poll() {
+	end := time.Now()
+	start := a.since.Add(-a.conf.Overlap)
+	query := buildQuery(a.conf.Query, start)
+
+	pageToken := ""
+	nFetched, nShipped := 0, 0
+	for page := 0; page < maxPagesPerPoll; page++ {
+		if a.doStop.IsSet() {
+			return
+		}
+
+		raw, ok := a.list(query, pageToken)
+		if !ok {
+			return
+		}
+		list, err := parseListMessages(raw)
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("gmail: list parse error: %v", err))
+			return
+		}
+
+		for _, ref := range list.Messages {
+			if a.doStop.IsSet() {
+				return
+			}
+			if ref.ID == "" {
+				continue
+			}
+
+			// Fetch before consulting the deduper: a fetch can fail and we must
+			// not mark a message seen unless it actually shipped. The overlap
+			// re-lists at most a couple of minutes of recent ids, so the
+			// redundant fetches are bounded.
+			msg, status := a.fetch(ref.ID)
+			switch status {
+			case fetchSkip:
+				continue
+			case fetchAbort:
+				return
+			}
+			nFetched++
+
+			if a.deduper.CheckAndAdd(ref.ID) {
+				continue
+			}
+			if !a.ship(ref.ID, msg) {
+				return
+			}
+			nShipped++
+		}
+
+		if list.NextPageToken == "" {
+			break
+		}
+		pageToken = list.NextPageToken
+	}
+
+	// Only advance the high-water mark once the poll fully succeeded.
+	a.since = end
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"gmail: poll complete (fetched=%d shipped=%d) up to %s",
+		nFetched, nShipped, end.UTC().Format(time.RFC3339)))
+}
+
+// list issues one messages.list request with transient-retry backoff. The bool
+// is false when the poll should be abandoned (a permanent error, or the adapter
+// is stopping).
+func (a *GmailAdapter) list(query, pageToken string) ([]byte, bool) {
+	raw, err := a.withRetry("messages.list", func() ([]byte, error) {
+		return a.client.ListMessages(a.ctx, listMessagesParams{
+			query:            query,
+			pageToken:        pageToken,
+			maxResults:       a.conf.MaxResults,
+			includeSpamTrash: a.conf.IncludeSpamTrash,
+			labelIDs:         a.conf.LabelIDs,
+		})
+	})
+	if err != nil {
+		a.handlePermanent("messages.list", err)
+		return nil, false
+	}
+	return raw, true
+}
+
+// fetchResult tells poll what to do after a messages.get attempt.
+type fetchResult int
+
+const (
+	fetchOK    fetchResult = iota // message fetched, proceed to dedupe/ship
+	fetchSkip                     // message gone (404); skip it, keep polling
+	fetchAbort                    // unrecoverable; abandon this poll
+)
+
+// fetch retrieves one message with transient-retry backoff and classifies the
+// outcome. A 404 (the message was deleted between the list and the get) is
+// benign and skipped; auth/permission failures abort and stop the adapter.
+func (a *GmailAdapter) fetch(id string) (utils.Dict, fetchResult) {
+	raw, err := a.withRetry("messages.get", func() ([]byte, error) {
+		return a.client.GetMessage(a.ctx, id, a.conf.Format, a.conf.MetadataHeaders)
+	})
+	if err != nil {
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			a.conf.ClientOptions.DebugLog(fmt.Sprintf("gmail: message %s vanished before fetch; skipping", id))
+			return nil, fetchSkip
+		}
+		a.handlePermanent("messages.get", err)
+		return nil, fetchAbort
+	}
+
+	msg, err := utils.UnmarshalCleanJSON(string(raw))
+	if err != nil {
+		a.conf.ClientOptions.OnError(fmt.Errorf("gmail: failed to parse message %s: %v", id, err))
+		return nil, fetchAbort
+	}
+	return utils.Dict(msg), fetchOK
+}
+
+// withRetry runs fn, retrying transient errors with exponential backoff. It
+// returns the final result, or the final (non-transient or attempts-exhausted)
+// error for the caller to classify. It does not set doStop.
+func (a *GmailAdapter) withRetry(label string, fn func() ([]byte, error)) ([]byte, error) {
+	var raw []byte
+	var err error
+	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
+		if a.doStop.IsSet() {
+			return nil, context.Canceled
+		}
+
+		raw, err = fn()
+		if err == nil {
+			return raw, nil
+		}
+		if !isTransientError(err) {
+			return nil, err
+		}
+		if attempt+1 >= a.conf.MaxRetryAttempts {
+			break
+		}
+		delay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
+		if delay > a.conf.MaxRetryDelay {
+			delay = a.conf.MaxRetryDelay
+		}
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"gmail: %s transient error (attempt %d/%d), retrying in %v: %v",
+			label, attempt+1, a.conf.MaxRetryAttempts, delay, err))
+		if a.doStop.WaitFor(delay) {
+			return nil, context.Canceled
+		}
+	}
+	return nil, fmt.Errorf("%s failed after %d attempts: %w", label, a.conf.MaxRetryAttempts, err)
+}
+
+// handlePermanent logs a non-recoverable error and, when it is a credential
+// failure, stops the adapter so it does not spin uselessly every interval. A
+// credential problem needs operator attention; other permanent errors (e.g. a
+// bad query) abandon this poll but keep the adapter alive to retry next interval.
+func (a *GmailAdapter) handlePermanent(label string, err error) {
+	if errors.Is(err, context.Canceled) {
+		// Adapter is stopping; not an error to surface.
+		return
+	}
+
+	var tokenErr *TokenError
+	var httpErr *HTTPError
+	if errors.As(err, &tokenErr) ||
+		(errors.As(err, &httpErr) &&
+			(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden)) {
+		a.conf.ClientOptions.OnError(fmt.Errorf("gmail: %s failed: %v", label, err))
+		a.conf.ClientOptions.OnError(fmt.Errorf(
+			"gmail: credentials rejected. Verify the OAuth client / refresh token (or service "+
+				"account key and that domain-wide delegation grants the %q scope for subject %q), "+
+				"and that the Gmail API is enabled for the project", strings.Join(a.conf.Scopes, ","), a.conf.Subject))
+		a.doStop.Set()
+		return
+	}
+	a.conf.ClientOptions.OnError(fmt.Errorf("gmail: %s failed: %v", label, err))
+}
+
+// ship forwards a single message to LimaCharlie. It returns false if the adapter
+// should stop (an unrecoverable shipping error).
+func (a *GmailAdapter) ship(id string, msg utils.Dict) bool {
+	dataMsg := &protocol.DataMessage{
+		JsonPayload: msg,
+		EventType:   eventType,
+		TimestampMs: eventTime(msg),
+	}
+	if err := a.uspClient.Ship(dataMsg, shipTimeout); err != nil {
+		if err == uspclient.ErrorBufferFull {
+			a.conf.ClientOptions.OnWarning("gmail: stream falling behind")
+			err = a.uspClient.Ship(dataMsg, 1*time.Hour)
+		}
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("gmail: Ship(): %v", err))
+			a.doStop.Set()
+			return false
+		}
+	}
+	return true
+}
+
+// buildQuery appends a time bound to the configured search query so each poll
+// only lists messages received at or after `start`. Gmail's `after:` operator
+// accepts an epoch-seconds value for second-level precision.
+func buildQuery(base string, start time.Time) string {
+	bound := fmt.Sprintf("after:%d", start.Unix())
+	base = strings.TrimSpace(base)
+	if base == "" {
+		return bound
+	}
+	return base + " " + bound
+}
+
+// eventTime extracts the message's event time from its internalDate (epoch
+// milliseconds, as a string), falling back to now when it is absent or
+// unparseable.
+func eventTime(msg utils.Dict) uint64 {
+	if raw := msg.FindOneString("internalDate"); raw != "" {
+		if ms, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); err == nil && ms > 0 {
+			return uint64(ms)
+		}
+	}
+	return uint64(time.Now().UnixMilli())
+}

--- a/gmail/client.go
+++ b/gmail/client.go
@@ -161,8 +161,11 @@ type GmailConfig struct {
 	// Domain restricts discovery to a single domain of a multi-domain Workspace.
 	Domain string `json:"domain" yaml:"domain"`
 
-	// DiscoveryQuery is an optional Directory API user search filter (e.g.
-	// "orgUnitPath=/Sales"); see the Directory API users.list "query" parameter.
+	// DiscoveryQuery is an optional Directory API user search filter, passed
+	// through verbatim as the users.list "query" parameter (e.g.
+	// "orgUnitPath='/Finance'" or "isSuspended=false"). See
+	// https://developers.google.com/admin-sdk/directory/v1/guides/search-users
+	// for the exact syntax (note that values like an org-unit path are quoted).
 	DiscoveryQuery string `json:"discovery_query" yaml:"discovery_query"`
 
 	// DiscoveryInterval is how often discovery re-enumerates. Default 1 hour.
@@ -484,6 +487,12 @@ type GmailAdapter struct {
 	newSink   sinkFactory
 	pollSlots chan struct{} // bounded poll-concurrency across all mailboxes
 
+	// apiRootCtx parents every Gmail and Directory API request (but not the
+	// sinks, which use ctx directly so they can still drain after apiCancel).
+	// Close cancels it to abort in-flight requests promptly.
+	apiRootCtx context.Context
+	apiCancel  context.CancelFunc
+
 	directory *directoryClient // nil unless discovery is enabled
 
 	mu          sync.Mutex
@@ -510,6 +519,7 @@ func newGmailAdapter(ctx context.Context, conf GmailConfig, newSink sinkFactory)
 		return nil, nil, err
 	}
 
+	apiRootCtx, apiCancel := context.WithCancel(ctx)
 	a := &GmailAdapter{
 		conf:       conf,
 		ctx:        ctx,
@@ -520,6 +530,8 @@ func newGmailAdapter(ctx context.Context, conf GmailConfig, newSink sinkFactory)
 		apiHTTP:    newAPIHTTPClient(),
 		newSink:    newSink,
 		pollSlots:  make(chan struct{}, conf.MaxConcurrentPolls),
+		apiRootCtx: apiRootCtx,
+		apiCancel:  apiCancel,
 		collectors: map[string]*mailboxCollector{},
 		doStop:     utils.NewEvent(),
 		chStopped:  make(chan struct{}),
@@ -528,6 +540,9 @@ func newGmailAdapter(ctx context.Context, conf GmailConfig, newSink sinkFactory)
 	if a.usesSA {
 		key, rsaKey, err := a.parseServiceAccount()
 		if err != nil {
+			a.apiCancel()
+			a.apiHTTP.CloseIdleConnections()
+			a.authHTTP.CloseIdleConnections()
 			return nil, nil, err
 		}
 		a.saKey, a.saRSA = key, rsaKey
@@ -548,6 +563,7 @@ func newGmailAdapter(ctx context.Context, conf GmailConfig, newSink sinkFactory)
 		}
 		if err := a.startCollector(t, delay); err != nil {
 			a.shutdownStartedCollectors()
+			a.apiCancel()
 			a.apiHTTP.CloseIdleConnections()
 			a.authHTTP.CloseIdleConnections()
 			return nil, nil, err
@@ -560,6 +576,7 @@ func newGmailAdapter(ctx context.Context, conf GmailConfig, newSink sinkFactory)
 		dir, err := a.newDirectoryClient()
 		if err != nil {
 			a.shutdownStartedCollectors()
+			a.apiCancel()
 			a.apiHTTP.CloseIdleConnections()
 			a.authHTTP.CloseIdleConnections()
 			return nil, nil, err
@@ -580,12 +597,13 @@ func newGmailAdapter(ctx context.Context, conf GmailConfig, newSink sinkFactory)
 // staticTargets enumerates the mailboxes known at startup (before discovery).
 func (a *GmailAdapter) staticTargets() []mailboxTarget {
 	if !a.usesSA {
-		return []mailboxTarget{{address: a.conf.UserID, subject: "", userID: a.conf.UserID}}
+		addr := canonicalMailbox(a.conf.UserID)
+		return []mailboxTarget{{address: addr, subject: "", userID: a.conf.UserID}}
 	}
 	seen := map[string]bool{}
 	var out []mailboxTarget
 	add := func(s string) {
-		s = strings.TrimSpace(s)
+		s = canonicalMailbox(s)
 		if s == "" || seen[s] {
 			return
 		}
@@ -597,6 +615,13 @@ func (a *GmailAdapter) staticTargets() []mailboxTarget {
 		add(s)
 	}
 	return out
+}
+
+// canonicalMailbox normalizes a mailbox address to a stable key. Workspace
+// addresses are case-insensitive, so two casings of the same mailbox must map to
+// one collector / one sensor / one dedupe namespace.
+func canonicalMailbox(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
 }
 
 // parseServiceAccount loads and parses the configured service-account key.
@@ -689,6 +714,12 @@ func (a *GmailAdapter) startCollector(t mailboxTarget, startDelay time.Duration)
 		since = now.Add(-a.conf.InitialLookback)
 	}
 
+	// The API context descends from the adapter's apiRootCtx so both this
+	// collector's requestStop and the adapter's Close can abort an in-flight Gmail
+	// request; the sink, by contrast, was created with the raw adapter context so
+	// cleanup can still drain it after the request context is cancelled.
+	apiCtx, apiCancel := context.WithCancel(a.apiRootCtx)
+
 	c := &mailboxCollector{
 		a:           a,
 		mailbox:     t.address,
@@ -696,6 +727,8 @@ func (a *GmailAdapter) startCollector(t mailboxTarget, startDelay time.Duration)
 		client:      client,
 		ts:          ts,
 		uspClient:   sink,
+		apiCtx:      apiCtx,
+		apiCancel:   apiCancel,
 		deduper:     deduper,
 		ownsDeduper: ownsDeduper,
 		since:       since,
@@ -758,8 +791,8 @@ func (a *GmailAdapter) shutdownStartedCollectors() {
 	}
 	for _, c := range cs {
 		<-c.stopped
-		_ = c.cleanup()
 	}
+	cleanupCollectors(cs)
 }
 
 // Close stops the adapter and all mailbox collectors. It is idempotent.
@@ -778,23 +811,49 @@ func (a *GmailAdapter) Close() error {
 		for _, c := range cs {
 			c.requestStop()
 		}
+		a.apiCancel()      // abort any in-flight Gmail/Directory request (e.g. a discovery enumeration)
 		a.wgSenders.Wait() // all collector loops and the discovery loop have exited
 
-		var firstErr error
-		for _, c := range cs {
-			if err := c.cleanup(); err != nil && firstErr == nil {
-				firstErr = err
-			}
-		}
+		// Drain the sensors concurrently: each Drain can wait up to a minute, and
+		// a large domain may have many mailboxes, so a serial loop could take far
+		// too long to shut down.
+		a.closeErr = cleanupCollectors(cs)
 
 		if a.directory != nil {
 			a.directory.Close()
 		}
 		a.apiHTTP.CloseIdleConnections()
 		a.authHTTP.CloseIdleConnections()
-		a.closeErr = firstErr
 	})
 	return a.closeErr
+}
+
+// cleanupCollectors drains and closes a set of collectors concurrently (bounded
+// fan-out), returning the first error. Each collector's cleanup is idempotent.
+func cleanupCollectors(cs []*mailboxCollector) error {
+	if len(cs) == 0 {
+		return nil
+	}
+	const maxConcurrentDrains = 16
+	sem := make(chan struct{}, maxConcurrentDrains)
+	errs := make([]error, len(cs))
+	var wg sync.WaitGroup
+	for i, c := range cs {
+		wg.Add(1)
+		go func(i int, c *mailboxCollector) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			errs[i] = c.cleanup()
+		}(i, c)
+	}
+	wg.Wait()
+	for _, e := range errs {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
 }
 
 // resolveBaseURL computes the Gmail API root from the config.

--- a/gmail/client_test.go
+++ b/gmail/client_test.go
@@ -16,6 +16,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// staticSink returns a sinkFactory that hands every mailbox the same sink. Used
+// by the single-mailbox tests, which assert against one captureSink.
+func staticSink(s uspSink) sinkFactory {
+	return func(context.Context, uspclient.ClientOptions, string) (uspSink, error) {
+		return s, nil
+	}
+}
+
 // testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
 // connection) with the logging callbacks pointed at the test log.
 func testClientOptions(t *testing.T) uspclient.ClientOptions {

--- a/gmail/client_test.go
+++ b/gmail/client_test.go
@@ -1,0 +1,311 @@
+package usp_gmail
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// --- unit tests: config validation ------------------------------------------
+
+func TestValidate(t *testing.T) {
+	refresh := func() GmailConfig {
+		return GmailConfig{
+			ClientOptions: testClientOptions(t),
+			ClientID:      "id", ClientSecret: "secret", RefreshToken: "rt",
+		}
+	}
+	serviceAccount := func() GmailConfig {
+		return GmailConfig{
+			ClientOptions:             testClientOptions(t),
+			ServiceAccountCredentials: `{"client_email":"x"}`,
+			Subject:                   "user@example.test",
+		}
+	}
+
+	t.Run("refresh flow requires every credential field", func(t *testing.T) {
+		for _, mut := range []func(*GmailConfig){
+			func(c *GmailConfig) { c.ClientID = "" },
+			func(c *GmailConfig) { c.ClientSecret = "" },
+			func(c *GmailConfig) { c.RefreshToken = "" },
+		} {
+			c := refresh()
+			mut(&c)
+			assert.Error(t, c.Validate())
+		}
+	})
+
+	t.Run("service account flow requires a subject", func(t *testing.T) {
+		c := serviceAccount()
+		c.Subject = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("rejects mixing both credential modes", func(t *testing.T) {
+		c := refresh()
+		c.ServiceAccountCredentials = `{"client_email":"x"}`
+		c.Subject = "user@example.test"
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("rejects no credentials at all", func(t *testing.T) {
+		c := GmailConfig{ClientOptions: testClientOptions(t)}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("rejects both inline and file service account", func(t *testing.T) {
+		c := serviceAccount()
+		c.ServiceAccountFile = "/tmp/key.json"
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("applies defaults", func(t *testing.T) {
+		c := refresh()
+		require.NoError(t, c.Validate())
+		assert.Equal(t, defaultUserID, c.UserID)
+		assert.Equal(t, defaultQuery, c.Query)
+		assert.Equal(t, defaultFormat, c.Format)
+		assert.Equal(t, defaultMaxResults, c.MaxResults)
+		assert.Equal(t, defaultPollInterval, c.PollInterval)
+		assert.Equal(t, defaultOverlap, c.Overlap)
+		assert.Equal(t, defaultDedupeTTL, c.DedupeTTL)
+		assert.Equal(t, defaultMaxRetryAttempts, c.MaxRetryAttempts)
+		assert.Equal(t, []string{gmailReadonlyScope}, c.Scopes)
+	})
+
+	t.Run("rejects an invalid format", func(t *testing.T) {
+		c := refresh()
+		c.Format = "html"
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("clamps max_results to the API ceiling", func(t *testing.T) {
+		c := refresh()
+		c.MaxResults = 9000
+		require.NoError(t, c.Validate())
+		assert.Equal(t, maxAllowedResults, c.MaxResults)
+	})
+}
+
+// --- unit tests: query building ---------------------------------------------
+
+func TestBuildQuery(t *testing.T) {
+	start := time.Unix(1716200000, 0)
+
+	t.Run("appends an epoch-seconds time bound to the base query", func(t *testing.T) {
+		assert.Equal(t, "in:inbox after:1716200000", buildQuery("in:inbox", start))
+	})
+	t.Run("handles an empty base query", func(t *testing.T) {
+		assert.Equal(t, "after:1716200000", buildQuery("  ", start))
+	})
+	t.Run("preserves a compound base query", func(t *testing.T) {
+		assert.Equal(t, "in:inbox -from:me after:1716200000", buildQuery("in:inbox -from:me", start))
+	})
+}
+
+// --- unit tests: event time -------------------------------------------------
+
+func TestEventTime(t *testing.T) {
+	t.Run("parses internalDate epoch milliseconds", func(t *testing.T) {
+		assert.Equal(t, uint64(1726234567000), eventTime(utils.Dict{"internalDate": "1726234567000"}))
+	})
+	t.Run("falls back to now when internalDate is missing", func(t *testing.T) {
+		before := uint64(time.Now().UnixMilli())
+		got := eventTime(utils.Dict{})
+		assert.GreaterOrEqual(t, got, before)
+	})
+	t.Run("falls back to now when internalDate is not numeric", func(t *testing.T) {
+		before := uint64(time.Now().UnixMilli())
+		got := eventTime(utils.Dict{"internalDate": "not-a-number"})
+		assert.GreaterOrEqual(t, got, before)
+	})
+}
+
+// --- unit tests: list parsing -----------------------------------------------
+
+func TestParseListMessages(t *testing.T) {
+	t.Run("parses message refs and the page token", func(t *testing.T) {
+		raw := []byte(`{"messages":[{"id":"a","threadId":"t1"},{"id":"b","threadId":"t2"}],"nextPageToken":"NPT","resultSizeEstimate":42}`)
+		resp, err := parseListMessages(raw)
+		require.NoError(t, err)
+		require.Len(t, resp.Messages, 2)
+		assert.Equal(t, "a", resp.Messages[0].ID)
+		assert.Equal(t, "t2", resp.Messages[1].ThreadID)
+		assert.Equal(t, "NPT", resp.NextPageToken)
+		assert.Equal(t, int64(42), resp.ResultSizeEstimate)
+	})
+	t.Run("an empty result set yields no messages", func(t *testing.T) {
+		// Gmail omits the messages field entirely when nothing matches.
+		resp, err := parseListMessages([]byte(`{"resultSizeEstimate":0}`))
+		require.NoError(t, err)
+		assert.Empty(t, resp.Messages)
+	})
+	t.Run("an empty body yields no messages", func(t *testing.T) {
+		resp, err := parseListMessages([]byte("  "))
+		require.NoError(t, err)
+		assert.Empty(t, resp.Messages)
+	})
+	t.Run("invalid json errors", func(t *testing.T) {
+		_, err := parseListMessages([]byte("not json"))
+		assert.Error(t, err)
+	})
+}
+
+// --- unit tests: error classification ---------------------------------------
+
+func TestIsTransientError(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		isTransient bool
+	}{
+		{"500", &HTTPError{StatusCode: 500}, true},
+		{"503", &HTTPError{StatusCode: 503}, true},
+		{"429", &HTTPError{StatusCode: 429}, true},
+		{"403 rate limit", &HTTPError{StatusCode: 403, Reason: "rateLimitExceeded"}, true},
+		{"403 user rate limit", &HTTPError{StatusCode: 403, Reason: "userRateLimitExceeded"}, true},
+		{"403 permission denied", &HTTPError{StatusCode: 403, Reason: "forbidden"}, false},
+		{"401", &HTTPError{StatusCode: 401}, false},
+		{"404", &HTTPError{StatusCode: 404}, false},
+		{"400", &HTTPError{StatusCode: 400}, false},
+		{"token error wrapping 400", &TokenError{Err: &HTTPError{StatusCode: 400}}, false},
+		{"token error wrapping 500", &TokenError{Err: &HTTPError{StatusCode: 500}}, true},
+		{"network", fmt.Errorf("failed to execute request %q: connection refused", "x"), true},
+		{"context canceled", context.Canceled, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.isTransient, isTransientError(c.err))
+		})
+	}
+}
+
+func TestParseHTTPError(t *testing.T) {
+	t.Run("extracts the reason from the errors array", func(t *testing.T) {
+		body := `{"error":{"code":403,"message":"Rate Limit Exceeded","errors":[{"reason":"rateLimitExceeded"}],"status":"PERMISSION_DENIED"}}`
+		e := parseHTTPError(403, "http://x", body)
+		assert.Equal(t, 403, e.StatusCode)
+		assert.Equal(t, "rateLimitExceeded", e.Reason)
+	})
+	t.Run("falls back to the status when no reason array", func(t *testing.T) {
+		body := `{"error":{"code":401,"message":"Invalid Credentials","status":"UNAUTHENTICATED"}}`
+		e := parseHTTPError(401, "http://x", body)
+		assert.Equal(t, "UNAUTHENTICATED", e.Reason)
+	})
+	t.Run("tolerates a non-envelope body", func(t *testing.T) {
+		e := parseHTTPError(500, "http://x", "upstream boom")
+		assert.Equal(t, 500, e.StatusCode)
+		assert.Empty(t, e.Reason)
+	})
+}
+
+func TestResolveURLs(t *testing.T) {
+	assert.Equal(t, gmailAPIBaseURL, resolveBaseURL(GmailConfig{}))
+	assert.Equal(t, "https://example.test", resolveBaseURL(GmailConfig{BaseURL: "https://example.test/"}))
+	assert.Equal(t, googleTokenEndpoint, resolveTokenURL(GmailConfig{}))
+	assert.Equal(t, "https://token.test", resolveTokenURL(GmailConfig{TokenURL: "https://token.test"}))
+}
+
+// --- integration test: request shape ----------------------------------------
+
+// TestRequestShape asserts the adapter authenticates and issues well-formed
+// Gmail API requests: a bearer-token GET to users.messages.list carrying the
+// time-bounded query and page size, then a bearer-token GET to
+// users.messages.get carrying the requested format.
+func TestRequestShape(t *testing.T) {
+	var mu sync.Mutex
+	var listMethod, listAuth, listQ, listMax string
+	var getMethod, getAuth, getFormat, getPath string
+	listHits, getHits := 0, 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"AT-1","token_type":"Bearer","expires_in":3600}`))
+	})
+	mux.HandleFunc("/gmail/v1/users/me/messages", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		listHits++
+		listMethod = r.Method
+		listAuth = r.Header.Get("Authorization")
+		listQ = r.URL.Query().Get("q")
+		listMax = r.URL.Query().Get("maxResults")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"messages":[{"id":"m1","threadId":"t1"}]}`))
+	})
+	mux.HandleFunc("/gmail/v1/users/me/messages/", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		getHits++
+		getMethod = r.Method
+		getAuth = r.Header.Get("Authorization")
+		getFormat = r.URL.Query().Get("format")
+		getPath = r.URL.Path
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"m1","threadId":"t1","internalDate":"1726234567000","payload":{"headers":[]}}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := GmailConfig{
+		ClientOptions: testClientOptions(t),
+		ClientID:      "cid", ClientSecret: "csec", RefreshToken: "rt",
+		BaseURL:      server.URL,
+		TokenURL:     server.URL + "/token",
+		PollInterval: 40 * time.Millisecond,
+		MaxResults:   25,
+		Query:        "in:inbox",
+	}
+	adapter, _, err := NewGmailAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return listHits >= 1 && getHits >= 1
+	}, 3*time.Second, 20*time.Millisecond, "adapter never completed an authenticated list+get")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, http.MethodGet, listMethod)
+	assert.Equal(t, "Bearer AT-1", listAuth)
+	assert.Equal(t, "25", listMax)
+	assert.True(t, strings.HasPrefix(listQ, "in:inbox after:"), "query must carry the base query and a time bound, got %q", listQ)
+	assert.Equal(t, http.MethodGet, getMethod)
+	assert.Equal(t, "Bearer AT-1", getAuth)
+	assert.Equal(t, "full", getFormat)
+	assert.Equal(t, "/gmail/v1/users/me/messages/m1", getPath)
+}

--- a/gmail/client_test.go
+++ b/gmail/client_test.go
@@ -106,6 +106,21 @@ func TestValidate(t *testing.T) {
 		assert.Error(t, c.Validate())
 	})
 
+	t.Run("defaults to message collection when no capability is set", func(t *testing.T) {
+		c := refresh()
+		require.NoError(t, c.Validate())
+		assert.True(t, c.CollectMessages, "messages must default on for backward compatibility")
+		assert.Equal(t, defaultSettingsPollInterval, c.SettingsPollInterval)
+	})
+
+	t.Run("does not force messages on when a BEC capability is selected", func(t *testing.T) {
+		c := refresh()
+		c.CollectFilters = true
+		require.NoError(t, c.Validate())
+		assert.False(t, c.CollectMessages, "selecting only a BEC capability must leave messages off")
+		assert.True(t, c.CollectFilters)
+	})
+
 	t.Run("clamps max_results to the API ceiling", func(t *testing.T) {
 		c := refresh()
 		c.MaxResults = 9000

--- a/gmail/collector.go
+++ b/gmail/collector.go
@@ -1,0 +1,408 @@
+package usp_gmail
+
+// This file implements the per-mailbox collector. The adapter (client.go) runs
+// one mailboxCollector per mailbox it is configured to watch, and each collector
+// ships to that mailbox's own LimaCharlie sensor. A collector owns everything
+// that is mailbox-specific: its Gmail client (bound to one impersonated subject),
+// its token source, its sensor sink, its collection state (the message
+// high-water mark, the settings clock, the history cursor) and its dedupe keys.
+//
+// Collectors share nothing mutable with each other except, optionally, a single
+// embedder-provided deduper -- and even then every dedupe key is namespaced with
+// the mailbox address so two mailboxes that hold an identical item (the same
+// filter, say) never suppress each other.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	uspclient "github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+// Dedupe-key namespaces. Every key is additionally prefixed with the mailbox
+// address (see dkey) so keys never collide across mailboxes.
+const (
+	dedupeKindMessage = "msg"
+	dedupeKindHistory = "history"
+)
+
+// mailboxCollector collects from exactly one mailbox.
+type mailboxCollector struct {
+	a       *GmailAdapter
+	mailbox string // mailbox address; identifies the sensor and namespaces dedupe keys
+	tag     string // log prefix, e.g. `gmail[user@x]`
+
+	client    *GmailClient
+	ts        *tokenSource
+	uspClient uspSink
+
+	deduper     utils.Deduper
+	ownsDeduper bool
+
+	// since is the high-water mark of the message collection window. It advances
+	// to the poll's end time after every fully-successful message poll.
+	since time.Time
+	// lastSettings is when the configuration-state capabilities last ran.
+	lastSettings time.Time
+	// lastHistoryID is the users.history.list cursor.
+	lastHistoryID string
+
+	// startDelay staggers the collector's first poll so that, when many mailboxes
+	// start together, they do not all hit the Gmail API in the same instant.
+	startDelay time.Duration
+
+	// stop carries the stop signal two ways: the Event drives WaitFor sleeps and
+	// IsSet checks, while stopCh (closed once) is selectable alongside the
+	// adapter's poll-slot channel. requestStop trips both.
+	stop     *utils.Event
+	stopCh   chan struct{}
+	stopOnce sync.Once
+
+	stopped   chan struct{} // closed when run() returns
+	cleanOnce sync.Once
+}
+
+// requestStop signals this collector to wind down. It is idempotent.
+func (c *mailboxCollector) requestStop() {
+	c.stopOnce.Do(func() {
+		close(c.stopCh)
+		c.stop.Set()
+	})
+}
+
+// run polls this mailbox until the collector is stopped (by the adapter closing,
+// or by this mailbox being deprovisioned, or by a fatal credential error).
+func (c *mailboxCollector) run() {
+	defer c.a.wgSenders.Done()
+	defer close(c.stopped)
+	defer c.a.conf.ClientOptions.DebugLog(c.tag + ": collection stopped")
+
+	if c.startDelay > 0 {
+		if c.stop.WaitFor(c.startDelay) {
+			return
+		}
+	}
+
+	isFirstRun := true
+	for isFirstRun || !c.stop.WaitFor(c.a.conf.PollInterval) {
+		isFirstRun = false
+		c.runCycle()
+	}
+}
+
+// runCycle runs one tick of every enabled capability for this mailbox, while
+// holding one of the adapter's bounded poll slots so concurrent API usage across
+// all mailboxes stays capped. A capability failing does not abort the others.
+func (c *mailboxCollector) runCycle() {
+	if !c.acquire() {
+		return
+	}
+	defer c.release()
+
+	if c.a.conf.CollectMessages {
+		c.pollMessages()
+	}
+	if c.stop.IsSet() {
+		return
+	}
+	if c.a.conf.CollectHistory {
+		c.pollHistory()
+	}
+	if c.stop.IsSet() {
+		return
+	}
+	if c.a.conf.anySettingsCapabilityEnabled() && c.settingsDue(time.Now()) {
+		c.pollSettings()
+		c.lastSettings = time.Now()
+	}
+}
+
+// acquire takes a poll slot from the adapter's concurrency limiter, returning
+// false if the collector is asked to stop while waiting.
+func (c *mailboxCollector) acquire() bool {
+	select {
+	case c.a.pollSlots <- struct{}{}:
+		return true
+	case <-c.stopCh:
+		return false
+	}
+}
+
+func (c *mailboxCollector) release() { <-c.a.pollSlots }
+
+// settingsDue reports whether the configuration-state capabilities should run
+// this cycle: always on the first pass, then once per SettingsPollInterval.
+func (c *mailboxCollector) settingsDue(now time.Time) bool {
+	return c.lastSettings.IsZero() || now.Sub(c.lastSettings) >= c.a.conf.SettingsPollInterval
+}
+
+// dkey builds a dedupe key namespaced to this mailbox so identical items in
+// different mailboxes never collide (and so a shared embedder deduper stays
+// correct across mailboxes).
+func (c *mailboxCollector) dkey(kind, id string) string {
+	return c.mailbox + "\x00" + kind + "\x00" + id
+}
+
+// pollMessages performs one message collection cycle over the rolling window:
+// list message ids, fetch each not-yet-seen message, and ship it. On success the
+// window's high-water mark advances; on any error it does not, so the next poll
+// re-covers the same range (the deduper prevents re-shipping).
+func (c *mailboxCollector) pollMessages() {
+	end := time.Now()
+	start := c.since.Add(-c.a.conf.Overlap)
+	query := buildQuery(c.a.conf.Query, start)
+
+	pageToken := ""
+	nFetched, nShipped := 0, 0
+	for page := 0; page < maxPagesPerPoll; page++ {
+		if c.stop.IsSet() {
+			return
+		}
+
+		raw, ok := c.list(query, pageToken)
+		if !ok {
+			return
+		}
+		list, err := parseListMessages(raw)
+		if err != nil {
+			c.a.conf.ClientOptions.OnError(fmt.Errorf("%s: list parse error: %v", c.tag, err))
+			return
+		}
+
+		for _, ref := range list.Messages {
+			if c.stop.IsSet() {
+				return
+			}
+			if ref.ID == "" {
+				continue
+			}
+
+			// Fetch before consulting the deduper: a fetch can fail and we must
+			// not mark a message seen unless it actually shipped.
+			msg, status := c.fetch(ref.ID)
+			switch status {
+			case fetchSkip:
+				continue
+			case fetchAbort:
+				return
+			}
+			nFetched++
+
+			if c.deduper.CheckAndAdd(c.dkey(dedupeKindMessage, ref.ID)) {
+				continue
+			}
+			if !c.ship(msg) {
+				return
+			}
+			nShipped++
+		}
+
+		if list.NextPageToken == "" {
+			break
+		}
+		pageToken = list.NextPageToken
+	}
+
+	// Only advance the high-water mark once the poll fully succeeded.
+	c.since = end
+	c.a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"%s: poll complete (fetched=%d shipped=%d) up to %s",
+		c.tag, nFetched, nShipped, end.UTC().Format(time.RFC3339)))
+}
+
+// list issues one messages.list request with transient-retry backoff. The bool
+// is false when the poll should be abandoned (a permanent error, or the
+// collector is stopping).
+func (c *mailboxCollector) list(query, pageToken string) ([]byte, bool) {
+	raw, err := c.withRetry("messages.list", func() ([]byte, error) {
+		return c.client.ListMessages(c.a.ctx, listMessagesParams{
+			query:            query,
+			pageToken:        pageToken,
+			maxResults:       c.a.conf.MaxResults,
+			includeSpamTrash: c.a.conf.IncludeSpamTrash,
+			labelIDs:         c.a.conf.LabelIDs,
+		})
+	})
+	if err != nil {
+		c.handlePermanent("messages.list", err)
+		return nil, false
+	}
+	return raw, true
+}
+
+// fetchResult tells the poll what to do after a messages.get attempt.
+type fetchResult int
+
+const (
+	fetchOK    fetchResult = iota // message fetched, proceed to dedupe/ship
+	fetchSkip                     // message gone (404); skip it, keep polling
+	fetchAbort                    // unrecoverable; abandon this poll
+)
+
+// fetch retrieves one message with transient-retry backoff and classifies the
+// outcome. A 404 (the message was deleted between the list and the get) is
+// benign and skipped; auth/permission failures abort and stop this collector.
+func (c *mailboxCollector) fetch(id string) (utils.Dict, fetchResult) {
+	raw, err := c.withRetry("messages.get", func() ([]byte, error) {
+		return c.client.GetMessage(c.a.ctx, id, c.a.conf.Format, c.a.conf.MetadataHeaders)
+	})
+	if err != nil {
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			c.a.conf.ClientOptions.DebugLog(fmt.Sprintf("%s: message %s vanished before fetch; skipping", c.tag, id))
+			return nil, fetchSkip
+		}
+		c.handlePermanent("messages.get", err)
+		return nil, fetchAbort
+	}
+
+	msg, err := utils.UnmarshalCleanJSON(string(raw))
+	if err != nil {
+		c.a.conf.ClientOptions.OnError(fmt.Errorf("%s: failed to parse message %s: %v", c.tag, id, err))
+		return nil, fetchAbort
+	}
+	return utils.Dict(msg), fetchOK
+}
+
+// withRetry runs fn, retrying transient errors with exponential backoff. It
+// returns the final result, or the final (non-transient or attempts-exhausted)
+// error for the caller to classify. It does not set the stop event.
+func (c *mailboxCollector) withRetry(label string, fn func() ([]byte, error)) ([]byte, error) {
+	var raw []byte
+	var err error
+	for attempt := 0; attempt < c.a.conf.MaxRetryAttempts; attempt++ {
+		if c.stop.IsSet() {
+			return nil, context.Canceled
+		}
+
+		raw, err = fn()
+		if err == nil {
+			return raw, nil
+		}
+		if !isTransientError(err) {
+			return nil, err
+		}
+		if attempt+1 >= c.a.conf.MaxRetryAttempts {
+			break
+		}
+		delay := c.a.conf.RetryBaseDelay * time.Duration(1<<attempt)
+		if delay > c.a.conf.MaxRetryDelay {
+			delay = c.a.conf.MaxRetryDelay
+		}
+		c.a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"%s: %s transient error (attempt %d/%d), retrying in %v: %v",
+			c.tag, label, attempt+1, c.a.conf.MaxRetryAttempts, delay, err))
+		if c.stop.WaitFor(delay) {
+			return nil, context.Canceled
+		}
+	}
+	return nil, fmt.Errorf("%s failed after %d attempts: %w", label, c.a.conf.MaxRetryAttempts, err)
+}
+
+// handlePermanent logs a non-recoverable error and, when it is a credential
+// failure, stops this collector so it does not spin uselessly every interval. A
+// credential problem needs operator attention; other permanent errors (e.g. a
+// bad query) abandon this poll but keep the collector alive to retry next
+// interval. Only this mailbox's collector is affected -- its siblings keep
+// running, since a rejected impersonation for one subject does not imply the
+// others are dead.
+func (c *mailboxCollector) handlePermanent(label string, err error) {
+	if errors.Is(err, context.Canceled) {
+		// Collector is stopping; not an error to surface.
+		return
+	}
+
+	var tokenErr *TokenError
+	var httpErr *HTTPError
+	if errors.As(err, &tokenErr) ||
+		(errors.As(err, &httpErr) &&
+			(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden)) {
+		c.a.conf.ClientOptions.OnError(fmt.Errorf("%s: %s failed: %v", c.tag, label, err))
+		c.a.conf.ClientOptions.OnError(fmt.Errorf(
+			"%s: credentials rejected for this mailbox. Verify the OAuth client / refresh token "+
+				"(or that domain-wide delegation grants the %q scope for subject %q), and that the "+
+				"Gmail API is enabled for the project", c.tag, strings.Join(c.a.conf.Scopes, ","), c.mailbox))
+		c.requestStop()
+		return
+	}
+	c.a.conf.ClientOptions.OnError(fmt.Errorf("%s: %s failed: %v", c.tag, label, err))
+}
+
+// ship forwards a single incoming message to this mailbox's sensor.
+func (c *mailboxCollector) ship(msg utils.Dict) bool {
+	return c.shipEvent(eventTypeMessage, msg, eventTime(msg))
+}
+
+// shipEvent forwards one event of the given type to this mailbox's sensor. It
+// returns false if the collector should stop (an unrecoverable shipping error).
+func (c *mailboxCollector) shipEvent(evtType string, payload utils.Dict, tsMs uint64) bool {
+	dataMsg := &protocol.DataMessage{
+		JsonPayload: payload,
+		EventType:   evtType,
+		TimestampMs: tsMs,
+	}
+	if err := c.uspClient.Ship(dataMsg, shipTimeout); err != nil {
+		if err == uspclient.ErrorBufferFull {
+			c.a.conf.ClientOptions.OnWarning(c.tag + ": stream falling behind")
+			err = c.uspClient.Ship(dataMsg, 1*time.Hour)
+		}
+		if err != nil {
+			c.a.conf.ClientOptions.OnError(fmt.Errorf("%s: Ship(): %v", c.tag, err))
+			c.requestStop()
+			return false
+		}
+	}
+	return true
+}
+
+// cleanup drains and closes this collector's sensor and releases its owned
+// deduper. It is idempotent and safe to call once the run loop has returned. The
+// token source and Gmail client hold shared HTTP transports owned by the adapter,
+// so they are not closed here.
+func (c *mailboxCollector) cleanup() error {
+	var err error
+	c.cleanOnce.Do(func() {
+		if c.uspClient != nil {
+			err = c.uspClient.Drain(1 * time.Minute)
+			if _, e := c.uspClient.Close(); err == nil {
+				err = e
+			}
+		}
+		if c.ownsDeduper && c.deduper != nil {
+			c.deduper.Close()
+		}
+	})
+	return err
+}
+
+// eventTime extracts the message's event time from its internalDate (epoch
+// milliseconds, as a string), falling back to now when it is absent or
+// unparseable.
+func eventTime(msg utils.Dict) uint64 {
+	if raw := msg.FindOneString("internalDate"); raw != "" {
+		if ms, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); err == nil && ms > 0 {
+			return uint64(ms)
+		}
+	}
+	return uint64(time.Now().UnixMilli())
+}
+
+// buildQuery appends a time bound to the configured search query so each poll
+// only lists messages received at or after `start`. Gmail's `after:` operator
+// accepts an epoch-seconds value for second-level precision.
+func buildQuery(base string, start time.Time) string {
+	bound := fmt.Sprintf("after:%d", start.Unix())
+	base = strings.TrimSpace(base)
+	if base == "" {
+		return bound
+	}
+	return base + " " + bound
+}

--- a/gmail/collector.go
+++ b/gmail/collector.go
@@ -44,6 +44,13 @@ type mailboxCollector struct {
 	ts        *tokenSource
 	uspClient uspSink
 
+	// apiCtx scopes every Gmail API request for this mailbox; apiCancel aborts an
+	// in-flight request the instant the collector is asked to stop, so shutdown
+	// and deprovisioning do not wait out the HTTP timeout. It descends from the
+	// adapter context, not the sink context, so cleanup can still drain the sink.
+	apiCtx    context.Context
+	apiCancel context.CancelFunc
+
 	deduper     utils.Deduper
 	ownsDeduper bool
 
@@ -70,11 +77,16 @@ type mailboxCollector struct {
 	cleanOnce sync.Once
 }
 
-// requestStop signals this collector to wind down. It is idempotent.
+// requestStop signals this collector to wind down. It trips the stop Event and
+// stopCh (waking sleeps and selects) and cancels any in-flight API request. It is
+// idempotent.
 func (c *mailboxCollector) requestStop() {
 	c.stopOnce.Do(func() {
 		close(c.stopCh)
 		c.stop.Set()
+		if c.apiCancel != nil {
+			c.apiCancel()
+		}
 	})
 }
 
@@ -98,15 +110,12 @@ func (c *mailboxCollector) run() {
 	}
 }
 
-// runCycle runs one tick of every enabled capability for this mailbox, while
-// holding one of the adapter's bounded poll slots so concurrent API usage across
-// all mailboxes stays capped. A capability failing does not abort the others.
+// runCycle runs one tick of every enabled capability for this mailbox. Each
+// individual API request acquires one of the adapter's bounded poll slots (see
+// withRetry), so concurrent API usage across all mailboxes stays capped without a
+// slow mailbox holding a slot across its whole cycle. A capability failing does
+// not abort the others.
 func (c *mailboxCollector) runCycle() {
-	if !c.acquire() {
-		return
-	}
-	defer c.release()
-
 	if c.a.conf.CollectMessages {
 		c.pollMessages()
 	}
@@ -223,7 +232,7 @@ func (c *mailboxCollector) pollMessages() {
 // collector is stopping).
 func (c *mailboxCollector) list(query, pageToken string) ([]byte, bool) {
 	raw, err := c.withRetry("messages.list", func() ([]byte, error) {
-		return c.client.ListMessages(c.a.ctx, listMessagesParams{
+		return c.client.ListMessages(c.apiCtx, listMessagesParams{
 			query:            query,
 			pageToken:        pageToken,
 			maxResults:       c.a.conf.MaxResults,
@@ -252,7 +261,7 @@ const (
 // benign and skipped; auth/permission failures abort and stop this collector.
 func (c *mailboxCollector) fetch(id string) (utils.Dict, fetchResult) {
 	raw, err := c.withRetry("messages.get", func() ([]byte, error) {
-		return c.client.GetMessage(c.a.ctx, id, c.a.conf.Format, c.a.conf.MetadataHeaders)
+		return c.client.GetMessage(c.apiCtx, id, c.a.conf.Format, c.a.conf.MetadataHeaders)
 	})
 	if err != nil {
 		var httpErr *HTTPError
@@ -272,9 +281,12 @@ func (c *mailboxCollector) fetch(id string) (utils.Dict, fetchResult) {
 	return utils.Dict(msg), fetchOK
 }
 
-// withRetry runs fn, retrying transient errors with exponential backoff. It
-// returns the final result, or the final (non-transient or attempts-exhausted)
-// error for the caller to classify. It does not set the stop event.
+// withRetry runs fn, retrying transient errors with exponential backoff. Each
+// attempt holds one of the adapter's poll slots only for the duration of the call
+// (not across the backoff sleep), so the concurrency cap bounds in-flight API
+// requests without a backing-off mailbox starving the others. It returns the
+// final result, or the final (non-transient or attempts-exhausted) error for the
+// caller to classify. It does not set the stop event.
 func (c *mailboxCollector) withRetry(label string, fn func() ([]byte, error)) ([]byte, error) {
 	var raw []byte
 	var err error
@@ -283,7 +295,12 @@ func (c *mailboxCollector) withRetry(label string, fn func() ([]byte, error)) ([
 			return nil, context.Canceled
 		}
 
+		if !c.acquire() {
+			return nil, context.Canceled
+		}
 		raw, err = fn()
+		c.release()
+
 		if err == nil {
 			return raw, nil
 		}
@@ -349,16 +366,26 @@ func (c *mailboxCollector) shipEvent(evtType string, payload utils.Dict, tsMs ui
 		EventType:   evtType,
 		TimestampMs: tsMs,
 	}
-	if err := c.uspClient.Ship(dataMsg, shipTimeout); err != nil {
-		if err == uspclient.ErrorBufferFull {
-			c.a.conf.ClientOptions.OnWarning(c.tag + ": stream falling behind")
-			err = c.uspClient.Ship(dataMsg, 1*time.Hour)
+	err := c.uspClient.Ship(dataMsg, shipTimeout)
+	if err == uspclient.ErrorBufferFull {
+		// The stream is backed up. Keep trying in bounded steps, rechecking the
+		// stop signal between attempts so a stalled sensor cannot block shutdown
+		// or deprovisioning indefinitely.
+		c.a.conf.ClientOptions.OnWarning(c.tag + ": stream falling behind")
+		for {
+			if c.stop.IsSet() {
+				return false
+			}
+			err = c.uspClient.Ship(dataMsg, shipTimeout)
+			if err != uspclient.ErrorBufferFull {
+				break
+			}
 		}
-		if err != nil {
-			c.a.conf.ClientOptions.OnError(fmt.Errorf("%s: Ship(): %v", c.tag, err))
-			c.requestStop()
-			return false
-		}
+	}
+	if err != nil {
+		c.a.conf.ClientOptions.OnError(fmt.Errorf("%s: Ship(): %v", c.tag, err))
+		c.requestStop()
+		return false
 	}
 	return true
 }

--- a/gmail/discovery.go
+++ b/gmail/discovery.go
@@ -35,10 +35,13 @@ const directoryAPIBaseURL = "https://admin.googleapis.com"
 const directoryMaxResults = 500
 
 // discoveredUser is the subset of a Directory API user resource we use.
+//
+// Only `suspended` is consulted for filtering: it is returned under the default
+// "basic" projection. (`archived` is not part of the basic projection, so it
+// would always read false here and cannot be relied on.)
 type discoveredUser struct {
 	PrimaryEmail string `json:"primaryEmail"`
 	Suspended    bool   `json:"suspended"`
-	Archived     bool   `json:"archived"`
 }
 
 // directoryUsersResponse mirrors the users.list response envelope.
@@ -147,39 +150,42 @@ func (d *directoryClient) getOnce(ctx context.Context, reqURL string, forceToken
 	return respBody, nil
 }
 
-// enumerate walks every page of the domain's users and returns the mailbox
-// addresses to collect, honoring the suspended/archived filters.
-func (d *directoryClient) enumerate(ctx context.Context, conf GmailConfig) ([]string, error) {
-	var out []string
+// enumerate walks every page of the domain's users and returns the canonicalized
+// mailbox addresses to collect, skipping suspended accounts (unless
+// IncludeSuspended). `complete` is false if the page cap was hit before the
+// listing ended, i.e. the result is a truncated view of the domain -- callers
+// must not treat a truncated result as authoritative for removals.
+func (d *directoryClient) enumerate(ctx context.Context, conf GmailConfig) (emails []string, complete bool, err error) {
 	seen := map[string]bool{}
 	pageToken := ""
 	for page := 0; page < maxPagesPerPoll; page++ {
-		resp, err := d.listUsers(ctx, listUsersParams{
+		resp, lerr := d.listUsers(ctx, listUsersParams{
 			customer:  conf.Customer,
 			domain:    conf.Domain,
 			query:     conf.DiscoveryQuery,
 			pageToken: pageToken,
 		})
-		if err != nil {
-			return nil, err
+		if lerr != nil {
+			return nil, false, lerr
 		}
 		for _, u := range resp.Users {
-			email := strings.TrimSpace(u.PrimaryEmail)
+			if u.Suspended && !conf.IncludeSuspended {
+				continue
+			}
+			email := canonicalMailbox(u.PrimaryEmail)
 			if email == "" || seen[email] {
 				continue
 			}
-			if (u.Suspended || u.Archived) && !conf.IncludeSuspended {
-				continue
-			}
 			seen[email] = true
-			out = append(out, email)
+			emails = append(emails, email)
 		}
 		if resp.NextPageToken == "" {
-			break
+			return emails, true, nil
 		}
 		pageToken = resp.NextPageToken
 	}
-	return out, nil
+	// Loop exited on the page cap, not an empty nextPageToken: the view is partial.
+	return emails, false, nil
 }
 
 // runDiscovery enumerates the domain immediately, then re-enumerates every
@@ -202,7 +208,7 @@ func (a *GmailAdapter) runDiscovery() {
 // discoverOnce performs one enumeration + reconciliation pass. Errors are logged
 // and the pass is abandoned; the static mailboxes keep collecting regardless.
 func (a *GmailAdapter) discoverOnce() {
-	emails, err := a.directory.enumerate(a.ctx, a.conf)
+	emails, complete, err := a.directory.enumerate(a.apiRootCtx, a.conf)
 	if err != nil {
 		a.conf.ClientOptions.OnWarning(fmt.Sprintf("gmail: mailbox discovery failed, keeping the current set: %v", err))
 		return
@@ -235,20 +241,34 @@ func (a *GmailAdapter) discoverOnce() {
 		nAdded++
 	}
 
-	// Stop collectors for mailboxes that are no longer present (never the static
+	// Determine which active mailboxes are no longer present (never the static
 	// ones, which are always in `desired`).
-	nRemoved := 0
+	var stale []string
 	for addr := range a.activeMailboxes() {
-		if desired[addr] {
-			continue
+		if !desired[addr] {
+			stale = append(stale, addr)
 		}
+	}
+
+	// Guard against mass teardown on a suspicious enumeration. A truncated view
+	// (page cap hit) is not authoritative, and an empty result while we are
+	// already collecting discovered mailboxes is far more likely a misconfigured
+	// query or a transient API state than the whole domain vanishing. In those
+	// cases, keep the current set and try again next interval.
+	if len(stale) > 0 && (!complete || len(emails) == 0) {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"gmail: discovery returned a %s result (%d mailboxes); keeping %d existing collector(s) rather than removing them",
+			map[bool]string{true: "truncated", false: "complete"}[!complete], len(emails), len(stale)))
+		stale = nil
+	}
+
+	for _, addr := range stale {
 		a.removeCollector(addr)
-		nRemoved++
 	}
 
 	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
 		"gmail: discovery pass complete (discovered=%d added=%d removed=%d active=%d)",
-		len(emails), nAdded, nRemoved, len(a.activeMailboxes())))
+		len(emails), nAdded, len(stale), len(a.activeMailboxes())))
 }
 
 // resolveDirectoryBaseURL computes the Directory API root from the config.

--- a/gmail/discovery.go
+++ b/gmail/discovery.go
@@ -1,0 +1,260 @@
+package usp_gmail
+
+// This file implements automatic mailbox discovery via the Admin SDK Directory
+// API. When enabled, the adapter periodically enumerates the Workspace domain's
+// users and reconciles the running set of per-mailbox collectors against it:
+// newly-provisioned mailboxes get a collector (and their own sensor), and
+// deprovisioned ones are stopped and torn down. Mailboxes named explicitly in
+// the config (subject / subjects) are always kept regardless of what discovery
+// returns.
+//
+// Discovery impersonates an administrator (admin_subject) and needs the
+// admin.directory.user.readonly scope in the service account's domain-wide
+// delegation. The Gmail collection of each discovered mailbox still impersonates
+// that mailbox with the Gmail scope.
+//
+// Reference:
+// https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// directoryAPIBaseURL is the root of the Admin SDK Directory API.
+const directoryAPIBaseURL = "https://admin.googleapis.com"
+
+// directoryMaxResults is the page size for the users.list enumeration (the API
+// caps this at 500).
+const directoryMaxResults = 500
+
+// discoveredUser is the subset of a Directory API user resource we use.
+type discoveredUser struct {
+	PrimaryEmail string `json:"primaryEmail"`
+	Suspended    bool   `json:"suspended"`
+	Archived     bool   `json:"archived"`
+}
+
+// directoryUsersResponse mirrors the users.list response envelope.
+type directoryUsersResponse struct {
+	Users         []discoveredUser `json:"users"`
+	NextPageToken string           `json:"nextPageToken"`
+}
+
+// directoryClient is a thin Admin SDK Directory API client for enumerating the
+// domain's mailboxes. Like GmailClient, it refreshes its token once on a 401.
+type directoryClient struct {
+	baseURL    string
+	ts         *tokenSource
+	httpClient *http.Client
+}
+
+// newDirectoryClient builds the Directory API client used for discovery. It
+// impersonates the configured admin subject with the directory read-only scope.
+func (a *GmailAdapter) newDirectoryClient() (*directoryClient, error) {
+	ts := newServiceAccountSource(
+		a.saKey, a.saRSA, a.conf.AdminSubject,
+		[]string{adminDirectoryUserReadonlyScope}, a.tokenURL, a.authHTTP)
+	return &directoryClient{
+		baseURL:    resolveDirectoryBaseURL(a.conf),
+		ts:         ts,
+		httpClient: newAPIHTTPClient(),
+	}, nil
+}
+
+func (d *directoryClient) Close() {
+	d.ts.Close()
+	d.httpClient.CloseIdleConnections()
+}
+
+// listUsersParams bundles the query knobs for one users.list page.
+type listUsersParams struct {
+	customer  string
+	domain    string
+	query     string
+	pageToken string
+}
+
+// listUsers issues one users.list request and returns the parsed page.
+func (d *directoryClient) listUsers(ctx context.Context, p listUsersParams) (*directoryUsersResponse, error) {
+	q := url.Values{}
+	if p.domain != "" {
+		q.Set("domain", p.domain)
+	} else {
+		q.Set("customer", p.customer)
+	}
+	if p.query != "" {
+		q.Set("query", p.query)
+	}
+	q.Set("maxResults", fmt.Sprintf("%d", directoryMaxResults))
+	if p.pageToken != "" {
+		q.Set("pageToken", p.pageToken)
+	}
+
+	reqURL := d.baseURL + "/admin/directory/v1/users?" + q.Encode()
+	raw, err := d.get(ctx, reqURL)
+	if err != nil {
+		return nil, err
+	}
+	var resp directoryUsersResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("invalid directory users JSON: %v", err)
+	}
+	return &resp, nil
+}
+
+// get executes a GET, transparently refreshing the access token once on a 401.
+func (d *directoryClient) get(ctx context.Context, reqURL string) ([]byte, error) {
+	body, err := d.getOnce(ctx, reqURL, false)
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized {
+		return d.getOnce(ctx, reqURL, true)
+	}
+	return body, err
+}
+
+func (d *directoryClient) getOnce(ctx context.Context, reqURL string, forceToken bool) ([]byte, error) {
+	token, err := d.ts.Token(ctx, forceToken)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request %q: %v", reqURL, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request %q: %v", reqURL, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response %q: %v", reqURL, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseHTTPError(resp.StatusCode, reqURL, string(respBody))
+	}
+	return respBody, nil
+}
+
+// enumerate walks every page of the domain's users and returns the mailbox
+// addresses to collect, honoring the suspended/archived filters.
+func (d *directoryClient) enumerate(ctx context.Context, conf GmailConfig) ([]string, error) {
+	var out []string
+	seen := map[string]bool{}
+	pageToken := ""
+	for page := 0; page < maxPagesPerPoll; page++ {
+		resp, err := d.listUsers(ctx, listUsersParams{
+			customer:  conf.Customer,
+			domain:    conf.Domain,
+			query:     conf.DiscoveryQuery,
+			pageToken: pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, u := range resp.Users {
+			email := strings.TrimSpace(u.PrimaryEmail)
+			if email == "" || seen[email] {
+				continue
+			}
+			if (u.Suspended || u.Archived) && !conf.IncludeSuspended {
+				continue
+			}
+			seen[email] = true
+			out = append(out, email)
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return out, nil
+}
+
+// runDiscovery enumerates the domain immediately, then re-enumerates every
+// DiscoveryInterval, reconciling the running collectors against the result. It
+// runs as a sender goroutine and exits when the adapter is closed.
+func (a *GmailAdapter) runDiscovery() {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog("gmail: discovery stopped")
+
+	isFirstRun := true
+	for isFirstRun || !a.doStop.WaitFor(a.conf.DiscoveryInterval) {
+		isFirstRun = false
+		a.discoverOnce()
+		if a.doStop.IsSet() {
+			return
+		}
+	}
+}
+
+// discoverOnce performs one enumeration + reconciliation pass. Errors are logged
+// and the pass is abandoned; the static mailboxes keep collecting regardless.
+func (a *GmailAdapter) discoverOnce() {
+	emails, err := a.directory.enumerate(a.ctx, a.conf)
+	if err != nil {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf("gmail: mailbox discovery failed, keeping the current set: %v", err))
+		return
+	}
+
+	desired := make(map[string]bool, len(emails)+len(a.staticAddrs))
+	for addr := range a.staticAddrs {
+		desired[addr] = true
+	}
+	for _, e := range emails {
+		desired[e] = true
+	}
+
+	// Start collectors for newly-discovered mailboxes.
+	nAdded := 0
+	for _, e := range emails {
+		if a.staticAddrs[e] {
+			continue
+		}
+		a.mu.Lock()
+		_, running := a.collectors[e]
+		a.mu.Unlock()
+		if running {
+			continue
+		}
+		if err := a.startCollector(mailboxTarget{address: e, subject: e, userID: defaultUserID}, 0); err != nil {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf("gmail: could not start collector for discovered mailbox %q: %v", e, err))
+			continue
+		}
+		nAdded++
+	}
+
+	// Stop collectors for mailboxes that are no longer present (never the static
+	// ones, which are always in `desired`).
+	nRemoved := 0
+	for addr := range a.activeMailboxes() {
+		if desired[addr] {
+			continue
+		}
+		a.removeCollector(addr)
+		nRemoved++
+	}
+
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"gmail: discovery pass complete (discovered=%d added=%d removed=%d active=%d)",
+		len(emails), nAdded, nRemoved, len(a.activeMailboxes())))
+}
+
+// resolveDirectoryBaseURL computes the Directory API root from the config.
+func resolveDirectoryBaseURL(conf GmailConfig) string {
+	if conf.DirectoryBaseURL != "" {
+		return strings.TrimRight(conf.DirectoryBaseURL, "/")
+	}
+	return directoryAPIBaseURL
+}

--- a/gmail/mock_test.go
+++ b/gmail/mock_test.go
@@ -110,10 +110,41 @@ type mockGmail struct {
 	// lastAssertionClaims captures the claims of the most recent service-account
 	// assertion, for delegation assertions in tests.
 	lastAssertionClaims jwt.MapClaims
+
+	// --- BEC capability state (settings, profile, history) -----------------
+
+	filters             []utils.Dict
+	forwardingAddresses []utils.Dict
+	autoForwarding      utils.Dict
+	sendAs              []utils.Dict
+	delegates           []utils.Dict
+	imap                utils.Dict
+	pop                 utils.Dict
+	vacation            utils.Dict
+
+	// profileHistoryID is what users.getProfile reports as the current historyId
+	// (the baseline cursor for history collection).
+	profileHistoryID string
+	// history is the change log; the list handler returns records whose id is
+	// greater than the requested startHistoryId.
+	history []utils.Dict
+
+	// statusOverride, keyed by capability path suffix (e.g. "settings/delegates",
+	// "history"), forces that endpoint to answer the given HTTP status, to
+	// simulate a feature unavailable for the account type or an expired cursor.
+	statusOverride map[string]int
+
+	// per-capability request counters, for asserting cadence.
+	capabilityRequests map[string]int
 }
 
 func newMockGmail() *mockGmail {
-	return &mockGmail{messages: map[string]utils.Dict{}, getNotFound: map[string]bool{}}
+	return &mockGmail{
+		messages:           map[string]utils.Dict{},
+		getNotFound:        map[string]bool{},
+		statusOverride:     map[string]int{},
+		capabilityRequests: map[string]int{},
+	}
 }
 
 // markGetNotFound makes get(id) answer 404 while the id stays listable.
@@ -144,6 +175,18 @@ func (m *mockGmail) handler(t *testing.T) http.Handler {
 	mux.HandleFunc("/token", m.tokenHandler(t))
 	mux.HandleFunc("/gmail/v1/users/me/messages", m.listHandler(t))
 	mux.HandleFunc("/gmail/v1/users/me/messages/", m.getHandler(t))
+
+	// BEC capability endpoints.
+	mux.HandleFunc("/gmail/v1/users/me/settings/filters", m.capListHandler("settings/filters", "filter", func() []utils.Dict { return m.filters }))
+	mux.HandleFunc("/gmail/v1/users/me/settings/forwardingAddresses", m.capListHandler("settings/forwardingAddresses", "forwardingAddresses", func() []utils.Dict { return m.forwardingAddresses }))
+	mux.HandleFunc("/gmail/v1/users/me/settings/sendAs", m.capListHandler("settings/sendAs", "sendAs", func() []utils.Dict { return m.sendAs }))
+	mux.HandleFunc("/gmail/v1/users/me/settings/delegates", m.capListHandler("settings/delegates", "delegates", func() []utils.Dict { return m.delegates }))
+	mux.HandleFunc("/gmail/v1/users/me/settings/autoForwarding", m.capObjectHandler("settings/autoForwarding", func() utils.Dict { return m.autoForwarding }))
+	mux.HandleFunc("/gmail/v1/users/me/settings/imap", m.capObjectHandler("settings/imap", func() utils.Dict { return m.imap }))
+	mux.HandleFunc("/gmail/v1/users/me/settings/pop", m.capObjectHandler("settings/pop", func() utils.Dict { return m.pop }))
+	mux.HandleFunc("/gmail/v1/users/me/settings/vacation", m.capObjectHandler("settings/vacation", func() utils.Dict { return m.vacation }))
+	mux.HandleFunc("/gmail/v1/users/me/profile", m.profileHandler())
+	mux.HandleFunc("/gmail/v1/users/me/history", m.historyHandler())
 	return mux
 }
 
@@ -535,7 +578,7 @@ func TestMockEndToEndRefreshToken(t *testing.T) {
 
 	byID := map[string]*protocol.DataMessage{}
 	for _, msg := range sink.snapshot() {
-		assert.Equal(t, eventType, msg.EventType)
+		assert.Equal(t, eventTypeMessage, msg.EventType)
 		require.NotNil(t, msg.JsonPayload)
 		byID[utils.Dict(msg.JsonPayload).FindOneString("id")] = msg
 	}

--- a/gmail/mock_test.go
+++ b/gmail/mock_test.go
@@ -101,6 +101,11 @@ type mockGmail struct {
 	// every expected mailbox was delegated.
 	impersonatedSubjects map[string]int
 
+	// rejectSubjects makes the token endpoint answer 400 invalid_grant for a
+	// service-account assertion impersonating that subject, simulating a mailbox
+	// whose delegation/credentials are rejected while others succeed.
+	rejectSubjects map[string]bool
+
 	tokenRequests int
 	listRequests  int
 	getRequests   int
@@ -160,6 +165,7 @@ func newMockGmail() *mockGmail {
 		statusOverride:       map[string]int{},
 		capabilityRequests:   map[string]int{},
 		impersonatedSubjects: map[string]int{},
+		rejectSubjects:       map[string]bool{},
 	}
 }
 
@@ -238,10 +244,16 @@ func (m *mockGmail) tokenHandler(t *testing.T) http.HandlerFunc {
 				writeJSON(w, http.StatusBadRequest, `{"error":"invalid_grant","error_description":"assertion failed verification"}`)
 				return
 			}
-			if sub, _ := claims["sub"].(string); sub != "" {
-				m.mu.Lock()
+			sub, _ := claims["sub"].(string)
+			m.mu.Lock()
+			if sub != "" {
 				m.impersonatedSubjects[sub]++
-				m.mu.Unlock()
+			}
+			rejected := m.rejectSubjects[sub]
+			m.mu.Unlock()
+			if rejected {
+				writeJSON(w, http.StatusBadRequest, `{"error":"invalid_grant","error_description":"subject not authorized"}`)
+				return
 			}
 		default:
 			writeJSON(w, http.StatusBadRequest, `{"error":"unsupported_grant_type"}`)

--- a/gmail/mock_test.go
+++ b/gmail/mock_test.go
@@ -88,12 +88,18 @@ type mockGmail struct {
 	getNotFound map[string]bool
 
 	tokensIssued int
-	activeToken  string
 
 	// rejectTokensBefore makes data endpoints answer 401 for any access token
 	// numbered at or below this value, simulating an expired access token and
-	// forcing the adapter to refresh.
+	// forcing the adapter to refresh. Any issued token numbered above it is
+	// accepted, so multiple mailboxes minting tokens concurrently do not
+	// invalidate each other.
 	rejectTokensBefore int
+
+	// impersonatedSubjects counts, per impersonated subject, the service-account
+	// assertions the token endpoint minted. It lets multi-mailbox tests assert
+	// every expected mailbox was delegated.
+	impersonatedSubjects map[string]int
 
 	tokenRequests int
 	listRequests  int
@@ -136,14 +142,24 @@ type mockGmail struct {
 
 	// per-capability request counters, for asserting cadence.
 	capabilityRequests map[string]int
+
+	// --- Admin SDK Directory API (mailbox discovery) -----------------------
+
+	// directoryUsers is what users.list returns, across pages of directoryPageSize.
+	directoryUsers []discoveredUser
+	// directoryPageSize, when > 0, forces users.list to paginate at this size.
+	directoryPageSize int
+	directoryStatus   int // when non-zero, users.list answers this HTTP status
+	directoryRequests int
 }
 
 func newMockGmail() *mockGmail {
 	return &mockGmail{
-		messages:           map[string]utils.Dict{},
-		getNotFound:        map[string]bool{},
-		statusOverride:     map[string]int{},
-		capabilityRequests: map[string]int{},
+		messages:             map[string]utils.Dict{},
+		getNotFound:          map[string]bool{},
+		statusOverride:       map[string]int{},
+		capabilityRequests:   map[string]int{},
+		impersonatedSubjects: map[string]int{},
 	}
 }
 
@@ -187,6 +203,9 @@ func (m *mockGmail) handler(t *testing.T) http.Handler {
 	mux.HandleFunc("/gmail/v1/users/me/settings/vacation", m.capObjectHandler("settings/vacation", func() utils.Dict { return m.vacation }))
 	mux.HandleFunc("/gmail/v1/users/me/profile", m.profileHandler())
 	mux.HandleFunc("/gmail/v1/users/me/history", m.historyHandler())
+
+	// Admin SDK Directory API (mailbox discovery).
+	mux.HandleFunc("/admin/directory/v1/users", m.directoryUsersHandler())
 	return mux
 }
 
@@ -214,9 +233,15 @@ func (m *mockGmail) tokenHandler(t *testing.T) http.HandlerFunc {
 				return
 			}
 		case jwtBearerGrantType:
-			if !m.verifyAssertion(t, r.Form.Get("assertion")) {
+			claims, ok := m.verifyAssertion(t, r.Form.Get("assertion"))
+			if !ok {
 				writeJSON(w, http.StatusBadRequest, `{"error":"invalid_grant","error_description":"assertion failed verification"}`)
 				return
+			}
+			if sub, _ := claims["sub"].(string); sub != "" {
+				m.mu.Lock()
+				m.impersonatedSubjects[sub]++
+				m.mu.Unlock()
 			}
 		default:
 			writeJSON(w, http.StatusBadRequest, `{"error":"unsupported_grant_type"}`)
@@ -230,8 +255,7 @@ func (m *mockGmail) tokenHandler(t *testing.T) http.HandlerFunc {
 
 		m.mu.Lock()
 		m.tokensIssued++
-		m.activeToken = fmt.Sprintf("AT-%d", m.tokensIssued)
-		token := m.activeToken
+		token := fmt.Sprintf("AT-%d", m.tokensIssued)
 		m.mu.Unlock()
 
 		writeJSON(w, http.StatusOK, fmt.Sprintf(
@@ -241,13 +265,13 @@ func (m *mockGmail) tokenHandler(t *testing.T) http.HandlerFunc {
 }
 
 // verifyAssertion validates a service-account JWT assertion's signature and
-// records its claims. Caller must not hold m.mu.
-func (m *mockGmail) verifyAssertion(t *testing.T, assertion string) bool {
+// records its claims, returning the parsed claims. Caller must not hold m.mu.
+func (m *mockGmail) verifyAssertion(t *testing.T, assertion string) (jwt.MapClaims, bool) {
 	m.mu.Lock()
 	pub := m.saPublicKey
 	m.mu.Unlock()
 	if pub == nil || assertion == "" {
-		return false
+		return nil, false
 	}
 	claims := jwt.MapClaims{}
 	_, err := jwt.ParseWithClaims(assertion, claims, func(tok *jwt.Token) (interface{}, error) {
@@ -258,12 +282,12 @@ func (m *mockGmail) verifyAssertion(t *testing.T, assertion string) bool {
 	})
 	if err != nil {
 		t.Logf("assertion verification failed: %v", err)
-		return false
+		return nil, false
 	}
 	m.mu.Lock()
 	m.lastAssertionClaims = claims
 	m.mu.Unlock()
-	return true
+	return claims, true
 }
 
 func (m *mockGmail) listHandler(t *testing.T) http.HandlerFunc {
@@ -326,14 +350,15 @@ func (m *mockGmail) getHandler(t *testing.T) http.HandlerFunc {
 }
 
 // authorize validates the bearer token, writing a 401 and returning false on
-// failure.
+// failure. Any token the endpoint issued (AT-n with 1<=n<=tokensIssued) is
+// accepted, except those at or below rejectTokensBefore -- so concurrent
+// mailboxes minting their own tokens never invalidate each other.
 func (m *mockGmail) authorize(w http.ResponseWriter, r *http.Request) bool {
 	auth := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 	m.mu.Lock()
-	active := m.activeToken
-	reject := m.tokenRejected(auth)
+	ok := m.tokenAccepted(auth)
 	m.mu.Unlock()
-	if auth == "" || auth != active || reject {
+	if !ok {
 		writeJSON(w, http.StatusUnauthorized,
 			`{"error":{"code":401,"message":"Invalid Credentials","errors":[{"reason":"authError"}],"status":"UNAUTHENTICATED"}}`)
 		return false
@@ -341,17 +366,14 @@ func (m *mockGmail) authorize(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
-// tokenRejected reports whether the given access token should be answered with a
-// 401. Caller holds m.mu.
-func (m *mockGmail) tokenRejected(token string) bool {
-	if m.rejectTokensBefore == 0 {
-		return false
-	}
+// tokenAccepted reports whether the given access token is a currently-valid
+// issued token. Caller holds m.mu.
+func (m *mockGmail) tokenAccepted(token string) bool {
 	var n int
 	if _, err := fmt.Sscanf(token, "AT-%d", &n); err != nil {
 		return false
 	}
-	return n <= m.rejectTokensBefore
+	return n >= 1 && n <= m.tokensIssued && n > m.rejectTokensBefore
 }
 
 // buildList renders a messages.list response: ids whose internalDate is at or
@@ -567,7 +589,7 @@ func TestMockEndToEndRefreshToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	adapter, _, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), sink)
+	adapter, _, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -621,7 +643,7 @@ func TestMockEndToEndServiceAccount(t *testing.T) {
 		InitialLookback:           24 * time.Hour,
 		PollInterval:              40 * time.Millisecond,
 	}
-	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	adapter, _, err := newGmailAdapter(ctx, conf, staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -651,7 +673,7 @@ func TestMockNewMessageShippedOnce(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	adapter, _, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), sink)
+	adapter, _, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -691,7 +713,7 @@ func TestMockMultiPollNoReship(t *testing.T) {
 	// A generous overlap forces every poll to re-list both messages.
 	conf := refreshConfig(t, server.URL)
 	conf.Overlap = time.Hour
-	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	adapter, _, err := newGmailAdapter(ctx, conf, staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -718,7 +740,7 @@ func TestMockTokenRefreshOn401(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	adapter, chStopped, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), sink)
+	adapter, chStopped, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -749,7 +771,7 @@ func TestMockBadCredentialsStops(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	adapter, chStopped, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), sink)
+	adapter, chStopped, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -782,7 +804,7 @@ func TestMockPagination(t *testing.T) {
 
 	conf := refreshConfig(t, server.URL)
 	conf.MaxResults = 2 // force three pages (2 + 2 + 1)
-	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	adapter, _, err := newGmailAdapter(ctx, conf, staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 
@@ -819,7 +841,7 @@ func TestMockMissingMessageSkipped(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	adapter, chStopped, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), sink)
+	adapter, chStopped, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), staticSink(sink))
 	require.NoError(t, err)
 	defer adapter.Close()
 

--- a/gmail/mock_test.go
+++ b/gmail/mock_test.go
@@ -1,0 +1,792 @@
+package usp_gmail
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"context"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock Gmail API -- the
+// OAuth token endpoint, users.messages.list and users.messages.get -- and
+// captures the exact messages it ships so their content (event type, timestamp
+// from internalDate, and verbatim payload) can be asserted. Both authentication
+// modes (refresh token and service-account JWT-bearer) are covered.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Gmail API ---------------------------------------------------------
+
+const (
+	mockClientID     = "test-client-id"
+	mockClientSecret = "test-client-secret"
+	mockRefreshToken = "test-refresh-token"
+	mockSubject      = "user@example.test"
+)
+
+// mockGmail stands in for the Gmail OAuth + REST surface. It mints
+// counter-numbered access tokens (so re-mints are observable), validates the
+// bearer token on data requests, filters messages.list by the after: bound in
+// the query, paginates, and serves full messages on get.
+type mockGmail struct {
+	mu sync.Mutex
+
+	// messages is the mailbox, keyed by message id.
+	messages map[string]utils.Dict
+	order    []string // insertion order, for stable listing
+
+	// getNotFound marks ids that appear in listings but whose get returns 404,
+	// simulating a message deleted between the list and the get.
+	getNotFound map[string]bool
+
+	tokensIssued int
+	activeToken  string
+
+	// rejectTokensBefore makes data endpoints answer 401 for any access token
+	// numbered at or below this value, simulating an expired access token and
+	// forcing the adapter to refresh.
+	rejectTokensBefore int
+
+	tokenRequests int
+	listRequests  int
+	getRequests   int
+
+	// failTokenStatus, when non-zero, makes the token endpoint return that
+	// status instead of issuing a token (e.g. 400 invalid_grant).
+	failTokenStatus int
+
+	// saPublicKey, when set, makes the token endpoint accept the jwt-bearer
+	// grant and verify the assertion signature against it.
+	saPublicKey *rsa.PublicKey
+
+	// lastAssertionClaims captures the claims of the most recent service-account
+	// assertion, for delegation assertions in tests.
+	lastAssertionClaims jwt.MapClaims
+}
+
+func newMockGmail() *mockGmail {
+	return &mockGmail{messages: map[string]utils.Dict{}, getNotFound: map[string]bool{}}
+}
+
+// markGetNotFound makes get(id) answer 404 while the id stays listable.
+func (m *mockGmail) markGetNotFound(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.getNotFound[id] = true
+}
+
+func (m *mockGmail) addMessage(msg utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id := msg.FindOneString("id")
+	if _, ok := m.messages[id]; !ok {
+		m.order = append(m.order, id)
+	}
+	m.messages[id] = msg
+}
+
+func (m *mockGmail) counts() (tokens, list, get int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests, m.listRequests, m.getRequests
+}
+
+func (m *mockGmail) handler(t *testing.T) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", m.tokenHandler(t))
+	mux.HandleFunc("/gmail/v1/users/me/messages", m.listHandler(t))
+	mux.HandleFunc("/gmail/v1/users/me/messages/", m.getHandler(t))
+	return mux
+}
+
+func (m *mockGmail) tokenHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.tokenRequests++
+		failStatus := m.failTokenStatus
+		m.mu.Unlock()
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if !assert.NoError(t, r.ParseForm()) {
+			return
+		}
+
+		switch r.Form.Get("grant_type") {
+		case "refresh_token":
+			if r.Form.Get("client_id") != mockClientID ||
+				r.Form.Get("client_secret") != mockClientSecret ||
+				r.Form.Get("refresh_token") != mockRefreshToken {
+				writeJSON(w, http.StatusBadRequest, `{"error":"invalid_grant"}`)
+				return
+			}
+		case jwtBearerGrantType:
+			if !m.verifyAssertion(t, r.Form.Get("assertion")) {
+				writeJSON(w, http.StatusBadRequest, `{"error":"invalid_grant","error_description":"assertion failed verification"}`)
+				return
+			}
+		default:
+			writeJSON(w, http.StatusBadRequest, `{"error":"unsupported_grant_type"}`)
+			return
+		}
+
+		if failStatus != 0 {
+			writeJSON(w, failStatus, `{"error":"invalid_grant"}`)
+			return
+		}
+
+		m.mu.Lock()
+		m.tokensIssued++
+		m.activeToken = fmt.Sprintf("AT-%d", m.tokensIssued)
+		token := m.activeToken
+		m.mu.Unlock()
+
+		writeJSON(w, http.StatusOK, fmt.Sprintf(
+			`{"access_token":%q,"token_type":"Bearer","expires_in":3600,"scope":%q}`,
+			token, gmailReadonlyScope))
+	}
+}
+
+// verifyAssertion validates a service-account JWT assertion's signature and
+// records its claims. Caller must not hold m.mu.
+func (m *mockGmail) verifyAssertion(t *testing.T, assertion string) bool {
+	m.mu.Lock()
+	pub := m.saPublicKey
+	m.mu.Unlock()
+	if pub == nil || assertion == "" {
+		return false
+	}
+	claims := jwt.MapClaims{}
+	_, err := jwt.ParseWithClaims(assertion, claims, func(tok *jwt.Token) (interface{}, error) {
+		if _, ok := tok.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method %v", tok.Header["alg"])
+		}
+		return pub, nil
+	})
+	if err != nil {
+		t.Logf("assertion verification failed: %v", err)
+		return false
+	}
+	m.mu.Lock()
+	m.lastAssertionClaims = claims
+	m.mu.Unlock()
+	return true
+}
+
+func (m *mockGmail) listHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.listRequests++
+		m.mu.Unlock()
+
+		if !m.authorize(w, r) {
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		q := r.URL.Query()
+		after := parseAfter(q.Get("q"))
+		maxResults, _ := strconv.Atoi(q.Get("maxResults"))
+		if maxResults <= 0 {
+			maxResults = 100
+		}
+		offset := 0
+		if pt := q.Get("pageToken"); pt != "" {
+			offset, _ = strconv.Atoi(pt)
+		}
+		includeSpamTrash := q.Get("includeSpamTrash") == "true"
+		labelFilter := q["labelIds"]
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(m.buildList(after, offset, maxResults, includeSpamTrash, labelFilter))
+	}
+}
+
+func (m *mockGmail) getHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.getRequests++
+		m.mu.Unlock()
+
+		if !m.authorize(w, r) {
+			return
+		}
+		id := strings.TrimPrefix(r.URL.Path, "/gmail/v1/users/me/messages/")
+
+		m.mu.Lock()
+		msg, ok := m.messages[id]
+		if m.getNotFound[id] {
+			ok = false
+		}
+		m.mu.Unlock()
+		if !ok {
+			writeJSON(w, http.StatusNotFound,
+				`{"error":{"code":404,"message":"Requested entity was not found.","errors":[{"reason":"notFound"}],"status":"NOT_FOUND"}}`)
+			return
+		}
+		b, _ := json.Marshal(msg)
+		writeJSON(w, http.StatusOK, string(b))
+	}
+}
+
+// authorize validates the bearer token, writing a 401 and returning false on
+// failure.
+func (m *mockGmail) authorize(w http.ResponseWriter, r *http.Request) bool {
+	auth := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	m.mu.Lock()
+	active := m.activeToken
+	reject := m.tokenRejected(auth)
+	m.mu.Unlock()
+	if auth == "" || auth != active || reject {
+		writeJSON(w, http.StatusUnauthorized,
+			`{"error":{"code":401,"message":"Invalid Credentials","errors":[{"reason":"authError"}],"status":"UNAUTHENTICATED"}}`)
+		return false
+	}
+	return true
+}
+
+// tokenRejected reports whether the given access token should be answered with a
+// 401. Caller holds m.mu.
+func (m *mockGmail) tokenRejected(token string) bool {
+	if m.rejectTokensBefore == 0 {
+		return false
+	}
+	var n int
+	if _, err := fmt.Sscanf(token, "AT-%d", &n); err != nil {
+		return false
+	}
+	return n <= m.rejectTokensBefore
+}
+
+// buildList renders a messages.list response: ids whose internalDate is at or
+// after `after` (seconds), respecting the label/spam-trash filters, sorted by
+// internalDate then id, paginated from `offset` by `maxResults`.
+func (m *mockGmail) buildList(after int64, offset, maxResults int, includeSpamTrash bool, labelFilter []string) []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var matched []utils.Dict
+	for _, id := range m.order {
+		msg := m.messages[id]
+		ms := internalDateMs(msg)
+		if ms/1000 < after {
+			continue
+		}
+		labels := messageLabels(msg)
+		if !includeSpamTrash && (labels["SPAM"] || labels["TRASH"]) {
+			continue
+		}
+		if !hasAllLabels(labels, labelFilter) {
+			continue
+		}
+		matched = append(matched, msg)
+	}
+	sort.SliceStable(matched, func(i, j int) bool {
+		mi, mj := internalDateMs(matched[i]), internalDateMs(matched[j])
+		if mi != mj {
+			return mi < mj
+		}
+		return matched[i].FindOneString("id") < matched[j].FindOneString("id")
+	})
+
+	total := len(matched)
+	end := offset + maxResults
+	if end > total {
+		end = total
+	}
+	page := matched
+	if offset < total {
+		page = matched[offset:end]
+	} else {
+		page = nil
+	}
+
+	resp := map[string]interface{}{"resultSizeEstimate": total}
+	if len(page) > 0 {
+		refs := make([]map[string]string, 0, len(page))
+		for _, msg := range page {
+			refs = append(refs, map[string]string{
+				"id":       msg.FindOneString("id"),
+				"threadId": msg.FindOneString("threadId"),
+			})
+		}
+		resp["messages"] = refs
+	}
+	if end < total {
+		resp["nextPageToken"] = strconv.Itoa(end)
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+// --- helpers ----------------------------------------------------------------
+
+func writeJSON(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
+}
+
+// parseAfter extracts the epoch-seconds value of an "after:" operator from a
+// Gmail query, or 0 if absent.
+func parseAfter(q string) int64 {
+	for _, tok := range strings.Fields(q) {
+		if v, ok := strings.CutPrefix(tok, "after:"); ok {
+			n, _ := strconv.ParseInt(v, 10, 64)
+			return n
+		}
+	}
+	return 0
+}
+
+func internalDateMs(msg utils.Dict) int64 {
+	n, _ := strconv.ParseInt(msg.FindOneString("internalDate"), 10, 64)
+	return n
+}
+
+func messageLabels(msg utils.Dict) map[string]bool {
+	out := map[string]bool{}
+	if raw, ok := msg["labelIds"]; ok {
+		if list, ok := raw.([]interface{}); ok {
+			for _, l := range list {
+				if s, ok := l.(string); ok {
+					out[s] = true
+				}
+			}
+		}
+	}
+	return out
+}
+
+func hasAllLabels(have map[string]bool, want []string) bool {
+	for _, l := range want {
+		if !have[l] {
+			return false
+		}
+	}
+	return true
+}
+
+// recentMs renders an internalDate (epoch ms, as Gmail returns it) for a time
+// `ago` before now, so fixtures land inside the adapter's collection window.
+func recentMs(ago time.Duration) string {
+	return strconv.FormatInt(time.Now().Add(-ago).UnixMilli(), 10)
+}
+
+// realisticMessage builds a full-format Gmail message resource with the nested
+// payload/headers/body shape the real API returns.
+func realisticMessage(id, threadID, internalDate, from, subject string) utils.Dict {
+	body := base64.URLEncoding.EncodeToString([]byte("Hello, this is the body of " + subject))
+	return utils.Dict{
+		"id":           id,
+		"threadId":     threadID,
+		"labelIds":     []interface{}{"INBOX", "UNREAD"},
+		"snippet":      "Hello, this is the body of " + subject,
+		"historyId":    "987654",
+		"internalDate": internalDate,
+		"sizeEstimate": 1024,
+		"payload": utils.Dict{
+			"partId":   "",
+			"mimeType": "text/plain",
+			"filename": "",
+			"headers": []interface{}{
+				utils.Dict{"name": "From", "value": from},
+				utils.Dict{"name": "To", "value": mockSubject},
+				utils.Dict{"name": "Subject", "value": subject},
+				utils.Dict{"name": "Date", "value": "Wed, 13 Sep 2023 15:42:47 +0000"},
+				utils.Dict{"name": "Message-ID", "value": "<" + id + "@mail.example.test>"},
+			},
+			"body": utils.Dict{"size": 256, "data": body},
+		},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// refreshConfig is a minimal valid refresh-token config pointed at the mock.
+func refreshConfig(t *testing.T, baseURL string) GmailConfig {
+	t.Helper()
+	return GmailConfig{
+		ClientOptions:   testClientOptions(t),
+		ClientID:        mockClientID,
+		ClientSecret:    mockClientSecret,
+		RefreshToken:    mockRefreshToken,
+		BaseURL:         baseURL,
+		TokenURL:        baseURL + "/token",
+		InitialLookback: 24 * time.Hour,
+		PollInterval:    40 * time.Millisecond,
+	}
+}
+
+// generateServiceAccount builds a throwaway RSA key and a service-account JSON
+// key embedding it, returning the JSON and the matching public key.
+func generateServiceAccount(t *testing.T) (saJSON string, pub *rsa.PublicKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	sa := map[string]string{
+		"type":           "service_account",
+		"project_id":     "test-project",
+		"private_key_id": "kid-123",
+		"private_key":    string(pemBytes),
+		"client_email":   "collector@test-project.iam.gserviceaccount.com",
+		"client_id":      "1234567890",
+		"token_uri":      "https://oauth2.googleapis.com/token",
+	}
+	b, err := json.Marshal(sa)
+	require.NoError(t, err)
+	return string(b), &key.PublicKey
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestMockEndToEndRefreshToken drives the adapter against the mock API via the
+// refresh-token flow and asserts the exact events shipped: event type
+// "gmail_message", timestamp from internalDate, and the message payload
+// preserved verbatim (nested payload/headers/body included).
+func TestMockEndToEndRefreshToken(t *testing.T) {
+	mock := newMockGmail()
+	msgs := []utils.Dict{
+		realisticMessage("m1", "t1", recentMs(50*time.Minute), "alice@partner.test", "Invoice #1"),
+		realisticMessage("m2", "t2", recentMs(40*time.Minute), "bob@partner.test", "Re: meeting"),
+		realisticMessage("m3", "t3", recentMs(30*time.Minute), "carol@partner.test", "Welcome"),
+	}
+	for _, m := range msgs {
+		mock.addMessage(m)
+	}
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 messages to ship")
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "messages were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		assert.Equal(t, eventType, msg.EventType)
+		require.NotNil(t, msg.JsonPayload)
+		byID[utils.Dict(msg.JsonPayload).FindOneString("id")] = msg
+	}
+
+	for _, want := range msgs {
+		shipped := byID[want.FindOneString("id")]
+		require.NotNil(t, shipped, "message %s not shipped", want.FindOneString("id"))
+
+		ms, perr := strconv.ParseInt(want.FindOneString("internalDate"), 10, 64)
+		require.NoError(t, perr)
+		assert.Equal(t, uint64(ms), shipped.TimestampMs, "event time must come from internalDate")
+		assert.JSONEq(t, mustJSON(t, want), mustJSON(t, shipped.JsonPayload),
+			"shipped payload must match the original Gmail message verbatim")
+	}
+}
+
+// TestMockEndToEndServiceAccount drives the adapter via the service-account
+// JWT-bearer flow and asserts collection works and the signed assertion carried
+// the delegation claims (subject, scope, issuer).
+func TestMockEndToEndServiceAccount(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.addMessage(realisticMessage("s1", "t1", recentMs(20*time.Minute), "dave@partner.test", "Quarterly report"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := GmailConfig{
+		ClientOptions:             testClientOptions(t),
+		ServiceAccountCredentials: saJSON,
+		Subject:                   mockSubject,
+		BaseURL:                   server.URL,
+		TokenURL:                  server.URL + "/token",
+		InitialLookback:           24 * time.Hour,
+		PollInterval:              40 * time.Millisecond,
+	}
+	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the message should ship via the service-account flow")
+
+	mock.mu.Lock()
+	claims := mock.lastAssertionClaims
+	mock.mu.Unlock()
+	require.NotNil(t, claims, "the token endpoint should have received a signed assertion")
+	assert.Equal(t, mockSubject, claims["sub"], "assertion must impersonate the configured subject")
+	assert.Equal(t, gmailReadonlyScope, claims["scope"], "assertion must request the configured scope")
+	assert.Equal(t, "collector@test-project.iam.gserviceaccount.com", claims["iss"])
+}
+
+// TestMockNewMessageShippedOnce verifies a message that arrives mid-run is
+// shipped exactly once, and already-shipped messages are never re-sent across
+// overlapping polls.
+func TestMockNewMessageShippedOnce(t *testing.T) {
+	mock := newMockGmail()
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(50*time.Minute), "alice@partner.test", "First"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new email arrives.
+	mock.addMessage(realisticMessage("m2", "t2", recentMs(1*time.Second), "bob@partner.test", "Second"))
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "the new message should ship")
+	require.Never(t, func() bool { return sink.count() > 2 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[utils.Dict(msg.JsonPayload).FindOneString("id")]++
+	}
+	assert.Equal(t, map[string]int{"m1": 1, "m2": 1}, shippedPerID, "every message must ship exactly once")
+}
+
+// TestMockMultiPollNoReship verifies the rolling-window cursor advances and the
+// deduper keeps each message to exactly one shipment across many overlapping
+// polls.
+func TestMockMultiPollNoReship(t *testing.T) {
+	mock := newMockGmail()
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "alice@partner.test", "A"))
+	mock.addMessage(realisticMessage("m2", "t2", recentMs(5*time.Minute), "bob@partner.test", "B"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// A generous overlap forces every poll to re-list both messages.
+	conf := refreshConfig(t, server.URL)
+	conf.Overlap = time.Hour
+	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+	require.Never(t, func() bool { return sink.count() != 2 },
+		500*time.Millisecond, 40*time.Millisecond, "overlapping polls must not re-ship")
+
+	_, listReqs, _ := mock.counts()
+	assert.GreaterOrEqual(t, listReqs, 3, "several polls should have run")
+}
+
+// TestMockTokenRefreshOn401 verifies the adapter transparently re-mints its
+// access token when the API rejects it with a 401, then succeeds.
+func TestMockTokenRefreshOn401(t *testing.T) {
+	mock := newMockGmail()
+	mock.rejectTokensBefore = 1 // reject AT-1 on data calls, forcing a refresh to AT-2
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "alice@partner.test", "Hi"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, chStopped, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the message should ship after a token refresh")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped on a recoverable 401 instead of refreshing")
+	default:
+	}
+
+	tokens, _, _ := mock.counts()
+	assert.GreaterOrEqual(t, tokens, 2, "expected at least an initial mint plus one refresh")
+}
+
+// TestMockBadCredentialsStops verifies the adapter stops, and ships nothing,
+// when the token endpoint permanently rejects the credentials.
+func TestMockBadCredentialsStops(t *testing.T) {
+	mock := newMockGmail()
+	mock.failTokenStatus = http.StatusBadRequest // invalid_grant
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "alice@partner.test", "Hi"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, chStopped, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	select {
+	case <-chStopped:
+		// Expected: dead credentials stop the adapter.
+	case <-time.After(3 * time.Second):
+		t.Fatal("adapter should stop when the credentials are rejected")
+	}
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+}
+
+// TestMockPagination verifies the adapter walks every page of a multi-page
+// listing and ships all messages exactly once.
+func TestMockPagination(t *testing.T) {
+	mock := newMockGmail()
+	const n = 5
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("m%d", i)
+		mock.addMessage(realisticMessage(id, "t"+id, recentMs(time.Duration(n-i)*time.Minute),
+			"sender@partner.test", "Subject "+id))
+	}
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := refreshConfig(t, server.URL)
+	conf.MaxResults = 2 // force three pages (2 + 2 + 1)
+	adapter, _, err := newGmailAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == n },
+		5*time.Second, 20*time.Millisecond, "all paginated messages should ship")
+	require.Never(t, func() bool { return sink.count() != n },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		ids[utils.Dict(msg.JsonPayload).FindOneString("id")]++
+	}
+	require.Len(t, ids, n)
+	for id, c := range ids {
+		assert.Equal(t, 1, c, "message %s shipped more than once", id)
+	}
+}
+
+// TestMockMissingMessageSkipped verifies that a message id returned by list but
+// missing on get (deleted in between) is skipped without stopping the adapter,
+// and other messages still ship.
+func TestMockMissingMessageSkipped(t *testing.T) {
+	mock := newMockGmail()
+	// "ghost" is returned by the listing but 404s on get -- the message was
+	// deleted between the list and the fetch. "real" is a normal message.
+	mock.addMessage(realisticMessage("ghost", "tg", recentMs(9*time.Minute), "x@partner.test", "Ghost"))
+	mock.addMessage(realisticMessage("real", "tr", recentMs(8*time.Minute), "y@partner.test", "Real"))
+	mock.markGetNotFound("ghost")
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, chStopped, err := newGmailAdapter(ctx, refreshConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the real message should still ship despite the 404")
+
+	select {
+	case <-chStopped:
+		t.Fatal("a 404 on one message must not stop the adapter")
+	default:
+	}
+	assert.Equal(t, "real", utils.Dict(sink.snapshot()[0].JsonPayload).FindOneString("id"))
+}

--- a/gmail/multimailbox_test.go
+++ b/gmail/multimailbox_test.go
@@ -1,0 +1,537 @@
+package usp_gmail
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	uspclient "github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises multi-mailbox collection: the service-account flow with a
+// static list of subjects, Admin SDK Directory API auto-discovery (including
+// dynamic add/remove), per-mailbox sensor identity, and the validation rules
+// that gate the new modes.
+
+// --- mock Directory API -----------------------------------------------------
+
+// directoryUsersHandler serves the Admin SDK users.list endpoint, paginating at
+// directoryPageSize and honoring directoryStatus.
+func (m *mockGmail) directoryUsersHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !m.authorize(w, r) {
+			return
+		}
+		m.mu.Lock()
+		m.directoryRequests++
+		status := m.directoryStatus
+		users := append([]discoveredUser(nil), m.directoryUsers...)
+		pageSize := m.directoryPageSize
+		m.mu.Unlock()
+
+		if status != 0 {
+			writeJSON(w, status, capErrorBody(status))
+			return
+		}
+
+		offset := 0
+		if pt := r.URL.Query().Get("pageToken"); pt != "" {
+			offset, _ = strconv.Atoi(pt)
+		}
+		if offset > len(users) {
+			offset = len(users)
+		}
+		end := len(users)
+		if pageSize > 0 && offset+pageSize < end {
+			end = offset + pageSize
+		}
+		resp := map[string]any{"users": users[offset:end]}
+		if end < len(users) {
+			resp["nextPageToken"] = strconv.Itoa(end)
+		}
+		writeJSON(w, http.StatusOK, mustJSONString(resp))
+	}
+}
+
+func (m *mockGmail) setDirectoryUsers(u ...discoveredUser) {
+	m.mu.Lock()
+	m.directoryUsers = u
+	m.mu.Unlock()
+}
+
+func activeUser(email string) discoveredUser { return discoveredUser{PrimaryEmail: email} }
+func suspendedUser(email string) discoveredUser {
+	return discoveredUser{PrimaryEmail: email, Suspended: true}
+}
+
+// --- per-mailbox capturing sink hub -----------------------------------------
+
+// sinkHub hands each mailbox its own captureSink and records the ClientOptions
+// (sensor identity) the adapter derived for it.
+type sinkHub struct {
+	mu    sync.Mutex
+	sinks map[string]*captureSink
+	opts  map[string]uspclient.ClientOptions
+}
+
+func newSinkHub() *sinkHub {
+	return &sinkHub{sinks: map[string]*captureSink{}, opts: map[string]uspclient.ClientOptions{}}
+}
+
+func (h *sinkHub) factory() sinkFactory {
+	return func(_ context.Context, opts uspclient.ClientOptions, mailbox string) (uspSink, error) {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		s := h.sinks[mailbox]
+		if s == nil {
+			s = &captureSink{}
+			h.sinks[mailbox] = s
+		}
+		h.opts[mailbox] = opts
+		return s, nil
+	}
+}
+
+func (h *sinkHub) sink(mailbox string) *captureSink {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.sinks[mailbox]
+}
+
+func (h *sinkHub) options(mailbox string) (uspclient.ClientOptions, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	o, ok := h.opts[mailbox]
+	return o, ok
+}
+
+func (h *sinkHub) countByType(mailbox, evtType string) int {
+	s := h.sink(mailbox)
+	if s == nil {
+		return 0
+	}
+	return countByType(s, evtType)
+}
+
+// saConfig is a service-account config pointed at the mock, with fast cadences.
+func saConfig(t *testing.T, baseURL, saJSON string) GmailConfig {
+	t.Helper()
+	return GmailConfig{
+		ClientOptions:             testClientOptions(t),
+		ServiceAccountCredentials: saJSON,
+		BaseURL:                   baseURL,
+		TokenURL:                  baseURL + "/token",
+		DirectoryBaseURL:          baseURL,
+		InitialLookback:           24 * time.Hour,
+		PollInterval:              40 * time.Millisecond,
+		DiscoveryInterval:         40 * time.Millisecond,
+	}
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestStaticSubjectsFanOut verifies that a static list of subjects produces one
+// collector and one sensor per mailbox, each impersonating its own subject and
+// each shipping the mailbox's messages to its own sensor with a per-mailbox
+// sensor identity.
+func TestStaticSubjectsFanOut(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(30*time.Minute), "alice@partner.test", "Invoice"))
+	mock.addMessage(realisticMessage("m2", "t2", recentMs(20*time.Minute), "bob@partner.test", "Wire"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	subjects := []string{"ceo@corp.test", "cfo@corp.test", "it@corp.test"}
+	conf := saConfig(t, server.URL, saJSON)
+	conf.Subjects = subjects
+	conf.ClientOptions.SensorSeedKey = "corp"
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// Each mailbox ships both messages to its own sensor.
+	for _, s := range subjects {
+		s := s
+		require.Eventually(t, func() bool { return hub.countByType(s, eventTypeMessage) == 2 },
+			5*time.Second, 20*time.Millisecond, "mailbox %s should ship both messages", s)
+	}
+	require.Never(t, func() bool {
+		for _, s := range subjects {
+			if hub.countByType(s, eventTypeMessage) != 2 {
+				return true
+			}
+		}
+		return false
+	}, 300*time.Millisecond, 30*time.Millisecond, "no mailbox should re-ship")
+
+	// Each mailbox got its own sensor identity derived from its address.
+	for _, s := range subjects {
+		opts, ok := hub.options(s)
+		require.True(t, ok, "expected a sensor for %s", s)
+		assert.Equal(t, "corp/"+s, opts.SensorSeedKey, "sensor seed key must be per-mailbox")
+		assert.Equal(t, s, opts.Hostname, "sensor hostname must be the mailbox address")
+	}
+
+	// Every subject was impersonated via its own delegated assertion.
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	for _, s := range subjects {
+		assert.GreaterOrEqual(t, mock.impersonatedSubjects[s], 1, "subject %s must have been impersonated", s)
+	}
+}
+
+// TestSingleSubjectKeepsConfiguredSensor verifies that a single explicit mailbox
+// (not multi-mailbox) keeps the operator's configured sensor identity verbatim,
+// rather than deriving a per-mailbox one.
+func TestSingleSubjectKeepsConfiguredSensor(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "alice@partner.test", "Hi"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.Subject = "solo@corp.test"
+	conf.ClientOptions.SensorSeedKey = "configured-seed"
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return hub.countByType("solo@corp.test", eventTypeMessage) == 1 },
+		5*time.Second, 20*time.Millisecond)
+
+	opts, ok := hub.options("solo@corp.test")
+	require.True(t, ok)
+	assert.Equal(t, "configured-seed", opts.SensorSeedKey, "a single mailbox keeps the configured seed key")
+	assert.Equal(t, "", opts.Hostname, "a single mailbox does not get a derived hostname")
+}
+
+// TestDiscoveryEnumeratesAndCollects verifies that discovery enumerates the
+// domain's mailboxes, starts a collector per active mailbox (skipping suspended
+// accounts), and impersonates the admin for the Directory call.
+func TestDiscoveryEnumeratesAndCollects(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "x@partner.test", "Hello"))
+	mock.setDirectoryUsers(
+		activeUser("ann@corp.test"),
+		activeUser("ben@corp.test"),
+		suspendedUser("gone@corp.test"),
+	)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.DiscoverMailboxes = true
+	conf.AdminSubject = "admin@corp.test"
+	conf.ClientOptions.SensorSeedKey = "corp"
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		return hub.countByType("ann@corp.test", eventTypeMessage) == 1 &&
+			hub.countByType("ben@corp.test", eventTypeMessage) == 1
+	}, 5*time.Second, 20*time.Millisecond, "both active mailboxes should be discovered and collected")
+
+	// The suspended account must never get a collector.
+	require.Never(t, func() bool {
+		active := adapter.activeMailboxes()
+		return active["gone@corp.test"]
+	}, 400*time.Millisecond, 40*time.Millisecond, "suspended mailbox must be skipped")
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	assert.GreaterOrEqual(t, mock.impersonatedSubjects["admin@corp.test"], 1, "the Directory call must impersonate the admin")
+	assert.GreaterOrEqual(t, mock.impersonatedSubjects["ann@corp.test"], 1)
+	assert.GreaterOrEqual(t, mock.impersonatedSubjects["ben@corp.test"], 1)
+	assert.Equal(t, 0, mock.impersonatedSubjects["gone@corp.test"], "the suspended mailbox must never be impersonated")
+}
+
+// TestDiscoveryDynamicAddRemove verifies that a mailbox provisioned after startup
+// gets a collector on the next discovery pass, and a mailbox deprovisioned later
+// has its collector stopped and torn down.
+func TestDiscoveryDynamicAddRemove(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "x@partner.test", "Hello"))
+	mock.setDirectoryUsers(activeUser("ann@corp.test"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.DiscoverMailboxes = true
+	conf.AdminSubject = "admin@corp.test"
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return adapter.activeMailboxes()["ann@corp.test"] },
+		5*time.Second, 20*time.Millisecond, "the initial mailbox should be collected")
+
+	// A new mailbox is provisioned.
+	mock.setDirectoryUsers(activeUser("ann@corp.test"), activeUser("ben@corp.test"))
+	require.Eventually(t, func() bool {
+		return adapter.activeMailboxes()["ben@corp.test"] && hub.countByType("ben@corp.test", eventTypeMessage) == 1
+	}, 5*time.Second, 20*time.Millisecond, "the newly-provisioned mailbox should be discovered and collected")
+
+	// The new mailbox is deprovisioned.
+	mock.setDirectoryUsers(activeUser("ann@corp.test"))
+	require.Eventually(t, func() bool { return !adapter.activeMailboxes()["ben@corp.test"] },
+		5*time.Second, 20*time.Millisecond, "the deprovisioned mailbox's collector should be torn down")
+
+	// Ann keeps collecting throughout.
+	assert.True(t, adapter.activeMailboxes()["ann@corp.test"], "the surviving mailbox must keep collecting")
+}
+
+// TestDiscoveryNeverRemovesStaticSubject verifies that a mailbox named explicitly
+// in the config is collected and never removed, even when discovery returns an
+// empty domain.
+func TestDiscoveryNeverRemovesStaticSubject(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "x@partner.test", "Hello"))
+	// Discovery returns no users at all.
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.Subject = "keep@corp.test"
+	conf.DiscoverMailboxes = true
+	conf.AdminSubject = "admin@corp.test"
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return hub.countByType("keep@corp.test", eventTypeMessage) == 1 },
+		5*time.Second, 20*time.Millisecond, "the static subject should be collected")
+	require.Never(t, func() bool { return !adapter.activeMailboxes()["keep@corp.test"] },
+		500*time.Millisecond, 40*time.Millisecond, "discovery must never remove a static subject")
+}
+
+// TestDiscoveryPagination verifies discovery walks every page of users.list.
+func TestDiscoveryPagination(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.directoryPageSize = 2 // force three pages for five users
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "x@partner.test", "Hello"))
+	users := []discoveredUser{}
+	for i := 0; i < 5; i++ {
+		users = append(users, activeUser("u"+strconv.Itoa(i)+"@corp.test"))
+	}
+	mock.setDirectoryUsers(users...)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.DiscoverMailboxes = true
+	conf.AdminSubject = "admin@corp.test"
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		active := adapter.activeMailboxes()
+		for _, u := range users {
+			if !active[u.PrimaryEmail] {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 20*time.Millisecond, "all five paginated mailboxes should be discovered")
+}
+
+// TestDiscoveryFailureKeepsStaticMailboxes verifies that a failing Directory API
+// (e.g. the admin lacks the directory scope) does not stop the adapter: the
+// explicitly-configured mailboxes keep collecting.
+func TestDiscoveryFailureKeepsStaticMailboxes(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.directoryStatus = http.StatusForbidden // discovery enumeration fails
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "x@partner.test", "Hello"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.Subject = "keep@corp.test"
+	conf.DiscoverMailboxes = true
+	conf.AdminSubject = "admin@corp.test"
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, chStopped, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return hub.countByType("keep@corp.test", eventTypeMessage) == 1 },
+		5*time.Second, 20*time.Millisecond, "the static subject collects despite discovery failing")
+
+	select {
+	case <-chStopped:
+		t.Fatal("a Directory API failure must not stop the adapter")
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// TestPerMailboxDedupeIsolation verifies that two mailboxes holding an item with
+// identical content (here, the same message id served to both) each ship it --
+// one mailbox's dedupe state must not suppress another's.
+func TestPerMailboxDedupeIsolation(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.addMessage(realisticMessage("shared", "t1", recentMs(10*time.Minute), "a@partner.test", "Same"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.Subjects = []string{"a@corp.test", "b@corp.test"}
+	// Share a single deduper across mailboxes to prove keys are mailbox-namespaced.
+	dd, err := utils.NewLocalDeduper(time.Hour, 24*time.Hour)
+	require.NoError(t, err)
+	defer dd.Close()
+	conf.Deduper = dd
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		return hub.countByType("a@corp.test", eventTypeMessage) == 1 &&
+			hub.countByType("b@corp.test", eventTypeMessage) == 1
+	}, 5*time.Second, 20*time.Millisecond, "both mailboxes must ship the identical message to their own sensor")
+	require.Never(t, func() bool {
+		return hub.countByType("a@corp.test", eventTypeMessage) > 1 ||
+			hub.countByType("b@corp.test", eventTypeMessage) > 1
+	}, 300*time.Millisecond, 30*time.Millisecond, "neither mailbox should re-ship")
+}
+
+// TestValidateMultiMailbox covers the validation rules gating the new modes.
+func TestValidateMultiMailbox(t *testing.T) {
+	base := func() GmailConfig {
+		return GmailConfig{
+			ClientOptions:             testClientOptions(t),
+			ServiceAccountCredentials: `{"client_email":"x"}`,
+		}
+	}
+
+	t.Run("service account with only subjects is valid", func(t *testing.T) {
+		c := base()
+		c.Subjects = []string{"a@x.test", "b@x.test"}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("discover_mailboxes requires admin_subject", func(t *testing.T) {
+		c := base()
+		c.DiscoverMailboxes = true
+		assert.Error(t, c.Validate())
+		c.AdminSubject = "admin@x.test"
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("service account with no mailbox source is rejected", func(t *testing.T) {
+		c := base() // no subject, no subjects, no discovery
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("refresh-token flow rejects multi-mailbox fields", func(t *testing.T) {
+		c := GmailConfig{
+			ClientOptions: testClientOptions(t),
+			ClientID:      "id", ClientSecret: "secret", RefreshToken: "rt",
+			Subjects: []string{"a@x.test"},
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("refresh-token flow rejects admin_subject", func(t *testing.T) {
+		c := GmailConfig{
+			ClientOptions: testClientOptions(t),
+			ClientID:      "id", ClientSecret: "secret", RefreshToken: "rt",
+			AdminSubject: "admin@x.test",
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("rejects customer and domain together", func(t *testing.T) {
+		c := base()
+		c.Subject = "a@x.test"
+		c.Customer = "my_customer"
+		c.Domain = "x.test"
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("discovery defaults the customer when neither customer nor domain is set", func(t *testing.T) {
+		c := base()
+		c.DiscoverMailboxes = true
+		c.AdminSubject = "admin@x.test"
+		require.NoError(t, c.Validate())
+		assert.Equal(t, defaultCustomer, c.Customer)
+	})
+}

--- a/gmail/multimailbox_test.go
+++ b/gmail/multimailbox_test.go
@@ -66,6 +66,12 @@ func (m *mockGmail) setDirectoryUsers(u ...discoveredUser) {
 	m.mu.Unlock()
 }
 
+func (m *mockGmail) rejectSubject(sub string) {
+	m.mu.Lock()
+	m.rejectSubjects[sub] = true
+	m.mu.Unlock()
+}
+
 func activeUser(email string) discoveredUser { return discoveredUser{PrimaryEmail: email} }
 func suspendedUser(email string) discoveredUser {
 	return discoveredUser{PrimaryEmail: email, Suspended: true}
@@ -534,4 +540,194 @@ func TestValidateMultiMailbox(t *testing.T) {
 		require.NoError(t, c.Validate())
 		assert.Equal(t, defaultCustomer, c.Customer)
 	})
+}
+
+// TestPerMailboxCredentialIsolation verifies that one mailbox whose impersonation
+// is rejected stops only its own collector, while sibling mailboxes keep
+// collecting and the adapter as a whole stays up.
+func TestPerMailboxCredentialIsolation(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.rejectSubject("bad@corp.test") // this mailbox's delegation is rejected
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "x@partner.test", "Hello"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.Subjects = []string{"good@corp.test", "bad@corp.test"}
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, chStopped, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The healthy mailbox collects; the rejected one ships nothing.
+	require.Eventually(t, func() bool { return hub.countByType("good@corp.test", eventTypeMessage) == 1 },
+		5*time.Second, 20*time.Millisecond, "the healthy mailbox must keep collecting")
+	assert.Equal(t, 0, hub.countByType("bad@corp.test", eventTypeMessage), "the rejected mailbox must ship nothing")
+
+	// The rejected mailbox stopping must not bring the adapter down.
+	select {
+	case <-chStopped:
+		t.Fatal("one mailbox's rejected credentials must not stop the whole adapter")
+	case <-time.After(300 * time.Millisecond):
+	}
+	assert.True(t, adapter.activeMailboxes()["good@corp.test"], "the healthy mailbox must still be active")
+}
+
+// TestMultiMailboxBECCapability verifies a BEC (configuration-state) capability is
+// collected independently for each mailbox, to its own sensor, even when a single
+// deduper is shared across mailboxes (keys are mailbox-namespaced).
+func TestMultiMailboxBECCapability(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.setFilters(utils.Dict{"id": "f1", "action": utils.Dict{"forward": "attacker@evil.test"}})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.Subjects = []string{"a@corp.test", "b@corp.test"}
+	conf.CollectMessages = false
+	conf.CollectFilters = true
+	conf.SettingsPollInterval = 25 * time.Millisecond
+	dd, err := utils.NewLocalDeduper(time.Hour, 24*time.Hour)
+	require.NoError(t, err)
+	defer dd.Close()
+	conf.Deduper = dd // shared across mailboxes on purpose
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		return hub.countByType("a@corp.test", eventTypeFilter) == 1 &&
+			hub.countByType("b@corp.test", eventTypeFilter) == 1
+	}, 5*time.Second, 20*time.Millisecond, "each mailbox must ship its filter to its own sensor")
+	require.Never(t, func() bool {
+		return hub.countByType("a@corp.test", eventTypeFilter) > 1 ||
+			hub.countByType("b@corp.test", eventTypeFilter) > 1
+	}, 300*time.Millisecond, 30*time.Millisecond, "an unchanged filter must not re-ship per mailbox")
+}
+
+// TestDiscoveryIncludeSuspended verifies that include_suspended collects suspended
+// mailboxes that are otherwise skipped.
+func TestDiscoveryIncludeSuspended(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "x@partner.test", "Hello"))
+	mock.setDirectoryUsers(activeUser("ann@corp.test"), suspendedUser("susie@corp.test"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.DiscoverMailboxes = true
+	conf.AdminSubject = "admin@corp.test"
+	conf.IncludeSuspended = true
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		active := adapter.activeMailboxes()
+		return active["ann@corp.test"] && active["susie@corp.test"]
+	}, 5*time.Second, 20*time.Millisecond, "include_suspended must collect the suspended mailbox too")
+}
+
+// TestDiscoveryEmptyResultKeepsCollectors verifies that an empty discovery result
+// while mailboxes are already being collected does NOT tear them down (guard
+// against a misconfigured query or transient API state).
+func TestDiscoveryEmptyResultKeepsCollectors(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "x@partner.test", "Hello"))
+	mock.setDirectoryUsers(activeUser("ann@corp.test"), activeUser("ben@corp.test"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.DiscoverMailboxes = true
+	conf.AdminSubject = "admin@corp.test"
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		active := adapter.activeMailboxes()
+		return active["ann@corp.test"] && active["ben@corp.test"]
+	}, 5*time.Second, 20*time.Millisecond, "both mailboxes should be discovered")
+
+	// Discovery now returns nothing. The existing collectors must be kept.
+	mock.setDirectoryUsers()
+	require.Never(t, func() bool {
+		active := adapter.activeMailboxes()
+		return !active["ann@corp.test"] || !active["ben@corp.test"]
+	}, 600*time.Millisecond, 40*time.Millisecond, "an empty discovery result must not tear down existing collectors")
+}
+
+// TestMailboxAddressCanonicalization verifies that mailbox addresses are
+// case-folded, so differing casings of the same mailbox collapse to one
+// collector / one sensor rather than producing duplicates.
+func TestMailboxAddressCanonicalization(t *testing.T) {
+	saJSON, pub := generateServiceAccount(t)
+
+	mock := newMockGmail()
+	mock.saPublicKey = pub
+	mock.addMessage(realisticMessage("m1", "t1", recentMs(10*time.Minute), "x@partner.test", "Hello"))
+	// Static config names the mailbox in one casing; discovery returns another.
+	mock.setDirectoryUsers(activeUser("alice@corp.test"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	conf := saConfig(t, server.URL, saJSON)
+	conf.Subjects = []string{"Alice@Corp.test", "ALICE@corp.test"} // same mailbox, two casings
+	conf.DiscoverMailboxes = true
+	conf.AdminSubject = "admin@corp.test"
+
+	hub := newSinkHub()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newGmailAdapter(ctx, conf, hub.factory())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return adapter.activeMailboxes()["alice@corp.test"] },
+		5*time.Second, 20*time.Millisecond, "the canonical (lower-cased) mailbox should collect")
+
+	// There must be exactly one collector for this mailbox, and none under any
+	// other casing, even though discovery also returns it.
+	require.Never(t, func() bool {
+		active := adapter.activeMailboxes()
+		return len(active) != 1 || active["Alice@Corp.test"] || active["ALICE@corp.test"]
+	}, 500*time.Millisecond, 40*time.Millisecond, "differing casings must collapse to a single collector")
 }


### PR DESCRIPTION
## Summary

Adds a **Gmail** USP adapter that collects incoming email and Business-Email-Compromise (BEC) signals from **one or many Gmail mailboxes** via the [Gmail REST API](https://developers.google.com/workspace/gmail/api/reference/rest). Each mailbox is collected independently and shipped to **its own LimaCharlie sensor**.

Message telemetry polls [`users.messages.list`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/list) on a rolling window (default query `in:inbox`, with an `after:<epoch>` bound appended automatically), fetches each newly-seen message with [`users.messages.get`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/get), and ships it as a `gmail_message` event with the full message resource preserved verbatim. The event timestamp comes from the message's `internalDate`.

## Authentication

- **OAuth 2.0 refresh token** — a single mailbox (`client_id` / `client_secret` / `refresh_token`).
- **Service account + domain-wide delegation** — one or many Google Workspace mailboxes; the adapter signs an RS256 JWT-bearer assertion impersonating each mailbox.

## Multiple mailboxes (service-account flow)

Each mailbox is impersonated independently and shipped to **its own sensor**: when more than one mailbox is collected, the sensor seed key is derived as `<sensor_seed_key>/<mailbox-address>` and the hostname is set to the address. A single explicit `subject` keeps the configured identity verbatim. Enumeration is combinable (the union is collected):

| Mode | Config | Notes |
|---|---|---|
| Static list | `subjects: [...]` | A fixed set of mailboxes |
| Auto-discovery | `discover_mailboxes: true` + `admin_subject` | Enumerates the domain via the Admin SDK Directory API ([`users.list`](https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list)), re-run on `discovery_interval`; newly-provisioned mailboxes get a collector, deprovisioned ones are stopped and torn down. Skips suspended/archived unless `include_suspended`. |

Auto-discovery needs an `admin_subject` (an admin to impersonate for the Directory call) and the `admin.directory.user.readonly` scope added to the delegation, in addition to `gmail.readonly`. Other knobs: `customer`/`domain`, `discovery_query`, `max_concurrent_polls` (default 10, bounds simultaneous Gmail API usage).

## BEC capabilities

Collection is a set of independent, **opt-in capabilities**, each shipping its own event type (default when none is set: messages only). All are readable with the existing `gmail.readonly` scope.

| Flag | Event type(s) | Gmail API | BEC relevance |
|---|---|---|---|
| `collect_messages` | `gmail_message` | `messages.list`/`get` | Incoming email (default) |
| `collect_filters` | `gmail_filter` | `settings.filters.list` | Auto-delete/forward rules hiding invoice/wire replies |
| `collect_forwarding` | `gmail_forwarding_address`, `gmail_auto_forwarding` | `settings.forwardingAddresses.list`, `getAutoForwarding` | Mail exfiltration |
| `collect_send_as` | `gmail_send_as` | `settings.sendAs.list` | Impersonation / added "from" identities |
| `collect_delegates` | `gmail_delegate` | `settings.delegates.list` | Persistence (**Workspace only**) |
| `collect_imap_pop` | `gmail_imap`, `gmail_pop` | `settings.getImap`, `getPop` | Bulk mailbox download bypassing browser controls |
| `collect_vacation` | `gmail_vacation` | `settings.getVacation` | Harvesting / social engineering |
| `collect_history` | `gmail_history` | `users.history.list` | Deletions and label changes (covering tracks) |

The configuration-state capabilities emit **change-only** events (an item ships when it first appears or its content changes, deduped on a content hash) on a slower `settings_poll_interval` (default 15m). **History** baselines silently from the mailbox profile, lists `messageDeleted`/`labelAdded`/`labelRemoved` forward from a cursor, advances only on a fully-successful pass, and **re-baselines on a 404** (cursor aged out of Gmail's ~1-week retention).

## Reliability

- High-water-mark cursor per mailbox with configurable `overlap`; exactly-once delivery via a deduper keyed on the immutable message id, **namespaced by mailbox** so identical items in different mailboxes never suppress each other.
- Transparent access-token refresh + retry on `401`; transient backoff on `429` / `5xx` / `403` rate-limit.
- **Per-mailbox failure isolation** — rejected credentials stop only that mailbox; siblings keep running. A failing BEC capability (e.g. `delegates` 403 on a consumer account) or a failing discovery pass is logged and skipped, never stopping the adapter or the other mailboxes.
- A `404` on an individual message (deleted between list and get) is skipped, not fatal. Listing/history pagination is walked fully.
- Shared HTTP transports owned by the adapter; idempotent `Close`; construction does no blocking network I/O.

## Architecture

`GmailAdapter` orchestrates a per-mailbox `mailboxCollector` that owns all mailbox-specific state (Gmail client, token source, sensor sink, dedupe state, message/settings/history cursors) and, optionally, the Directory-API discovery loop.

- `gmail/client.go` — config + validation, orchestrator, enumeration, per-mailbox sensor derivation, concurrency limiter, lifecycle.
- `gmail/collector.go` — the per-mailbox collector and its message-poll/retry/ship logic.
- `gmail/capabilities.go` — the BEC and history collectors.
- `gmail/discovery.go` — Directory API client + the discovery reconcile loop.
- `gmail/auth.go` — token sources (refresh token + service-account JWT), error classification.
- `gmail/api.go` — the Gmail REST client.
- `gmail/README.md` + main `README.md`; wired into `containers/conf/all.go` and `containers/general/tool.go` (`gmail` adapter type).

No `go.mod` changes — reuses the vendored `github.com/golang-jwt/jwt/v4`.

## Testing

Mock-tested against the documented Gmail and Directory API shapes. **41 tests, 0 skipped, race-clean** (`CGO_ENABLED=1 go test ./gmail/... -race`):

- End-to-end for both auth flows, asserting event type, `internalDate` timestamp, and verbatim payload; service-account delegation claims (`sub`/`scope`/`iss`) and RS256 signature verified at the mock token endpoint.
- Pagination, multi-poll dedupe, mid-run arrival, `401` refresh, bad-credential stop, `404`-skip.
- Each BEC capability: change-only emit, no re-ship when unchanged, re-ship on edit, delegates-non-fatal, history collection + cursor expiry.
- Multi-mailbox: static fan-out + per-sensor identity, single-mailbox keeping its configured sensor, discovery enumerate/skip-suspended/pagination, dynamic add-then-remove, static-never-removed, discovery-failure-non-fatal, cross-mailbox dedupe isolation under a shared deduper, and the validation matrix.

> Verified against a mock mirroring the documented API shapes — not yet exercised against a live mailbox.

