### PR TITLE
Add CLAUDE.md with public-repo safety guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Repository guidelines
+
+This is a **public** repository. Keep that in mind for everything committed here.
+
+- Never commit API keys, URLs, IDs, domain names, or anything else that can identify a specific user. (Identifiers belonging to the vendors who provide the APIs we integrate with are fine.)
+- Never mention any private repos, APIs, accesses, Issues, or PRs to non-public repos in PR descriptions, commits, or comments.


### PR DESCRIPTION
Adds a `CLAUDE.md` to the repo root documenting two safety guidelines, since this is a public repository:

- Never commit API keys, URLs, IDs, domain names, or anything else that can identify a specific user (vendor-owned API identifiers are fine).
- Never mention private repos, APIs, accesses, Issues, or PRs to non-public repos in PR descriptions, commits, or comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)