### PR TITLE
docs(cato,gmail): recommend dedicated platforms instead of json

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,5 +144,15 @@ auto-discovery of the whole domain — each mailbox shipped to its own sensor. S
 [gmail/README.md](./gmail/README.md).
 
 ```
-./general gmail client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=gmail client_id=$GMAIL_CLIENT_ID client_secret=$GMAIL_CLIENT_SECRET refresh_token=$GMAIL_REFRESH_TOKEN
+./general gmail client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=gmail client_options.sensor_seed_key=gmail client_id=$GMAIL_CLIENT_ID client_secret=$GMAIL_CLIENT_SECRET refresh_token=$GMAIL_REFRESH_TOKEN
+```
+
+### Cato
+
+Pulls events from the Cato Networks API for a given account. It polls the event
+feed, using a marker to page through and resume from the last position across
+restarts.
+
+```
+./general cato client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=cato client_options.sensor_seed_key=cato apikey=$CATO_API_KEY accountid=$CATO_ACCOUNT_ID
 ```

--- a/gmail/README.md
+++ b/gmail/README.md
@@ -238,7 +238,7 @@ Refresh-token flow (single mailbox), via CLI:
 ./general gmail \
   client_options.identity.oid=$OID \
   client_options.identity.installation_key=$IK \
-  client_options.platform=json \
+  client_options.platform=gmail \
   client_options.sensor_seed_key=gmail \
   client_id=$GMAIL_CLIENT_ID \
   client_secret=$GMAIL_CLIENT_SECRET \
@@ -255,7 +255,7 @@ gmail:
     identity:
       oid: 11111111-1111-1111-1111-111111111111
       installation_key: e9a3bcdf-efa2-47ae-b6df-579a02f3a54d
-    platform: json
+    platform: gmail
     sensor_seed_key: gmail
   service_account_file: /secrets/gmail-collector.json
   subject: soc-mailbox@yourdomain.com
@@ -275,7 +275,7 @@ gmail:
     identity:
       oid: 11111111-1111-1111-1111-111111111111
       installation_key: e9a3bcdf-efa2-47ae-b6df-579a02f3a54d
-    platform: json
+    platform: gmail
     sensor_seed_key: gmail
   service_account_file: /secrets/gmail-collector.json
   subject: soc-mailbox@yourdomain.com
@@ -298,7 +298,7 @@ BEC flags and leave `collect_messages` unset/false:
 ./general gmail \
   client_options.identity.oid=$OID \
   client_options.identity.installation_key=$IK \
-  client_options.platform=json \
+  client_options.platform=gmail \
   client_options.sensor_seed_key=gmail \
   client_id=$GMAIL_CLIENT_ID \
   client_secret=$GMAIL_CLIENT_SECRET \


### PR DESCRIPTION
## What

Updates docs so the `cato` and `gmail` adapters are configured with their own dedicated platform identity instead of the generic `json` platform:

- **gmail/README.md** — all CLI and YAML examples now use `platform: gmail`
- **README.md** — gmail example uses `platform=gmail`
- **README.md** — adds a **Cato** section (previously undocumented) with `platform=cato`

## Why

The platform is a per-adapter **config value** (`client_options.platform`), not hard-coded in the adapter — it's required with no default. These adapters were documented to use `json`, which gives their events no distinct platform identity. With `cato`/`gmail` now registered as real platforms, tagging events accordingly makes them addressable in D&R / dataset identity rather than anonymous JSON.

## Compatibility

No behavior change for existing deployments — they keep sending whatever platform their config already specifies (`json`). They only pick up the new platform tag if/when an operator updates their config.

## Notes

- No dedicated parser exists in `legion_usp_proxy` for either platform yet, so events still parse via the generic JSON parser — same as `bitwarden` / `trend_micro` / `cortex_xdr` today. The platform change is about identity, not parsing.
- Out of scope but worth flagging: the **ThreatLocker** example in the root README still uses `platform=json` even though a dedicated `threatlocker` platform + parser exist — a separate cleanup if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)