### PR TITLE
fix(sentinelone): default poll interval when launched via general runner

### DIFF
--- a/sentinelone/s1.go
+++ b/sentinelone/s1.go
@@ -121,6 +121,11 @@ func (c *SentinelOneConfig) Validate() error {
 }
 
 func NewSentinelOneAdapter(ctx context.Context, conf SentinelOneConfig) (*SentinelOneAdapter, chan struct{}, error) {
+	// Ensure defaults are set (these may not be set if Validate() wasn't called,
+	// e.g. when launched through the general adapter runner).
+	if conf.TimeBetweenRequests == 0 {
+		conf.TimeBetweenRequests = 1 * time.Minute
+	}
 	// Ensure retry defaults are set (these may not be set if Validate() wasn't called)
 	if conf.RetryBaseDelay == 0 {
 		conf.RetryBaseDelay = baseRetryDelay


### PR DESCRIPTION
## Problem

`SentinelOneConfig.Validate()` is what sets the **1-minute default** for `TimeBetweenRequests`. But the general adapter runner (`containers/general/tool.go`) constructs the adapter directly via `NewSentinelOneAdapter` **without calling `Validate()`**. That left `TimeBetweenRequests` at `0`, so the poll loop's `a.doStop.WaitFor(a.conf.TimeBetweenRequests)` returned immediately and the adapter polled the SentinelOne API in a **tight loop with no delay**.

Observed while live-testing the adapter against a real tenant: **~511 requests in ~39 seconds (~13 req/s)** across the three default endpoints (`/activities`, `/threats`, `/cloud-detection/alerts`) — which would quickly trip SentinelOne rate limiting (429s) in production.

## Fix

`NewSentinelOneAdapter` already backfills the retry-related defaults (`RetryBaseDelay`, `MaxRetryDelay`, `MaxRetryAttempts`) for exactly this reason — the comment there even says "these may not be set if Validate() wasn't called". This adds `TimeBetweenRequests` to that same block:

```go
if conf.TimeBetweenRequests == 0 {
    conf.TimeBetweenRequests = 1 * time.Minute
}
```

After the fix, the same live test dropped from ~511 requests to **8**, properly paced at the 1-minute interval.

## Testing

- `go build ./sentinelone/` passes.
- Verified end-to-end against a live tenant: the adapter authenticates, fetches events, ships them, and the LimaCharlie cloud acks + drains cleanly — now at the correct 1-minute cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)