### PR TITLE
Add create-adapter Claude Code skill

### DIFF
--- a/.claude/skills/create-adapter/SKILL.md
+++ b/.claude/skills/create-adapter/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: create-adapter
+description: Guide for building a new LimaCharlie USP adapter in this repo — researching the source API, implementing it following existing patterns, writing thorough mock-backed tests, optionally live-testing against a real API key, validating the mock's fidelity, and shipping a documented PR. Use when the user wants to add a new adapter / data source / integration (e.g. "add an adapter for <vendor>", "ingest <product> logs into LimaCharlie").
+---
+
+# Building a new USP adapter
+
+A USP adapter pulls events from some external source (a SaaS API, a queue, a
+file) and ships them to LimaCharlie as USP `DataMessage`s. This skill walks you
+through building a new one the way the existing adapters in this repo are built,
+with thorough tests that don't require live credentials to run in CI.
+
+**The canonical example to read and imitate is `threatlocker/`** — a polling
+HTTP-API adapter with a clean separation between transport (`api.go`), adapter
+logic (`client.go`), unit tests (`client_test.go`), and an end-to-end mock
+(`mock_test.go`). Read all four before writing code. `1password/`, `gmail/`, and
+`sublime/` are good secondary references for other API shapes.
+
+Work through the phases below in order. Don't skip the research phase — getting
+the API shape right up front is what makes the rest (and the mock) correct.
+
+## Phase 0 — Scope it with the user
+
+Before writing anything, confirm with the user:
+
+- **What source / vendor** and **which events** they want ingested.
+- **Auth method**: API key/token, OAuth refresh token, basic auth, service
+  account, etc. This drives the config struct and the mock's auth check.
+- **Whether they have working credentials** you can use to live-test (ask now;
+  you'll need the answer in Phase 5). If they do, find out how they want to
+  provide them — env vars are simplest. **Never commit credentials.** Note that
+  this repo already uses files like `*-do-not-commit.txt` for local secrets;
+  follow that convention and double-check `.gitignore`.
+
+If the source is a pull-based HTTP API that paginates and you poll it on an
+interval, the `threatlocker` pattern fits almost exactly. If it's push-based
+(webhook/socket) or a stream/queue, study the closest existing adapter instead
+(`syslog`, `sqs`, `pubsub`, `azure_event_hub`).
+
+## Phase 1 — Research the API
+
+Read the actual vendor documentation — do not rely on memory. Use WebFetch /
+WebSearch to pull:
+
+- The **authentication** scheme (header name, token format, token lifetime,
+  refresh flow). Capture the exact header(s) the request must carry.
+- The **listing/query endpoint(s)** for the events: HTTP method, URL shape,
+  request body/query parameters, and especially **how pagination works**
+  (page number, cursor/`next` token, `has_more` flag, offset/limit, time
+  window). Pagination correctness is the #1 source of adapter bugs.
+- The **response envelope**: is the records array bare (`[...]`) or wrapped
+  (`{"data": [...]}`)? What key holds it?
+- A **stable per-record ID field** (for deduplication) and a **timestamp field**
+  (for event time). Note their exact paths and formats.
+- **Rate limits** and the **error model** (status codes, retry-after).
+
+Record the doc URLs and a couple of **real example response payloads** — you'll
+paste sanitized versions of these into the mock and the README. If a vendor
+OpenAPI/Swagger spec or Postman collection exists, grab it; it's the most
+reliable source for request/response shapes.
+
+Write down, before coding:
+- the auth header(s),
+- the endpoint URL(s) + method,
+- the pagination mechanism,
+- the items-array location,
+- the id + timestamp field paths,
+- a sample record (verbatim from docs).
+
+## Phase 2 — Implement, following existing patterns
+
+Create a new package directory `myadapter/` (lowercase, no underscores in the
+dir name to match siblings like `threatlocker`, `pandadoc`; the Go package is
+`usp_myadapter`).
+
+Mirror the `threatlocker` file layout:
+
+- **`api.go`** — a thin HTTP client: a constructor, a single generic request
+  helper (`Post`/`Get`) that sets auth headers and returns the raw body, an
+  `HTTPError{StatusCode, URL, Body}` type, an `isTransientError()` classifier
+  (retry 5xx/429/network; don't retry other 4xx or context-cancel), and a
+  `Close()` that releases idle connections.
+- **`client.go`** — the config struct + `Validate()` (apply defaults here),
+  the adapter struct, `NewMyAdapter(ctx, conf) (*MyAdapter, chan struct{},
+  error)`, the poll loop, pagination, dedup, timestamp extraction, and `Ship`.
+- **`client_test.go`** — unit tests for the pure logic (validation, pagination
+  math, id/timestamp extraction, transient-error classification) plus the
+  shared `testClientOptions(t)` helper.
+- **`mock_test.go`** — the end-to-end test against an in-memory mock API.
+- **`README.md`** — adapter documentation (see Phase 6).
+
+Key conventions to copy exactly (see `references/patterns.md` for annotated
+snippets):
+
+1. **Config**: embed `uspclient.ClientOptions` as `client_options`. Use
+   `json`+`yaml` tags on every field. Implement `Validate()` that calls
+   `c.ClientOptions.Validate()`, checks required fields, and fills defaults.
+2. **The sink seam**: define a small `uspSink` interface (`Ship`/`Drain`/
+   `Close`) and an unexported `newMyAdapter(ctx, conf, sink)` constructor so
+   tests can inject an in-memory sink. The exported constructor passes `nil`
+   and a real `uspclient.NewClient` is built. This is what makes end-to-end
+   tests possible without a LimaCharlie connection (also set
+   `TestSinkMode: true` in test `ClientOptions`).
+3. **Stop/lifecycle**: use `utils.NewEvent()` for the stop signal, a
+   `sync.WaitGroup` for feed goroutines, a `chStopped` channel closed when all
+   senders exit, and a `sync.Once`-guarded idempotent `Close()`.
+4. **Dedup**: every poll re-fetches pages, so dedup — not an early exit — is
+   what ships each record once. Use `utils.NewLocalDeduper(window, ttl)` and a
+   per-feed-namespaced key. Resolve the record id from the configured field,
+   fall back to common id fields, then a content hash.
+5. **Shipping**: build `protocol.DataMessage{JsonPayload, EventType,
+   TimestampMs}`. Ship payloads **verbatim** — don't reshape the vendor JSON
+   (LimaCharlie parses/maps in the cloud). Handle `uspclient.ErrorBufferFull`
+   by retrying the Ship with a long timeout (backpressure).
+6. **Retries**: wrap the page fetch in exponential backoff bounded by
+   `MaxRetryAttempts`; stop the whole adapter on 401/403 (auth failure affects
+   every poll), abandon just the current poll on other permanent errors.
+7. **JSON**: decode records with `utils.UnmarshalCleanJSON` (preserves integer
+   precision); use `utils.Dict` for record maps and its `FindOneString`/
+   `FindInt` helpers for field extraction.
+
+Then **register** the adapter (3 edits — see `references/registration.md`):
+- `containers/conf/all.go`: import the package, add a field to `GeneralConfigs`.
+- `containers/general/tool.go`: import the package, add the `else if method ==
+  "myadapter"` dispatch branch.
+- root `README.md`: add a short "### MyAdapter" section with a run example.
+
+Build with `go build ./containers/general` and `go fmt ./myadapter/...` before
+moving on.
+
+## Phase 3 — Write the mock (model the real API shape)
+
+The mock is the heart of testable-without-credentials. In `mock_test.go` build
+an `httptest.NewServer` whose handler faithfully reproduces the **real** API:
+
+- **Auth**: reject requests missing/with the wrong token exactly as the real API
+  does (right status code, right-ish error body). Have a test that asserts a bad
+  token stops the adapter and ships nothing.
+- **Pagination**: implement the *same* pagination scheme the real API uses
+  (page number, cursor, or `has_more`) over an in-memory dataset, so the
+  adapter's paging logic is genuinely exercised. Test a multi-page dataset.
+- **Envelope**: return the records in the *same* shape (bare array vs.
+  `{"data":[...]}`). If the API can do both, cover both.
+- **Realistic fixtures**: build record fixtures that match real payloads from
+  Phase 1 — nested objects, arrays, mixed scalar types, the real id and
+  timestamp field names/formats. Copy structure from a real (sanitized) sample.
+
+End-to-end tests to write (model them on `threatlocker/mock_test.go`):
+- All records ship; event type, parsed timestamp, and **verbatim payload** match.
+- Re-polling does not re-ship (dedup works).
+- A record appearing mid-run ships exactly once.
+- A multi-page dataset is fully walked, each record once.
+- Multiple feeds/types (if applicable) are tagged correctly.
+- Bad auth → adapter stops, ships nothing.
+
+## Phase 4 — Run the tests
+
+This repo's tests are standard `go test`. Run:
+
+```
+go test ./myadapter/...
+```
+
+All tests must pass and be **fully enabled** — never skip a test or weaken an
+assertion to get green. If a `run_local_test.sh` exists at the repo root, prefer
+running that instead (it handles local system dependencies). There isn't one
+today, so `go test` is correct for a self-contained adapter.
+
+## Phase 5 — Live-test with real credentials (if available)
+
+If the user provided credentials in Phase 0, run the real adapter against the
+live API to prove it actually works end-to-end. Two options:
+
+- **Via the built binary** (matches production), using a sink/test OID, e.g.:
+  ```
+  go build ./containers/general
+  ./general myadapter \
+    client_options.identity.oid=$OID \
+    client_options.identity.installation_key=$INSTALLATION_KEY \
+    client_options.platform=json \
+    client_options.sensor_seed_key=myadapter \
+    api_key=$MYADAPTER_API_KEY
+  ```
+  Confirm a new sensor appears in the user's LimaCharlie org and events flow.
+- **Via a temporary integration test** gated on an env var being present (so CI
+  without the secret still passes by the var being absent — but do **not** make
+  this a permanent skipped test; remove it before the PR, its purpose is the
+  live capture, not CI). Capture the real request/response wire bytes while it
+  runs.
+
+**Capture the real responses** during this run (log the raw bodies, or use a
+proxy). These captures are gold for Phase 5b.
+
+### Phase 5b — Validate the mock against reality
+
+With real responses in hand, **diff them against your mock**:
+
+- Does the real **pagination** behave as the mock assumes (page sizes, the
+  end-of-data signal, cursor/`has_more`)? Fix the mock if not.
+- Is the **envelope** key and shape exactly what the mock returns?
+- Do the **id** and **timestamp** field paths/formats match? Are timestamps in
+  the format your parser handles?
+- Do the **fixtures** contain the field types the real data has (numbers that
+  are big integers, nullable fields, nested arrays)?
+- Does **auth** rejection use the status code your mock returns?
+
+Update the mock and fixtures so they mirror the captured reality. The goal: the
+mock-backed tests would have caught any wire-shape mistake, so future
+maintainers can evolve the adapter confidently **without** live credentials.
+Then re-run Phase 4 and confirm everything still passes.
+
+If the user has **no** credentials, say so plainly, make the mock as faithful as
+possible from the documented shapes (Phase 1), and note in the PR that it hasn't
+been live-verified.
+
+## Phase 6 — Document and open a draft PR
+
+Write `myadapter/README.md` (model it on `threatlocker/README.md`):
+- One-line description + link to the vendor and **the API docs** (the URLs from
+  Phase 1).
+- **Authentication**: how to obtain the credential, what header it maps to.
+- **Configuration table**: every config key, required?, description, defaults.
+- **What the data looks like**: which events are collected, the event types, and
+  a sample payload.
+- **How polling/pagination/dedup works** and any operational caveats (rate
+  limits, required filters, instance selection, etc.).
+- CLI and YAML run examples.
+
+Also add the short root-`README.md` entry (Phase 2) and ensure the example there
+matches.
+
+Then open the PR **as a draft**:
+
+```
+git checkout -b add-myadapter-adapter
+git add myadapter/ containers/conf/all.go containers/general/tool.go README.md
+git commit -m "Add MyAdapter adapter (<one-line of what it ingests>)"   # see commit trailer rule
+git push -u origin add-myadapter-adapter
+gh pr create --draft --title "Add MyAdapter adapter" --body "<summary>"
+```
+
+PR body should cover: what the adapter ingests, the API docs link, auth method,
+the event types/sample data, how it was tested (mock coverage + whether it was
+live-verified), and any follow-ups. Be careful to stage **only** your adapter's
+files — don't sweep in unrelated working-tree changes.
+
+## Checklist
+
+- [ ] API researched from real docs; auth, pagination, envelope, id+timestamp
+      fields, sample payload recorded.
+- [ ] `api.go` / `client.go` follow the `threatlocker` patterns (sink seam,
+      `utils` deduper/event, verbatim payloads, retry + auth-stop).
+- [ ] Registered in `containers/conf/all.go` and `containers/general/tool.go`;
+      `go build ./containers/general` passes.
+- [ ] Mock reproduces real auth + pagination + envelope; realistic fixtures.
+- [ ] End-to-end + unit tests pass, fully enabled (`go test ./myadapter/...`).
+- [ ] Live-tested if creds available; mock validated against captured responses.
+- [ ] `myadapter/README.md` + root README entry written with API doc links and
+      sample data.
+- [ ] Draft PR opened with only the adapter's files staged.

--- a/.claude/skills/create-adapter/SKILL.md
+++ b/.claude/skills/create-adapter/SKILL.md
@@ -89,8 +89,9 @@ Mirror the `threatlocker` file layout:
 - **`mock_test.go`** — the end-to-end test against an in-memory mock API.
 - **`README.md`** — adapter documentation (see Phase 6).
 
-Key conventions to copy exactly (see `references/patterns.md` for annotated
-snippets):
+Key conventions to copy exactly — `references/patterns.md` is a reading guide
+that points you at the specific files and symbols in `threatlocker/` (and the
+right alternative adapter when your API differs) to study and imitate:
 
 1. **Config**: embed `uspclient.ClientOptions` as `client_options`. Use
    `json`+`yaml` tags on every field. Implement `Validate()` that calls

--- a/.claude/skills/create-adapter/SKILL.md
+++ b/.claude/skills/create-adapter/SKILL.md
@@ -1,214 +1,184 @@
 ---
 name: create-adapter
-description: Guide for building a new LimaCharlie USP adapter in this repo — researching the source API, implementing it following existing patterns, writing thorough mock-backed tests, optionally live-testing against a real API key, validating the mock's fidelity, and shipping a documented PR. Use when the user wants to add a new adapter / data source / integration (e.g. "add an adapter for <vendor>", "ingest <product> logs into LimaCharlie").
+description: Guide for building a new LimaCharlie USP adapter in this repo — researching the source, implementing it by copying the closest existing adapter, writing thorough tests with a mock/fake of the source, optionally live-testing against real credentials, validating the mock's fidelity, and shipping a documented PR. Use when the user wants to add a new adapter / data source / integration (e.g. "add an adapter for <vendor>", "ingest <product> logs into LimaCharlie").
 ---
 
 # Building a new USP adapter
 
-A USP adapter pulls events from some external source (a SaaS API, a queue, a
-file) and ships them to LimaCharlie as USP `DataMessage`s. This skill walks you
-through building a new one the way the existing adapters in this repo are built,
-with thorough tests that don't require live credentials to run in CI.
+A USP adapter reads events from some external source and ships them to
+LimaCharlie as USP `DataMessage`s. Sources vary widely — REST APIs you poll,
+vendor SDKs (AWS/GCP/Azure), streaming sockets, mailboxes, local files, stdin —
+so **there is no single template**. What every adapter shares is one contract
+(see `references/patterns.md`); everything else you get by **copying the existing
+adapter closest to your source**.
 
-**The canonical example to read and imitate is `threatlocker/`** — a polling
-HTTP-API adapter with a clean separation between transport (`api.go`), adapter
-logic (`client.go`), unit tests (`client_test.go`), and an end-to-end mock
-(`mock_test.go`). Read all four before writing code. `1password/`, `gmail/`, and
-`sublime/` are good secondary references for other API shapes.
+The strongest, best-tested examples to imitate are `threatlocker/` and `gmail/`
+(both have full mock-backed test suites). But pick by source type:
 
-Work through the phases below in order. Don't skip the research phase — getting
-the API shape right up front is what makes the rest (and the mock) correct.
+- HTTP API you poll → `threatlocker/`, `1password/`, `gmail/`
+- a vendor SDK / cloud client → `s3/`, `sqs/` (AWS), `pubsub/`, `gcs/`,
+  `bigquery/` (GCP), `azure_event_hub/` (Azure)
+- streaming socket / push → `syslog/`, `azure_event_hub/`
+- mailbox → `imap/`, `gmail/`
+- local files / OS sources → `file/`, `evtx/`, `wel/`, `stdin/`
+
+`references/patterns.md` maps source types to examples and lists the shared
+contract and the patterns worth copying regardless of source. Read it plus your
+chosen example(s) before writing code.
+
+Work through the phases in order. Don't skip research — getting the source's real
+shape right up front is what makes the implementation and the mock correct.
 
 ## Phase 0 — Scope it with the user
 
-Before writing anything, confirm with the user:
+Before writing anything, confirm:
 
 - **What source / vendor** and **which events** they want ingested.
-- **Auth method**: API key/token, OAuth refresh token, basic auth, service
-  account, etc. This drives the config struct and the mock's auth check.
+- **How you reach the source**: a documented HTTP API, an official SDK, a
+  socket/stream, a file? This decides which existing adapter you copy.
+- **Auth method**: API key/token, OAuth refresh token, basic auth, cloud
+  credentials/service account, etc. This drives the config struct and the mock's
+  auth check.
 - **Whether they have working credentials** you can use to live-test (ask now;
-  you'll need the answer in Phase 5). If they do, find out how they want to
-  provide them — env vars are simplest. **Never commit credentials.** Note that
-  this repo already uses files like `*-do-not-commit.txt` for local secrets;
-  follow that convention and double-check `.gitignore`.
+  you'll need it in Phase 5). If they do, agree how they'll provide them — env
+  vars are simplest. **Never commit credentials.** This repo already uses files
+  like `*-do-not-commit.txt` for local secrets; follow that and check
+  `.gitignore`.
 
-If the source is a pull-based HTTP API that paginates and you poll it on an
-interval, the `threatlocker` pattern fits almost exactly. If it's push-based
-(webhook/socket) or a stream/queue, study the closest existing adapter instead
-(`syslog`, `sqs`, `pubsub`, `azure_event_hub`).
+## Phase 1 — Research the source
 
-## Phase 1 — Research the API
+Read the real vendor documentation / SDK reference — do not rely on memory. Use
+WebFetch / WebSearch. Capture, before coding:
 
-Read the actual vendor documentation — do not rely on memory. Use WebFetch /
-WebSearch to pull:
+- **Authentication** — exact mechanism (header + token format, OAuth refresh
+  flow, SDK credential object), token lifetime/refresh.
+- **How you list/receive events** — for an HTTP API: the endpoint(s), method,
+  request params, and **how pagination works** (page number, cursor/`next`,
+  `has_more`, offset/limit, time window) — pagination is the #1 source of adapter
+  bugs. For an SDK: which client method streams/lists the events and how it
+  signals "no more". For a stream/queue: how messages are received and
+  acknowledged.
+- **The event shape** — a real sample payload, the **stable per-record id field**
+  (for dedup) and the **timestamp field** (for event time), with exact
+  paths/formats. For HTTP, the response envelope (bare array vs. `{"data":[...]}`).
+- **Rate limits / error model** — status codes, retry-after, throttling.
 
-- The **authentication** scheme (header name, token format, token lifetime,
-  refresh flow). Capture the exact header(s) the request must carry.
-- The **listing/query endpoint(s)** for the events: HTTP method, URL shape,
-  request body/query parameters, and especially **how pagination works**
-  (page number, cursor/`next` token, `has_more` flag, offset/limit, time
-  window). Pagination correctness is the #1 source of adapter bugs.
-- The **response envelope**: is the records array bare (`[...]`) or wrapped
-  (`{"data": [...]}`)? What key holds it?
-- A **stable per-record ID field** (for deduplication) and a **timestamp field**
-  (for event time). Note their exact paths and formats.
-- **Rate limits** and the **error model** (status codes, retry-after).
+Record the doc URLs and a couple of **real sample payloads** — sanitized
+versions go into the mock fixtures and the README. Grab an OpenAPI/Swagger spec,
+Postman collection, or SDK example if one exists; it's the most reliable source
+of shapes.
 
-Record the doc URLs and a couple of **real example response payloads** — you'll
-paste sanitized versions of these into the mock and the README. If a vendor
-OpenAPI/Swagger spec or Postman collection exists, grab it; it's the most
-reliable source for request/response shapes.
+## Phase 2 — Implement by copying the closest adapter
 
-Write down, before coding:
-- the auth header(s),
-- the endpoint URL(s) + method,
-- the pagination mechanism,
-- the items-array location,
-- the id + timestamp field paths,
-- a sample record (verbatim from docs).
+Create package directory `myadapter/` (lowercase; the Go package is
+`usp_myadapter`). Most adapters are a single `client.go`; the well-tested ones
+add `*_test.go` and sometimes split transport into `api.go` (as `threatlocker`
+does for HTTP). **Mirror the file layout of whichever adapter you're copying.**
 
-## Phase 2 — Implement, following existing patterns
+Every adapter, whatever the source, must honor the universal contract (detailed
+in `references/patterns.md`):
 
-Create a new package directory `myadapter/` (lowercase, no underscores in the
-dir name to match siblings like `threatlocker`, `pandadoc`; the Go package is
-`usp_myadapter`).
+- Config struct embedding `uspclient.ClientOptions` as `client_options`
+  (json+yaml tags on every field) with a `Validate()` that fills defaults.
+- `func NewMyAdapter(ctx, conf) (*MyAdapter, chan struct{}, error)` and an
+  idempotent `Close() error`; the channel closes when the adapter stops itself.
+- Read from the source however it works, and **ship each event verbatim** as a
+  `protocol.DataMessage{JsonPayload, EventType, TimestampMs}` through the usp
+  client. Don't reshape payloads — LimaCharlie parses/maps in the cloud.
 
-Mirror the `threatlocker` file layout:
+Patterns worth copying from the well-tested adapters (all in
+`references/patterns.md`): a **test seam** that puts the external dependency
+behind a small interface so a fake/mock can stand in (`threatlocker`'s `uspSink`
++ unexported `newThreatLockerAdapter(ctx,conf,sink)`); lifecycle via
+`utils.NewEvent()` + `WaitGroup` + `sync.Once` `Close`; **exactly-once shipping**
+via `utils.NewLocalDeduper` keyed on a stable id when the source can re-deliver;
+robust transport (`HTTPError` + `isTransientError`, backoff, **stop on 401/403**)
+for HTTP sources; JSON fidelity via `utils.UnmarshalCleanJSON`/`utils.Dict`; and
+backpressure handling on `uspclient.ErrorBufferFull`.
 
-- **`api.go`** — a thin HTTP client: a constructor, a single generic request
-  helper (`Post`/`Get`) that sets auth headers and returns the raw body, an
-  `HTTPError{StatusCode, URL, Body}` type, an `isTransientError()` classifier
-  (retry 5xx/429/network; don't retry other 4xx or context-cancel), and a
-  `Close()` that releases idle connections.
-- **`client.go`** — the config struct + `Validate()` (apply defaults here),
-  the adapter struct, `NewMyAdapter(ctx, conf) (*MyAdapter, chan struct{},
-  error)`, the poll loop, pagination, dedup, timestamp extraction, and `Ship`.
-- **`client_test.go`** — unit tests for the pure logic (validation, pagination
-  math, id/timestamp extraction, transient-error classification) plus the
-  shared `testClientOptions(t)` helper.
-- **`mock_test.go`** — the end-to-end test against an in-memory mock API.
-- **`README.md`** — adapter documentation (see Phase 6).
-
-Key conventions to copy exactly — `references/patterns.md` is a reading guide
-that points you at the specific files and symbols in `threatlocker/` (and the
-right alternative adapter when your API differs) to study and imitate:
-
-1. **Config**: embed `uspclient.ClientOptions` as `client_options`. Use
-   `json`+`yaml` tags on every field. Implement `Validate()` that calls
-   `c.ClientOptions.Validate()`, checks required fields, and fills defaults.
-2. **The sink seam**: define a small `uspSink` interface (`Ship`/`Drain`/
-   `Close`) and an unexported `newMyAdapter(ctx, conf, sink)` constructor so
-   tests can inject an in-memory sink. The exported constructor passes `nil`
-   and a real `uspclient.NewClient` is built. This is what makes end-to-end
-   tests possible without a LimaCharlie connection (also set
-   `TestSinkMode: true` in test `ClientOptions`).
-3. **Stop/lifecycle**: use `utils.NewEvent()` for the stop signal, a
-   `sync.WaitGroup` for feed goroutines, a `chStopped` channel closed when all
-   senders exit, and a `sync.Once`-guarded idempotent `Close()`.
-4. **Dedup**: every poll re-fetches pages, so dedup — not an early exit — is
-   what ships each record once. Use `utils.NewLocalDeduper(window, ttl)` and a
-   per-feed-namespaced key. Resolve the record id from the configured field,
-   fall back to common id fields, then a content hash.
-5. **Shipping**: build `protocol.DataMessage{JsonPayload, EventType,
-   TimestampMs}`. Ship payloads **verbatim** — don't reshape the vendor JSON
-   (LimaCharlie parses/maps in the cloud). Handle `uspclient.ErrorBufferFull`
-   by retrying the Ship with a long timeout (backpressure).
-6. **Retries**: wrap the page fetch in exponential backoff bounded by
-   `MaxRetryAttempts`; stop the whole adapter on 401/403 (auth failure affects
-   every poll), abandon just the current poll on other permanent errors.
-7. **JSON**: decode records with `utils.UnmarshalCleanJSON` (preserves integer
-   precision); use `utils.Dict` for record maps and its `FindOneString`/
-   `FindInt` helpers for field extraction.
-
-Then **register** the adapter (3 edits — see `references/registration.md`):
+Then **register** the adapter (see `references/registration.md` — easiest is to
+grep an existing adapter like `threatlocker` across these files and replicate):
 - `containers/conf/all.go`: import the package, add a field to `GeneralConfigs`.
-- `containers/general/tool.go`: import the package, add the `else if method ==
-  "myadapter"` dispatch branch.
-- root `README.md`: add a short "### MyAdapter" section with a run example.
+- `containers/general/tool.go`: import it, add the `else if method == "myadapter"`
+  dispatch branch.
+- root `README.md`: add a short section with a run example.
 
-Build with `go build ./containers/general` and `go fmt ./myadapter/...` before
-moving on.
+Build with `go build ./containers/general` and `go fmt ./myadapter/...`.
 
-## Phase 3 — Write the mock (model the real API shape)
+## Phase 3 — Write a mock/fake of the source
 
-The mock is the heart of testable-without-credentials. In `mock_test.go` build
-an `httptest.NewServer` whose handler faithfully reproduces the **real** API:
+The whole point is end-to-end tests that run **without live credentials**, by
+substituting a stand-in for the external source through the test seam. Model on
+`threatlocker/mock_test.go` and `gmail/mock_test.go`:
 
-- **Auth**: reject requests missing/with the wrong token exactly as the real API
-  does (right status code, right-ish error body). Have a test that asserts a bad
-  token stops the adapter and ships nothing.
-- **Pagination**: implement the *same* pagination scheme the real API uses
-  (page number, cursor, or `has_more`) over an in-memory dataset, so the
-  adapter's paging logic is genuinely exercised. Test a multi-page dataset.
-- **Envelope**: return the records in the *same* shape (bare array vs.
-  `{"data":[...]}`). If the API can do both, cover both.
-- **Realistic fixtures**: build record fixtures that match real payloads from
-  Phase 1 — nested objects, arrays, mixed scalar types, the real id and
-  timestamp field names/formats. Copy structure from a real (sanitized) sample.
+- For an **HTTP** source: an `httptest.NewServer` whose handler **reproduces the
+  real API** — checks auth the way the real API does, paginates over an in-memory
+  dataset with the *same* mechanism, returns the *same* envelope shape.
+- For an **SDK / non-HTTP** source: a fake implementing the small interface your
+  adapter calls, returning realistic results and exercising the same "more
+  data / no more" and error behaviors.
+- **Realistic fixtures** matching the Phase-1 sample payloads — nested objects,
+  arrays, mixed scalar types, the real id and timestamp field names/formats.
 
-End-to-end tests to write (model them on `threatlocker/mock_test.go`):
-- All records ship; event type, parsed timestamp, and **verbatim payload** match.
-- Re-polling does not re-ship (dedup works).
-- A record appearing mid-run ships exactly once.
-- A multi-page dataset is fully walked, each record once.
-- Multiple feeds/types (if applicable) are tagged correctly.
+End-to-end tests to write:
+- All events ship; event type, parsed timestamp, and **verbatim payload** match.
+- Re-reading/re-polling does not re-ship (dedup works, when applicable).
+- An event appearing mid-run ships exactly once.
+- A multi-page / multi-batch dataset is fully consumed, each event once.
+- Multiple event types (if applicable) are tagged correctly.
 - Bad auth → adapter stops, ships nothing.
 
 ## Phase 4 — Run the tests
 
-This repo's tests are standard `go test`. Run:
+Standard `go test`:
 
 ```
 go test ./myadapter/...
 ```
 
 All tests must pass and be **fully enabled** — never skip a test or weaken an
-assertion to get green. If a `run_local_test.sh` exists at the repo root, prefer
-running that instead (it handles local system dependencies). There isn't one
-today, so `go test` is correct for a self-contained adapter.
+assertion to get green. If a `run_local_test.sh` ever exists at the repo root,
+prefer it (it handles local system dependencies). There isn't one today, so
+`go test` is correct for a self-contained adapter.
 
 ## Phase 5 — Live-test with real credentials (if available)
 
 If the user provided credentials in Phase 0, run the real adapter against the
-live API to prove it actually works end-to-end. Two options:
+live source to prove it works end-to-end. Easiest is via the built binary
+(matches production), pointed at a test OID:
 
-- **Via the built binary** (matches production), using a sink/test OID, e.g.:
-  ```
-  go build ./containers/general
-  ./general myadapter \
-    client_options.identity.oid=$OID \
-    client_options.identity.installation_key=$INSTALLATION_KEY \
-    client_options.platform=json \
-    client_options.sensor_seed_key=myadapter \
-    api_key=$MYADAPTER_API_KEY
-  ```
-  Confirm a new sensor appears in the user's LimaCharlie org and events flow.
-- **Via a temporary integration test** gated on an env var being present (so CI
-  without the secret still passes by the var being absent — but do **not** make
-  this a permanent skipped test; remove it before the PR, its purpose is the
-  live capture, not CI). Capture the real request/response wire bytes while it
-  runs.
+```
+go build ./containers/general
+./general myadapter \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=json \
+  client_options.sensor_seed_key=myadapter \
+  <your-auth-config>=$CREDENTIAL ...
+```
 
-**Capture the real responses** during this run (log the raw bodies, or use a
-proxy). These captures are gold for Phase 5b.
+Confirm a new sensor appears in the user's LimaCharlie org and events flow.
+**Capture the real responses/messages** while it runs (log the raw payloads, or
+use a proxy) — these are gold for Phase 5b. If you write a throwaway integration
+test to do the capture, **remove it before the PR**; do not leave a skipped test
+behind.
 
 ### Phase 5b — Validate the mock against reality
 
-With real responses in hand, **diff them against your mock**:
+With real data in hand, **diff it against your mock**:
 
-- Does the real **pagination** behave as the mock assumes (page sizes, the
-  end-of-data signal, cursor/`has_more`)? Fix the mock if not.
-- Is the **envelope** key and shape exactly what the mock returns?
-- Do the **id** and **timestamp** field paths/formats match? Are timestamps in
-  the format your parser handles?
-- Do the **fixtures** contain the field types the real data has (numbers that
-  are big integers, nullable fields, nested arrays)?
-- Does **auth** rejection use the status code your mock returns?
+- Does the real **pagination / batching** match what the mock assumes (sizes,
+  the end-of-data signal, cursor/`has_more`)?
+- Is the **envelope / result shape** exactly what the mock returns?
+- Do the **id** and **timestamp** field paths/formats match? Are timestamps in a
+  format your parser handles?
+- Do the **fixtures** carry the field types the real data has (big integers,
+  nullable fields, nested arrays)?
+- Does **auth** rejection behave as the mock simulates?
 
-Update the mock and fixtures so they mirror the captured reality. The goal: the
-mock-backed tests would have caught any wire-shape mistake, so future
-maintainers can evolve the adapter confidently **without** live credentials.
-Then re-run Phase 4 and confirm everything still passes.
+Update the mock and fixtures to mirror captured reality, so the tests would have
+caught any shape mistake and future maintainers can evolve the adapter
+confidently **without** live credentials. Re-run Phase 4.
 
 If the user has **no** credentials, say so plainly, make the mock as faithful as
 possible from the documented shapes (Phase 1), and note in the PR that it hasn't
@@ -216,46 +186,47 @@ been live-verified.
 
 ## Phase 6 — Document and open a draft PR
 
-Write `myadapter/README.md` (model it on `threatlocker/README.md`):
-- One-line description + link to the vendor and **the API docs** (the URLs from
-  Phase 1).
-- **Authentication**: how to obtain the credential, what header it maps to.
+Write `myadapter/README.md` (model on `threatlocker/README.md`):
+- One-line description + links to the vendor and **the API/SDK docs** (Phase 1).
+- **Authentication**: how to obtain the credential and how it's supplied.
 - **Configuration table**: every config key, required?, description, defaults.
-- **What the data looks like**: which events are collected, the event types, and
-  a sample payload.
-- **How polling/pagination/dedup works** and any operational caveats (rate
-  limits, required filters, instance selection, etc.).
+- **What the data looks like**: which events are collected, the event types, a
+  sample payload.
+- **How it works** (polling/streaming, pagination/batching, dedup) and
+  operational caveats (rate limits, required filters, region/instance, etc.).
 - CLI and YAML run examples.
 
-Also add the short root-`README.md` entry (Phase 2) and ensure the example there
-matches.
+Add the short root-`README.md` entry too and make sure the example matches.
 
 Then open the PR **as a draft**:
 
 ```
 git checkout -b add-myadapter-adapter
 git add myadapter/ containers/conf/all.go containers/general/tool.go README.md
-git commit -m "Add MyAdapter adapter (<one-line of what it ingests>)"   # see commit trailer rule
+git commit -m "Add MyAdapter adapter (<one-line of what it ingests>)"   # honor the repo commit-trailer rule
 git push -u origin add-myadapter-adapter
 gh pr create --draft --title "Add MyAdapter adapter" --body "<summary>"
 ```
 
-PR body should cover: what the adapter ingests, the API docs link, auth method,
-the event types/sample data, how it was tested (mock coverage + whether it was
-live-verified), and any follow-ups. Be careful to stage **only** your adapter's
-files — don't sweep in unrelated working-tree changes.
+PR body: what it ingests, API/SDK docs link, auth method, event types/sample
+data, how it was tested (mock coverage + whether live-verified), follow-ups. Be
+careful to stage **only** your adapter's files — don't sweep in unrelated
+working-tree changes.
 
 ## Checklist
 
-- [ ] API researched from real docs; auth, pagination, envelope, id+timestamp
-      fields, sample payload recorded.
-- [ ] `api.go` / `client.go` follow the `threatlocker` patterns (sink seam,
-      `utils` deduper/event, verbatim payloads, retry + auth-stop).
+- [ ] Source researched from real docs; auth, how-events-arrive, pagination/
+      batching, id+timestamp fields, sample payload recorded.
+- [ ] Closest existing adapter identified and copied; universal contract honored
+      (embeds `ClientOptions`, `New…/Close`, ships verbatim `DataMessage`s).
+- [ ] Patterns copied where applicable: test seam, lifecycle, dedup, transient/
+      auth handling, JSON fidelity, backpressure.
 - [ ] Registered in `containers/conf/all.go` and `containers/general/tool.go`;
       `go build ./containers/general` passes.
-- [ ] Mock reproduces real auth + pagination + envelope; realistic fixtures.
-- [ ] End-to-end + unit tests pass, fully enabled (`go test ./myadapter/...`).
-- [ ] Live-tested if creds available; mock validated against captured responses.
-- [ ] `myadapter/README.md` + root README entry written with API doc links and
+- [ ] Mock/fake reproduces the real source (auth, pagination/batching, shape);
+      realistic fixtures.
+- [ ] Tests pass, fully enabled (`go test ./myadapter/...`).
+- [ ] Live-tested if creds available; mock validated against captured data.
+- [ ] `myadapter/README.md` + root README entry written with doc links and
       sample data.
 - [ ] Draft PR opened with only the adapter's files staged.

--- a/.claude/skills/create-adapter/references/patterns.md
+++ b/.claude/skills/create-adapter/references/patterns.md
@@ -1,66 +1,99 @@
-# Adapter patterns — a reading guide
+# Adapter patterns — copy from an existing adapter
 
-Don't copy snippets from this file — **read the real code** and imitate it. The
-code in the repo is the source of truth and stays current; this file just tells
-you which symbols to study and why. `threatlocker/` is the canonical
-polling-HTTP-API adapter; open these files and find the named symbols.
+Don't work from snippets — **find the existing adapter closest to your source
+and copy its patterns.** The code in the repo is the source of truth and stays
+current. Adapters pull from very different places (raw HTTP, vendor SDKs,
+sockets, files, mailboxes), so there is no single template — but they all expose
+the **same contract** to the rest of the system.
 
-Replace `ThreatLocker`/`threatlocker` with your names; the Go package is
-`usp_myadapter`.
+## The universal contract (every adapter)
 
-## `threatlocker/api.go` — transport
+Whatever the source, an adapter:
 
-| Symbol | What to learn / copy |
-|---|---|
-| `HTTPError` | Carry `StatusCode`/`URL`/`Body` so callers classify retry-vs-give-up without parsing strings. |
-| `isTransientError` | The retry policy: retry 5xx, 429, and pre-response network errors; do **not** retry other 4xx or context cancellation. |
-| `ThreatLockerClient` + `NewThreatLockerClient` | A thin client holding `baseURL`, the credential, and an `http.Client` with sane timeouts/dialer. |
-| `Post` (the request helper) | One generic helper: set the **exact** auth header(s) the real API needs, read the body, turn non-2xx into `*HTTPError`. Adapt to GET/query params if your API uses them. |
-| `Close` | `CloseIdleConnections()`. |
+- Lives in its own package `usp_myadapter` under `myadapter/` (usually just
+  `client.go`; the well-tested ones add `*_test.go` and sometimes split out an
+  `api.go`).
+- Defines a config struct that **embeds `uspclient.ClientOptions`** as
+  `client_options` (json+yaml tags on every field) and usually a `Validate()`
+  that fills defaults.
+- Exposes `func NewMyAdapter(ctx context.Context, conf MyAdapterConfig)
+  (*MyAdapter, chan struct{}, error)` and a `Close() error`. The returned
+  `chan struct{}` is closed when the adapter stops on its own.
+- Reads from the source however that source works, and **ships each event
+  verbatim** as a `protocol.DataMessage{JsonPayload, EventType, TimestampMs}`
+  through the usp client (`Ship` → `Drain`/`Close` on shutdown). LimaCharlie
+  does parsing/field-mapping in the cloud — don't reshape payloads.
 
-## `threatlocker/client.go` — config + adapter
+Open any two adapters and you'll see this contract; everything else is
+source-specific.
 
-| Symbol | What to learn / copy |
-|---|---|
-| `ThreatLockerConfig` | Embed `uspclient.ClientOptions` as `client_options`; `json`+`yaml` tags on every field; a `Deduper utils.Deduper` field tagged `json:"-"` as a test/embedder seam. |
-| `ThreatLockerConfig.Validate` | Call `c.ClientOptions.Validate()` first, check required fields, then fill every default. This is where defaults live. |
-| `uspSink` interface | The seam that makes credential-free E2E tests possible: the subset of `*uspclient.Client` the adapter uses (`Ship`/`Drain`/`Close`). `*uspclient.Client` satisfies it; tests inject an in-memory sink. |
-| `NewThreatLockerAdapter` vs `newThreatLockerAdapter` | Exported constructor delegates to an unexported one taking a `sink`; `nil` sink ⇒ build a real `uspclient.NewClient`. Note how an owned deduper is created with `utils.NewLocalDeduper` and cleaned up on error. |
-| `Close` | Idempotent via `sync.Once`: `doStop.Set()`, `wgSenders.Wait()`, `Drain`, `Close`, release the deduper. |
-| `runFeed` / `pollFeed` | The poll loop. First poll fires immediately, then `doStop.WaitFor(interval)`. **Read the long comment on `pollFeed`** explaining why every page is re-walked each poll and why dedup (not an early exit) is what ships each record once. |
-| `fetchPage` | Exponential backoff bounded by `MaxRetryAttempts`; **401/403 stops the whole adapter**, other permanent errors abandon just this poll. |
-| `ship` | Build `protocol.DataMessage{JsonPayload, EventType, TimestampMs}`, ship **verbatim**, handle `uspclient.ErrorBufferFull` (backpressure) by re-shipping with a long timeout. |
-| `eventTime` | Extract the record's timestamp into UnixMilli; fall back to `time.Now()` when absent/unparseable (and `DebugLog` it). |
-| `recordID` / `dedupeKey` | Resolve a stable id (configured field → common id fields → content hash); namespace the dedupe key per feed/type. |
-| `extractItems` / `rawMessagesToDicts` | Handle bare-array vs object-envelope responses; decode each record with `utils.UnmarshalCleanJSON` (preserves integer precision — don't `json.Unmarshal` into `map[string]interface{}`, it coerces ints to float64). |
+## Pick the closest example, then copy it
 
-`utils.Dict` helpers worth knowing: `FindOneString("a/b")` (first string at a
-`/`-path), `FindInt("path")` (all int matches — use to detect a present `0`).
+| Your source is… | Read & copy | Notes |
+|---|---|---|
+| **HTTP API you poll** (REST, paginated) | `threatlocker/`, `1password/`, `gmail/` | The most thorough examples. `threatlocker/` has a clean `api.go`/`client.go` split, dedup, retries, and a full mock-backed test suite. `1password/` shows cursor/`has_more` paging. |
+| **A vendor SDK / cloud client** | `s3/` (AWS SDK), `sqs/` (AWS SDK), `pubsub/` + `gcs/` + `bigquery/` (GCP SDK), `azure_event_hub/` (Azure SDK) | No hand-rolled HTTP — you drive the SDK. Copy how it constructs the SDK client from config credentials and pumps results into `Ship`. |
+| **A streaming socket / push** | `syslog/`, `azure_event_hub/` | Long-lived connection, events arrive continuously rather than by polling. |
+| **A mailbox** | `imap/`, `gmail/` | IMAP library vs. Gmail REST. |
+| **Local files / OS sources** | `file/`, `evtx/`, `wel/`, `mac_unified_logging/`, `stdin/` | Tail a file, read Windows event logs, read stdin. |
+| **Another HTTP vendor (auth variety)** | `okta/`, `sophos/`, `defender/`, `mimecast/`, `wiz/` | More auth/pagination variations to mine. |
 
-## `threatlocker/mock_test.go` — the credential-free E2E harness
+Grep the chosen adapter end to end and replicate its structure for yours. If two
+examples are close, read both.
 
-| Symbol | What to learn / copy |
-|---|---|
-| `captureSink` | The in-memory `uspSink` that records shipped messages; `count`/`snapshot` for assertions. |
-| `mockThreatLocker` + `handler` | An `httptest` handler that **reproduces the real API**: checks the auth header, paginates over an in-memory dataset the same way the real API does, and can return a bare array or an object envelope. |
-| `realisticApprovalRequest` / `realisticActionLog` | Fixtures shaped like **real** payloads — nested objects, arrays, mixed scalar types, real id/timestamp field names. Build yours from a real sanitized sample. |
-| `TestMock*` tests | The coverage to mirror: all-records-ship + verbatim payload/timestamp, no re-ship on re-poll, mid-run record ships once, multi-page walk, multiple feeds tagged, bad token stops + ships nothing. |
+## What the well-tested adapters do (worth imitating regardless of source)
 
-`threatlocker/client_test.go` → `testClientOptions(t)` shows the `ClientOptions`
-to use in tests (note `TestSinkMode: true` and the log callbacks).
+These come from `threatlocker/` and `gmail/`, the strongest test exemplars:
 
-## When your API differs from ThreatLocker
+- **Config + `Validate()`** — embed `ClientOptions`, validate it first, then fill
+  every default. (`ThreatLockerConfig` / `ThreatLockerConfig.Validate`.)
+- **A test seam for the external dependency.** `threatlocker` defines a small
+  `uspSink` interface (the subset of `*uspclient.Client` it uses) and an
+  unexported `newThreatLockerAdapter(ctx, conf, sink)` so tests inject an
+  in-memory sink instead of a real LimaCharlie connection. The *same idea*
+  generalizes to any source: put the external client behind a small interface so
+  a fake can stand in. For HTTP that fake is an `httptest` server; for an SDK it's
+  a fake implementing the interface you call.
+- **Lifecycle** — `utils.NewEvent()` stop signal, a `sync.WaitGroup` for
+  goroutines, a `chStopped` closed when they exit, a `sync.Once`-guarded
+  idempotent `Close()` that drains and closes the usp client and the source
+  client. (`ThreatLockerAdapter` / its `Close`/`runFeed`.)
+- **Exactly-once shipping** — when a source re-delivers (re-polled pages,
+  at-least-once queues), dedup with `utils.NewLocalDeduper` keyed by a stable
+  record id (configured field → common fields → content hash). See
+  `recordID`/`dedupeKey`, and the long comment on `pollFeed` explaining why it
+  re-walks pages rather than stopping early.
+- **Robust transport (HTTP case)** — `HTTPError{StatusCode,...}`,
+  `isTransientError` (retry 5xx/429/network; not other 4xx or ctx-cancel),
+  exponential backoff, and **stop the adapter on 401/403**. (`threatlocker/api.go`.)
+- **JSON fidelity** — decode records with `utils.UnmarshalCleanJSON` (preserves
+  integer precision) into `utils.Dict`; extract fields with `FindOneString` /
+  `FindInt`.
+- **Backpressure** — on `uspclient.ErrorBufferFull`, re-`Ship` with a long
+  timeout. (`ThreatLockerAdapter.ship`.)
 
-ThreatLocker paginates by page-number and ends on a short page. If yours uses a
-cursor/`next` token or a `has_more` flag, study **`1password/`** instead (see
-commit `1fda4a3`, "drain pages using has_more"), and make your mock use the same
-mechanism. For OAuth-refresh auth see **`gmail/`**; for non-polling sources
-(streams/queues/webhooks) see `sqs/`, `pubsub/`, `azure_event_hub/`, `syslog/`.
+## Testing the mock / fake (see `threatlocker/mock_test.go`, `gmail/mock_test.go`)
+
+The point of the test seam is end-to-end tests **without live credentials**:
+
+- `captureSink` — an in-memory `uspSink` recording shipped messages to assert on.
+- `mockThreatLocker` + `handler` — an `httptest` server that **reproduces the
+  real API**: checks auth, paginates over an in-memory dataset the way the real
+  API does, returns the real envelope shape. For an SDK-based adapter, the
+  equivalent is a fake implementing the interface your adapter calls.
+- Realistic fixtures (`realisticApprovalRequest`) shaped like real payloads —
+  nested objects, arrays, mixed scalar types, real id/timestamp fields.
+- Tests to mirror: all records ship (verbatim payload + parsed timestamp + event
+  type), re-poll doesn't re-ship, a mid-run record ships once, multi-page is
+  fully walked, multiple types tagged correctly, bad auth stops + ships nothing.
+
+`testClientOptions(t)` in `threatlocker/client_test.go` shows the test
+`ClientOptions` to use (`TestSinkMode: true` + log callbacks).
 
 ## Non-negotiables
 
-- **Ship payloads verbatim** — LimaCharlie parses/maps fields in the cloud.
-- **Auth failure (401/403) stops the adapter**; transient errors retry.
-- **Dedup ships each record exactly once** even though pages re-fetch each poll.
-- **The mock mirrors the real wire shape** (auth, pagination, envelope, field
-  names/formats) so tests stay meaningful without live credentials.
+- Ship payloads **verbatim**.
+- **Auth failure stops the adapter**; transient errors retry.
+- If the source can re-deliver, **dedup so each event ships once**.
+- The **mock/fake mirrors the real source shape** so tests stay meaningful
+  without live credentials.

--- a/.claude/skills/create-adapter/references/patterns.md
+++ b/.claude/skills/create-adapter/references/patterns.md
@@ -1,0 +1,245 @@
+# Annotated adapter patterns
+
+Annotated, copy-ready snippets distilled from `threatlocker/`. Read the real
+files (`threatlocker/api.go`, `threatlocker/client.go`,
+`threatlocker/mock_test.go`) alongside this — they are the source of truth; this
+is a map. Replace `MyAdapter`/`myadapter` with your names.
+
+## Package + imports
+
+```go
+// Package usp_myadapter implements a USP adapter for the MyVendor API.
+package usp_myadapter
+
+import (
+    "context"
+    "sync"
+    "time"
+
+    "github.com/refractionPOINT/go-uspclient"
+    "github.com/refractionPOINT/go-uspclient/protocol"
+    "github.com/refractionPOINT/usp-adapters/utils"
+)
+```
+
+## api.go — transport
+
+```go
+// HTTPError carries the status code so callers can classify retry vs. give-up
+// without parsing error strings.
+type HTTPError struct {
+    StatusCode int
+    URL        string
+    Body       string
+}
+
+func (e *HTTPError) Error() string { /* include code, url, truncated body */ }
+
+// isTransientError: retry 5xx, 429, and pre-response network errors; do NOT
+// retry other 4xx (bad request/auth/not-found) or context cancellation.
+func isTransientError(err error) bool { /* see threatlocker/api.go */ }
+
+type MyAdapterClient struct {
+    baseURL    string
+    apiKey     string
+    httpClient *http.Client
+}
+
+func NewMyAdapterClient(baseURL, apiKey string) *MyAdapterClient {
+    return &MyAdapterClient{
+        baseURL: strings.TrimRight(baseURL, "/"),
+        apiKey:  apiKey,
+        httpClient: &http.Client{
+            Timeout:   60 * time.Second,
+            Transport: &http.Transport{Dial: (&net.Dialer{Timeout: 10 * time.Second}).Dial},
+        },
+    }
+}
+
+// One generic request helper. Sets the auth header(s) the real API requires,
+// returns the raw body, and turns non-2xx into *HTTPError.
+func (c *MyAdapterClient) Get(ctx context.Context, path string, query url.Values) ([]byte, error) {
+    // req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+    // req.Header.Set("Authorization", "Bearer "+c.apiKey)   // <-- match real API exactly
+    // resp, err := c.httpClient.Do(req) ...
+    // if resp.StatusCode != 200 { return nil, &HTTPError{...} }
+}
+
+func (c *MyAdapterClient) Close() { c.httpClient.CloseIdleConnections() }
+```
+
+## client.go — config + Validate
+
+```go
+type MyAdapterConfig struct {
+    ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+    APIKey  string `json:"api_key" yaml:"api_key"`
+    BaseURL string `json:"base_url" yaml:"base_url"`
+
+    PageSize     int           `json:"page_size" yaml:"page_size"`
+    PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+    DedupeTTL    time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
+
+    // Deduper is a test/embedder seam; not settable from config files.
+    Deduper utils.Deduper `json:"-" yaml:"-"`
+}
+
+func (c *MyAdapterConfig) Validate() error {
+    if err := c.ClientOptions.Validate(); err != nil {
+        return fmt.Errorf("client_options: %v", err)
+    }
+    if c.APIKey == "" {
+        return errors.New("missing api_key")
+    }
+    if c.PageSize <= 0 { c.PageSize = defaultPageSize }
+    if c.PollInterval <= 0 { c.PollInterval = defaultPollInterval }
+    if c.DedupeTTL <= 0 { c.DedupeTTL = defaultDedupeTTL }
+    return nil
+}
+```
+
+## client.go — the sink seam (makes E2E tests possible)
+
+```go
+// uspSink is the subset of *uspclient.Client the adapter uses; *uspclient.Client
+// satisfies it unchanged, and tests inject an in-memory capture sink.
+type uspSink interface {
+    Ship(message *protocol.DataMessage, timeout time.Duration) error
+    Drain(timeout time.Duration) error
+    Close() ([]*protocol.DataMessage, error)
+}
+
+func NewMyAdapter(ctx context.Context, conf MyAdapterConfig) (*MyAdapter, chan struct{}, error) {
+    return newMyAdapter(ctx, conf, nil) // nil => build a real uspclient.NewClient
+}
+
+func newMyAdapter(ctx context.Context, conf MyAdapterConfig, sink uspSink) (*MyAdapter, chan struct{}, error) {
+    if err := conf.Validate(); err != nil { return nil, nil, err }
+
+    a := &MyAdapter{conf: conf, ctx: ctx, doStop: utils.NewEvent()}
+
+    a.deduper = conf.Deduper
+    if a.deduper == nil {
+        d, err := utils.NewLocalDeduper(dedupeBucketWindow, conf.DedupeTTL)
+        if err != nil { return nil, nil, err }
+        a.deduper = d
+        a.ownsDeduper = true
+    }
+
+    if sink != nil {
+        a.uspClient = sink
+    } else {
+        c, err := uspclient.NewClient(ctx, conf.ClientOptions)
+        if err != nil { /* close owned deduper */ return nil, nil, err }
+        a.uspClient = c
+    }
+
+    a.client = NewMyAdapterClient(conf.BaseURL, conf.APIKey)
+    a.chStopped = make(chan struct{})
+    a.wgSenders.Add(1)
+    go a.run()
+    go func() { a.wgSenders.Wait(); close(a.chStopped) }()
+    return a, a.chStopped, nil
+}
+```
+
+## client.go — lifecycle, poll loop, dedup, ship
+
+```go
+type MyAdapter struct {
+    conf        MyAdapterConfig
+    uspClient   uspSink
+    client      *MyAdapterClient
+    deduper     utils.Deduper
+    ownsDeduper bool
+
+    chStopped chan struct{}
+    wgSenders sync.WaitGroup
+    doStop    *utils.Event
+    closeOnce sync.Once
+    closeErr  error
+    ctx       context.Context
+}
+
+// Close is idempotent (sync.Once): stop, drain, close, release deduper.
+func (a *MyAdapter) Close() error {
+    a.closeOnce.Do(func() {
+        a.doStop.Set()
+        a.wgSenders.Wait()
+        err1 := a.uspClient.Drain(1 * time.Minute)
+        _, err2 := a.uspClient.Close()
+        a.client.Close()
+        if a.ownsDeduper { a.deduper.Close() }
+        if err1 != nil { a.closeErr = err1 } else { a.closeErr = err2 }
+    })
+    return a.closeErr
+}
+
+// run polls forever until asked to stop; first poll fires immediately.
+func (a *MyAdapter) run() {
+    defer a.wgSenders.Done()
+    first := true
+    for first || !a.doStop.WaitFor(a.conf.PollInterval) {
+        first = false
+        a.poll()
+    }
+}
+
+// poll walks ALL pages every time. Dedup — not an early exit — ships each
+// record once; the API paginates over a live list, so an early stop on
+// already-seen records could skip a record that shifted across a page boundary.
+func (a *MyAdapter) poll() {
+    for page := 1; !a.doStop.IsSet(); page++ {
+        items, ok := a.fetchPage(page) // retries transient errors; stops adapter on 401/403
+        if !ok { return }
+        if len(items) == 0 { break }
+        for _, item := range items {
+            if a.deduper.CheckAndAdd(a.dedupeKey(item)) { continue }
+            if !a.ship(item) { return }
+        }
+        if len(items) < a.conf.PageSize { break } // short page == end
+    }
+}
+
+// ship: verbatim payload, event type, event time. Handle backpressure.
+func (a *MyAdapter) ship(item utils.Dict) bool {
+    msg := &protocol.DataMessage{
+        JsonPayload: item,
+        EventType:   "myadapter_event",
+        TimestampMs: a.eventTime(item),
+    }
+    if err := a.uspClient.Ship(msg, shipTimeout); err != nil {
+        if err == uspclient.ErrorBufferFull {
+            a.conf.ClientOptions.OnWarning("myadapter: stream falling behind")
+            err = a.uspClient.Ship(msg, 1*time.Hour)
+        }
+        if err != nil {
+            a.conf.ClientOptions.OnError(fmt.Errorf("myadapter: Ship(): %v", err))
+            a.doStop.Set()
+            return false
+        }
+    }
+    return true
+}
+```
+
+## Field extraction helpers (from utils.Dict)
+
+- `item.FindOneString("path")` — first string at a `/`-separated path.
+- `item.FindInt("path")` — all int matches (use to detect a present `0`).
+- `utils.UnmarshalCleanJSON(string)` — decode a record preserving integer
+  precision (don't use a plain `json.Unmarshal` into `map[string]interface{}`,
+  which coerces ints to float64).
+
+## Things to get right
+
+- **Verbatim payloads.** Ship the vendor JSON unchanged; LimaCharlie does
+  parsing/field-mapping in the cloud. Don't rename or restructure fields.
+- **Auth failure stops the adapter** (401/403). Transient errors retry; other
+  permanent errors abandon just the current poll.
+- **Timestamps**: parse the vendor's format(s) into UnixMilli; fall back to
+  `time.Now()` when absent/unparseable (and DebugLog it).
+- **Pagination shape varies.** threatlocker uses page-number + short-page-end.
+  If your API uses a cursor/`next` token or a `has_more` flag (see `1password/`),
+  loop on that instead — and make the mock use the same mechanism.

--- a/.claude/skills/create-adapter/references/patterns.md
+++ b/.claude/skills/create-adapter/references/patterns.md
@@ -1,245 +1,66 @@
-# Annotated adapter patterns
+# Adapter patterns — a reading guide
 
-Annotated, copy-ready snippets distilled from `threatlocker/`. Read the real
-files (`threatlocker/api.go`, `threatlocker/client.go`,
-`threatlocker/mock_test.go`) alongside this — they are the source of truth; this
-is a map. Replace `MyAdapter`/`myadapter` with your names.
+Don't copy snippets from this file — **read the real code** and imitate it. The
+code in the repo is the source of truth and stays current; this file just tells
+you which symbols to study and why. `threatlocker/` is the canonical
+polling-HTTP-API adapter; open these files and find the named symbols.
 
-## Package + imports
+Replace `ThreatLocker`/`threatlocker` with your names; the Go package is
+`usp_myadapter`.
 
-```go
-// Package usp_myadapter implements a USP adapter for the MyVendor API.
-package usp_myadapter
+## `threatlocker/api.go` — transport
 
-import (
-    "context"
-    "sync"
-    "time"
+| Symbol | What to learn / copy |
+|---|---|
+| `HTTPError` | Carry `StatusCode`/`URL`/`Body` so callers classify retry-vs-give-up without parsing strings. |
+| `isTransientError` | The retry policy: retry 5xx, 429, and pre-response network errors; do **not** retry other 4xx or context cancellation. |
+| `ThreatLockerClient` + `NewThreatLockerClient` | A thin client holding `baseURL`, the credential, and an `http.Client` with sane timeouts/dialer. |
+| `Post` (the request helper) | One generic helper: set the **exact** auth header(s) the real API needs, read the body, turn non-2xx into `*HTTPError`. Adapt to GET/query params if your API uses them. |
+| `Close` | `CloseIdleConnections()`. |
 
-    "github.com/refractionPOINT/go-uspclient"
-    "github.com/refractionPOINT/go-uspclient/protocol"
-    "github.com/refractionPOINT/usp-adapters/utils"
-)
-```
+## `threatlocker/client.go` — config + adapter
 
-## api.go — transport
+| Symbol | What to learn / copy |
+|---|---|
+| `ThreatLockerConfig` | Embed `uspclient.ClientOptions` as `client_options`; `json`+`yaml` tags on every field; a `Deduper utils.Deduper` field tagged `json:"-"` as a test/embedder seam. |
+| `ThreatLockerConfig.Validate` | Call `c.ClientOptions.Validate()` first, check required fields, then fill every default. This is where defaults live. |
+| `uspSink` interface | The seam that makes credential-free E2E tests possible: the subset of `*uspclient.Client` the adapter uses (`Ship`/`Drain`/`Close`). `*uspclient.Client` satisfies it; tests inject an in-memory sink. |
+| `NewThreatLockerAdapter` vs `newThreatLockerAdapter` | Exported constructor delegates to an unexported one taking a `sink`; `nil` sink ⇒ build a real `uspclient.NewClient`. Note how an owned deduper is created with `utils.NewLocalDeduper` and cleaned up on error. |
+| `Close` | Idempotent via `sync.Once`: `doStop.Set()`, `wgSenders.Wait()`, `Drain`, `Close`, release the deduper. |
+| `runFeed` / `pollFeed` | The poll loop. First poll fires immediately, then `doStop.WaitFor(interval)`. **Read the long comment on `pollFeed`** explaining why every page is re-walked each poll and why dedup (not an early exit) is what ships each record once. |
+| `fetchPage` | Exponential backoff bounded by `MaxRetryAttempts`; **401/403 stops the whole adapter**, other permanent errors abandon just this poll. |
+| `ship` | Build `protocol.DataMessage{JsonPayload, EventType, TimestampMs}`, ship **verbatim**, handle `uspclient.ErrorBufferFull` (backpressure) by re-shipping with a long timeout. |
+| `eventTime` | Extract the record's timestamp into UnixMilli; fall back to `time.Now()` when absent/unparseable (and `DebugLog` it). |
+| `recordID` / `dedupeKey` | Resolve a stable id (configured field → common id fields → content hash); namespace the dedupe key per feed/type. |
+| `extractItems` / `rawMessagesToDicts` | Handle bare-array vs object-envelope responses; decode each record with `utils.UnmarshalCleanJSON` (preserves integer precision — don't `json.Unmarshal` into `map[string]interface{}`, it coerces ints to float64). |
 
-```go
-// HTTPError carries the status code so callers can classify retry vs. give-up
-// without parsing error strings.
-type HTTPError struct {
-    StatusCode int
-    URL        string
-    Body       string
-}
+`utils.Dict` helpers worth knowing: `FindOneString("a/b")` (first string at a
+`/`-path), `FindInt("path")` (all int matches — use to detect a present `0`).
 
-func (e *HTTPError) Error() string { /* include code, url, truncated body */ }
+## `threatlocker/mock_test.go` — the credential-free E2E harness
 
-// isTransientError: retry 5xx, 429, and pre-response network errors; do NOT
-// retry other 4xx (bad request/auth/not-found) or context cancellation.
-func isTransientError(err error) bool { /* see threatlocker/api.go */ }
+| Symbol | What to learn / copy |
+|---|---|
+| `captureSink` | The in-memory `uspSink` that records shipped messages; `count`/`snapshot` for assertions. |
+| `mockThreatLocker` + `handler` | An `httptest` handler that **reproduces the real API**: checks the auth header, paginates over an in-memory dataset the same way the real API does, and can return a bare array or an object envelope. |
+| `realisticApprovalRequest` / `realisticActionLog` | Fixtures shaped like **real** payloads — nested objects, arrays, mixed scalar types, real id/timestamp field names. Build yours from a real sanitized sample. |
+| `TestMock*` tests | The coverage to mirror: all-records-ship + verbatim payload/timestamp, no re-ship on re-poll, mid-run record ships once, multi-page walk, multiple feeds tagged, bad token stops + ships nothing. |
 
-type MyAdapterClient struct {
-    baseURL    string
-    apiKey     string
-    httpClient *http.Client
-}
+`threatlocker/client_test.go` → `testClientOptions(t)` shows the `ClientOptions`
+to use in tests (note `TestSinkMode: true` and the log callbacks).
 
-func NewMyAdapterClient(baseURL, apiKey string) *MyAdapterClient {
-    return &MyAdapterClient{
-        baseURL: strings.TrimRight(baseURL, "/"),
-        apiKey:  apiKey,
-        httpClient: &http.Client{
-            Timeout:   60 * time.Second,
-            Transport: &http.Transport{Dial: (&net.Dialer{Timeout: 10 * time.Second}).Dial},
-        },
-    }
-}
+## When your API differs from ThreatLocker
 
-// One generic request helper. Sets the auth header(s) the real API requires,
-// returns the raw body, and turns non-2xx into *HTTPError.
-func (c *MyAdapterClient) Get(ctx context.Context, path string, query url.Values) ([]byte, error) {
-    // req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-    // req.Header.Set("Authorization", "Bearer "+c.apiKey)   // <-- match real API exactly
-    // resp, err := c.httpClient.Do(req) ...
-    // if resp.StatusCode != 200 { return nil, &HTTPError{...} }
-}
+ThreatLocker paginates by page-number and ends on a short page. If yours uses a
+cursor/`next` token or a `has_more` flag, study **`1password/`** instead (see
+commit `1fda4a3`, "drain pages using has_more"), and make your mock use the same
+mechanism. For OAuth-refresh auth see **`gmail/`**; for non-polling sources
+(streams/queues/webhooks) see `sqs/`, `pubsub/`, `azure_event_hub/`, `syslog/`.
 
-func (c *MyAdapterClient) Close() { c.httpClient.CloseIdleConnections() }
-```
+## Non-negotiables
 
-## client.go — config + Validate
-
-```go
-type MyAdapterConfig struct {
-    ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
-
-    APIKey  string `json:"api_key" yaml:"api_key"`
-    BaseURL string `json:"base_url" yaml:"base_url"`
-
-    PageSize     int           `json:"page_size" yaml:"page_size"`
-    PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
-    DedupeTTL    time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
-
-    // Deduper is a test/embedder seam; not settable from config files.
-    Deduper utils.Deduper `json:"-" yaml:"-"`
-}
-
-func (c *MyAdapterConfig) Validate() error {
-    if err := c.ClientOptions.Validate(); err != nil {
-        return fmt.Errorf("client_options: %v", err)
-    }
-    if c.APIKey == "" {
-        return errors.New("missing api_key")
-    }
-    if c.PageSize <= 0 { c.PageSize = defaultPageSize }
-    if c.PollInterval <= 0 { c.PollInterval = defaultPollInterval }
-    if c.DedupeTTL <= 0 { c.DedupeTTL = defaultDedupeTTL }
-    return nil
-}
-```
-
-## client.go — the sink seam (makes E2E tests possible)
-
-```go
-// uspSink is the subset of *uspclient.Client the adapter uses; *uspclient.Client
-// satisfies it unchanged, and tests inject an in-memory capture sink.
-type uspSink interface {
-    Ship(message *protocol.DataMessage, timeout time.Duration) error
-    Drain(timeout time.Duration) error
-    Close() ([]*protocol.DataMessage, error)
-}
-
-func NewMyAdapter(ctx context.Context, conf MyAdapterConfig) (*MyAdapter, chan struct{}, error) {
-    return newMyAdapter(ctx, conf, nil) // nil => build a real uspclient.NewClient
-}
-
-func newMyAdapter(ctx context.Context, conf MyAdapterConfig, sink uspSink) (*MyAdapter, chan struct{}, error) {
-    if err := conf.Validate(); err != nil { return nil, nil, err }
-
-    a := &MyAdapter{conf: conf, ctx: ctx, doStop: utils.NewEvent()}
-
-    a.deduper = conf.Deduper
-    if a.deduper == nil {
-        d, err := utils.NewLocalDeduper(dedupeBucketWindow, conf.DedupeTTL)
-        if err != nil { return nil, nil, err }
-        a.deduper = d
-        a.ownsDeduper = true
-    }
-
-    if sink != nil {
-        a.uspClient = sink
-    } else {
-        c, err := uspclient.NewClient(ctx, conf.ClientOptions)
-        if err != nil { /* close owned deduper */ return nil, nil, err }
-        a.uspClient = c
-    }
-
-    a.client = NewMyAdapterClient(conf.BaseURL, conf.APIKey)
-    a.chStopped = make(chan struct{})
-    a.wgSenders.Add(1)
-    go a.run()
-    go func() { a.wgSenders.Wait(); close(a.chStopped) }()
-    return a, a.chStopped, nil
-}
-```
-
-## client.go — lifecycle, poll loop, dedup, ship
-
-```go
-type MyAdapter struct {
-    conf        MyAdapterConfig
-    uspClient   uspSink
-    client      *MyAdapterClient
-    deduper     utils.Deduper
-    ownsDeduper bool
-
-    chStopped chan struct{}
-    wgSenders sync.WaitGroup
-    doStop    *utils.Event
-    closeOnce sync.Once
-    closeErr  error
-    ctx       context.Context
-}
-
-// Close is idempotent (sync.Once): stop, drain, close, release deduper.
-func (a *MyAdapter) Close() error {
-    a.closeOnce.Do(func() {
-        a.doStop.Set()
-        a.wgSenders.Wait()
-        err1 := a.uspClient.Drain(1 * time.Minute)
-        _, err2 := a.uspClient.Close()
-        a.client.Close()
-        if a.ownsDeduper { a.deduper.Close() }
-        if err1 != nil { a.closeErr = err1 } else { a.closeErr = err2 }
-    })
-    return a.closeErr
-}
-
-// run polls forever until asked to stop; first poll fires immediately.
-func (a *MyAdapter) run() {
-    defer a.wgSenders.Done()
-    first := true
-    for first || !a.doStop.WaitFor(a.conf.PollInterval) {
-        first = false
-        a.poll()
-    }
-}
-
-// poll walks ALL pages every time. Dedup — not an early exit — ships each
-// record once; the API paginates over a live list, so an early stop on
-// already-seen records could skip a record that shifted across a page boundary.
-func (a *MyAdapter) poll() {
-    for page := 1; !a.doStop.IsSet(); page++ {
-        items, ok := a.fetchPage(page) // retries transient errors; stops adapter on 401/403
-        if !ok { return }
-        if len(items) == 0 { break }
-        for _, item := range items {
-            if a.deduper.CheckAndAdd(a.dedupeKey(item)) { continue }
-            if !a.ship(item) { return }
-        }
-        if len(items) < a.conf.PageSize { break } // short page == end
-    }
-}
-
-// ship: verbatim payload, event type, event time. Handle backpressure.
-func (a *MyAdapter) ship(item utils.Dict) bool {
-    msg := &protocol.DataMessage{
-        JsonPayload: item,
-        EventType:   "myadapter_event",
-        TimestampMs: a.eventTime(item),
-    }
-    if err := a.uspClient.Ship(msg, shipTimeout); err != nil {
-        if err == uspclient.ErrorBufferFull {
-            a.conf.ClientOptions.OnWarning("myadapter: stream falling behind")
-            err = a.uspClient.Ship(msg, 1*time.Hour)
-        }
-        if err != nil {
-            a.conf.ClientOptions.OnError(fmt.Errorf("myadapter: Ship(): %v", err))
-            a.doStop.Set()
-            return false
-        }
-    }
-    return true
-}
-```
-
-## Field extraction helpers (from utils.Dict)
-
-- `item.FindOneString("path")` — first string at a `/`-separated path.
-- `item.FindInt("path")` — all int matches (use to detect a present `0`).
-- `utils.UnmarshalCleanJSON(string)` — decode a record preserving integer
-  precision (don't use a plain `json.Unmarshal` into `map[string]interface{}`,
-  which coerces ints to float64).
-
-## Things to get right
-
-- **Verbatim payloads.** Ship the vendor JSON unchanged; LimaCharlie does
-  parsing/field-mapping in the cloud. Don't rename or restructure fields.
-- **Auth failure stops the adapter** (401/403). Transient errors retry; other
-  permanent errors abandon just the current poll.
-- **Timestamps**: parse the vendor's format(s) into UnixMilli; fall back to
-  `time.Now()` when absent/unparseable (and DebugLog it).
-- **Pagination shape varies.** threatlocker uses page-number + short-page-end.
-  If your API uses a cursor/`next` token or a `has_more` flag (see `1password/`),
-  loop on that instead — and make the mock use the same mechanism.
+- **Ship payloads verbatim** — LimaCharlie parses/maps fields in the cloud.
+- **Auth failure (401/403) stops the adapter**; transient errors retry.
+- **Dedup ships each record exactly once** even though pages re-fetch each poll.
+- **The mock mirrors the real wire shape** (auth, pagination, envelope, field
+  names/formats) so tests stay meaningful without live credentials.

--- a/.claude/skills/create-adapter/references/registration.md
+++ b/.claude/skills/create-adapter/references/registration.md
@@ -1,0 +1,68 @@
+# Registering a new adapter
+
+After the `myadapter/` package compiles, wire it into the general container so
+`./general myadapter ...` runs it. Three files, plus the root README.
+
+## 1. `containers/conf/all.go`
+
+Add the import (keep the alphabetical-ish grouping with the others):
+
+```go
+import (
+    // ...
+    usp_myadapter "github.com/refractionPOINT/usp-adapters/myadapter"
+    // ...
+)
+```
+
+Add a field to the `GeneralConfigs` struct. The `json`/`yaml` tag is the
+adapter's CLI/config name:
+
+```go
+type GeneralConfigs struct {
+    // ...
+    ThreatLocker usp_threatlocker.ThreatLockerConfig `json:"threatlocker" yaml:"threatlocker"`
+    MyAdapter    usp_myadapter.MyAdapterConfig       `json:"myadapter" yaml:"myadapter"`
+    // ...
+}
+```
+
+## 2. `containers/general/tool.go`
+
+Add the import:
+
+```go
+"github.com/refractionPOINT/usp-adapters/myadapter"
+```
+
+Add a dispatch branch in `runAdapter` (the `else if` chain ending in `unknown
+adapter_type`). Match the existing branches exactly:
+
+```go
+} else if method == "myadapter" {
+    configs.MyAdapter.ClientOptions = applyLogging(configs.MyAdapter.ClientOptions)
+    configs.MyAdapter.ClientOptions.Architecture = "usp_adapter"
+    configToShow = configs.MyAdapter
+    client, chRunning, err = usp_myadapter.NewMyAdapter(ctx, configs.MyAdapter)
+}
+```
+
+(Use whatever package alias the import resolves to — `threatlocker`'s package is
+`usp_threatlocker`, so its branch calls `usp_threatlocker.NewThreatLockerAdapter`.
+Name your package `usp_myadapter` and the call is `usp_myadapter.NewMyAdapter`.)
+
+## 3. Root `README.md`
+
+Add a short section under "## Examples" describing the adapter and a run line,
+mirroring the ThreatLocker/Gmail entries. Link to `myadapter/README.md` for the
+full config reference.
+
+## 4. Build to verify
+
+```
+go fmt ./myadapter/...
+go build ./containers/general
+```
+
+The config field shows up automatically in `./general` (no args) usage output
+because `printUsage` reflects over `Configuration` / `GeneralConfigs`.

--- a/.claude/skills/create-adapter/references/registration.md
+++ b/.claude/skills/create-adapter/references/registration.md
@@ -1,61 +1,35 @@
 # Registering a new adapter
 
 After the `myadapter/` package compiles, wire it into the general container so
-`./general myadapter ...` runs it. Three files, plus the root README.
+`./general myadapter ...` runs it. The cleanest way is to **copy how an existing
+adapter is wired** — grep for `threatlocker` (or `gmail`) across these files and
+replicate every hit for your adapter. Four touch points:
 
 ## 1. `containers/conf/all.go`
 
-Add the import (keep the alphabetical-ish grouping with the others):
-
-```go
-import (
-    // ...
-    usp_myadapter "github.com/refractionPOINT/usp-adapters/myadapter"
-    // ...
-)
-```
-
-Add a field to the `GeneralConfigs` struct. The `json`/`yaml` tag is the
-adapter's CLI/config name:
-
-```go
-type GeneralConfigs struct {
-    // ...
-    ThreatLocker usp_threatlocker.ThreatLockerConfig `json:"threatlocker" yaml:"threatlocker"`
-    MyAdapter    usp_myadapter.MyAdapterConfig       `json:"myadapter" yaml:"myadapter"`
-    // ...
-}
-```
+- Add the package import alongside the others (`usp_myadapter "…/myadapter"` —
+  match the alias style the file already uses).
+- Add a field to the `GeneralConfigs` struct. The `json`/`yaml` tag **is** the
+  adapter's CLI/config name. Find the `ThreatLocker` field there and add an
+  analogous `MyAdapter usp_myadapter.MyAdapterConfig` line.
 
 ## 2. `containers/general/tool.go`
 
-Add the import:
+- Add the package import.
+- In `runAdapter` (the `else if method == …` chain that ends in
+  `unknown adapter_type`), copy the `else if method == "threatlocker"` branch
+  and adapt it: `applyLogging`, set `Architecture = "usp_adapter"`, set
+  `configToShow`, then call your `usp_myadapter.NewMyAdapter(ctx, …)`.
 
-```go
-"github.com/refractionPOINT/usp-adapters/myadapter"
-```
-
-Add a dispatch branch in `runAdapter` (the `else if` chain ending in `unknown
-adapter_type`). Match the existing branches exactly:
-
-```go
-} else if method == "myadapter" {
-    configs.MyAdapter.ClientOptions = applyLogging(configs.MyAdapter.ClientOptions)
-    configs.MyAdapter.ClientOptions.Architecture = "usp_adapter"
-    configToShow = configs.MyAdapter
-    client, chRunning, err = usp_myadapter.NewMyAdapter(ctx, configs.MyAdapter)
-}
-```
-
-(Use whatever package alias the import resolves to — `threatlocker`'s package is
-`usp_threatlocker`, so its branch calls `usp_threatlocker.NewThreatLockerAdapter`.
-Name your package `usp_myadapter` and the call is `usp_myadapter.NewMyAdapter`.)
+Read the real `threatlocker` branch in `tool.go` and the real `ThreatLocker`
+field in `all.go` rather than working from memory — that way you match the
+current conventions exactly (package alias, field ordering, tags).
 
 ## 3. Root `README.md`
 
 Add a short section under "## Examples" describing the adapter and a run line,
-mirroring the ThreatLocker/Gmail entries. Link to `myadapter/README.md` for the
-full config reference.
+mirroring the existing **ThreatLocker** / **Gmail** entries. Link to
+`myadapter/README.md` for the full config reference.
 
 ## 4. Build to verify
 
@@ -64,5 +38,5 @@ go fmt ./myadapter/...
 go build ./containers/general
 ```
 
-The config field shows up automatically in `./general` (no args) usage output
-because `printUsage` reflects over `Configuration` / `GeneralConfigs`.
+The config field shows up automatically in `./general` (no args) usage output —
+`printUsage` reflects over `Configuration` / `GeneralConfigs`.


### PR DESCRIPTION
## What

Adds a project-level Claude Code skill at `.claude/skills/create-adapter/` that guides a contributor (or Claude) through building a brand-new USP adapter end to end.

## Why

We get recurring requests to support new data sources, and the steps are tribal knowledge today (the root README's "Building a New Adapter Type" is a 7-line stub). This skill encodes the full, repeatable workflow and points at `threatlocker/` as the canonical example to imitate.

## What's in it

- **`SKILL.md`** — phased workflow:
  1. Scope the source/events/auth with the user (and ask up front whether they have credentials for live testing).
  2. Research the real vendor API (auth, pagination, response envelope, id + timestamp fields, sample payloads) — from docs, not memory.
  3. Implement following the existing patterns (file layout, config + `Validate`, the `uspSink` test seam, `utils` deduper/event, verbatim payloads, retry + auth-stop).
  4. Write a mock that faithfully reproduces the real API shape, plus thorough end-to-end + unit tests.
  5. Run tests (`go test`), fully enabled — no skips.
  6. Live-test with a real API key if available, then **validate the mock against captured responses** so it stays reliable without credentials.
  7. Document (`<adapter>/README.md` + root README entry with API doc links and sample data) and open a draft PR.
- **`references/patterns.md`** — annotated, copy-ready snippets distilled from `threatlocker/` (transport, config, sink seam, poll/dedup/ship lifecycle).
- **`references/registration.md`** — the exact edits to `containers/conf/all.go`, `containers/general/tool.go`, and the root README to wire the adapter in.

## Notes

- Docs/skill only — no code or behavior changes. Unrelated working-tree changes were deliberately left out of this branch.
- Opened as a draft for review of the guidance content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)