### PR TITLE
Add ServiceNow adapter (audit + system logs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ journalctl -f -q | netcat 127.0.0.1 4444
 ./adapter stdin client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=text "client_options.mapping.parsing_re=(?P<date>... \d\d \d\d:\d\d:\d\d) (?P<host>.+) (?P<exe>.+?)\[(?P<pid>\d+)\]: (?P<msg>.*)" client_options.sensor_seed_key=testclient3 client_options.mapping.event_type_path=exe
 ```
 
+### ServiceNow
+
+Pulls audit and system logs from the ServiceNow REST Table API. By default it
+collects the `sys_audit` table (field-level change history); other tables like
+`syslog_transaction` (transaction log) and `sysevent` (login events) can be
+added purely through configuration. See [servicenow/README.md](./servicenow/README.md).
+
+```
+./general servicenow client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=servicenow instance=example username=$SERVICENOW_USERNAME password=$SERVICENOW_PASSWORD
+```
+
 ### ThreatLocker
 
 Pulls events from the ThreatLocker Portal API. By default it collects pending

--- a/containers/conf/all.go
+++ b/containers/conf/all.go
@@ -32,6 +32,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/pubsub"
 	"github.com/refractionPOINT/usp-adapters/s3"
 	"github.com/refractionPOINT/usp-adapters/sentinelone"
+	"github.com/refractionPOINT/usp-adapters/servicenow"
 	"github.com/refractionPOINT/usp-adapters/simulator"
 	"github.com/refractionPOINT/usp-adapters/slack"
 	"github.com/refractionPOINT/usp-adapters/sophos"
@@ -90,6 +91,7 @@ type GeneralConfigs struct {
 	Box               usp_box.BoxConfig                               `json:"box" yaml:"box"`
 	Sublime           usp_sublime.SublimeConfig                       `json:"sublime" yaml:"sublime"`
 	SentinelOne       usp_sentinelone.SentinelOneConfig               `json:"sentinel_one" yaml:"sentinel_one"`
+	ServiceNow        usp_servicenow.ServiceNowConfig                 `json:"servicenow" yaml:"servicenow"`
 	ThreatLocker      usp_threatlocker.ThreatLockerConfig             `json:"threatlocker" yaml:"threatlocker"`
 	TrendMicro        usp_trendmicro.TrendMicroConfig                 `json:"trendmicro" yaml:"trendmicro"`
 	Wiz               usp_wiz.WizConfig                               `json:"wiz" yaml:"wiz"`

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -46,6 +46,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/pubsub"
 	"github.com/refractionPOINT/usp-adapters/s3"
 	"github.com/refractionPOINT/usp-adapters/sentinelone"
+	"github.com/refractionPOINT/usp-adapters/servicenow"
 	"github.com/refractionPOINT/usp-adapters/simulator"
 	"github.com/refractionPOINT/usp-adapters/slack"
 	"github.com/refractionPOINT/usp-adapters/sophos"
@@ -499,6 +500,11 @@ func runAdapter(ctx context.Context, method string, configs Configuration, showC
 		configs.TrendMicro.ClientOptions.Architecture = "usp_adapter"
 		configToShow = configs.TrendMicro
 		client, chRunning, err = usp_trendmicro.NewTrendMicroAdapter(ctx, configs.TrendMicro)
+	} else if method == "servicenow" {
+		configs.ServiceNow.ClientOptions = applyLogging(configs.ServiceNow.ClientOptions)
+		configs.ServiceNow.ClientOptions.Architecture = "usp_adapter"
+		configToShow = configs.ServiceNow
+		client, chRunning, err = usp_servicenow.NewServiceNowAdapter(ctx, configs.ServiceNow)
 	} else if method == "threatlocker" {
 		configs.ThreatLocker.ClientOptions = applyLogging(configs.ThreatLocker.ClientOptions)
 		configs.ThreatLocker.ClientOptions.Architecture = "usp_adapter"

--- a/servicenow/README.md
+++ b/servicenow/README.md
@@ -39,9 +39,10 @@ integration account — work with your ServiceNow administrator.
 > correct either way, but an account that can read the whole table avoids
 > wasted requests and surprises.
 
-An authentication/authorization failure (HTTP 401/403) stops the adapter so a
-misconfiguration is surfaced loudly; 403 can mean either bad credentials or
-missing table ACLs.
+Rejected credentials (HTTP 401) stop the adapter so a misconfiguration is
+surfaced loudly. A per-table ACL denial (HTTP 403) is feed-local: the feed
+ships nothing and keeps retrying every `poll_interval` (so a live ACL fix is
+picked up), while other feeds keep collecting.
 
 ## Deployment Configurations
 
@@ -65,8 +66,9 @@ Adapter Type: `servicenow`
 | `password` | yes | Service-account password. |
 | `feeds` | no | List of tables to poll (see [Feed fields](#feed-fields)). Default: the `sys_audit` table. |
 | `page_size` | no | Records per page (`sysparm_limit`). Default `1000`, maximum `10000`. |
-| `poll_interval` | no | Wait between polls of a feed, as a Go duration in **nanoseconds**. Default `60000000000` (1 minute). |
+| `poll_interval` | no | Wait between polls of a feed, as a Go duration in **nanoseconds** (like every duration below). Default `60000000000` (1 minute). |
 | `backfill` | no | How far back the first poll reaches. Default 15 minutes. |
+| `checkpoint_lag` | no | How long the incremental checkpoint trails the clock, bounding how late a record may become visible in the Table API (slow transactions, node clock differences) without being missed. Default 5 minutes. |
 | `dedupe_ttl` | no | How long a record id is remembered to suppress re-shipping. Default 7 days. |
 | `retry_base_delay` / `max_retry_delay` / `max_retry_attempts` | no | Transient-failure retry tuning. |
 
@@ -112,18 +114,30 @@ Each record ships verbatim under an `EventType` matching the feed's `name`. A
 ## How polling works
 
 Each feed keeps a per-feed **checkpoint** on its timestamp column. Every poll
-queries `<timestamp_field> >= <checkpoint>` ordered oldest-first
-(`ORDERBY`), walking pages with `sysparm_offset`/`sysparm_limit` until the
-API stops advertising a `Link: rel="next"` header. The checkpoint then
-advances to the newest record processed:
+queries `<timestamp_field> >= <checkpoint>` ordered oldest-first with the id
+column as a tiebreaker (`ORDERBY<timestamp>^ORDERBY<id>` — timestamps have
+one-second granularity, and without a total order a record could slip through
+a page boundary between page fetches), walking pages with
+`sysparm_offset`/`sysparm_limit` until the API stops advertising a
+`Link: rel="next"` header. Then:
 
 - A poll that fails midway does **not** advance the checkpoint — the same
-  range is retried on the next interval, so failures never open a gap.
-- The checkpoint filter is inclusive (`>=`), so records at the boundary are
-  re-read; an in-memory deduper keyed on `sys_id` ships each record exactly
-  once.
-- A poll capped by `max_pages` still advances the checkpoint to the last
-  record processed, so the next poll picks up exactly where it left off.
+  range is retried on the next interval.
+- A completed poll advances the checkpoint to `now - checkpoint_lag`: the lag
+  leaves room for records that become visible in the API some time after
+  their timestamp (slow transactions, node clock differences). Records inside
+  the lag window are re-read on later polls; an in-memory deduper keyed on
+  `sys_id` keeps them from shipping twice.
+- A poll capped by `max_pages` advances the checkpoint only to the newest
+  record processed, so the next poll picks up exactly where it left off. If
+  more than `max_pages × page_size` records share a single timestamp the
+  checkpoint cannot advance at all and the adapter warns loudly — raise
+  `max_pages` or `page_size` if that ever happens.
+
+Delivery is **at-least-once**: the checkpoint and dedup state live in memory,
+so a restart re-reads (and the fresh deduper re-ships) up to `backfill` of
+recent history, and downtime longer than `backfill` leaves a gap — size
+`backfill` above your expected restart-to-recovery time.
 
 Transient API failures (HTTP 5xx, 429, network errors) are retried with
 exponential backoff, honoring a 429's `Retry-After` delay. ServiceNow

--- a/servicenow/README.md
+++ b/servicenow/README.md
@@ -1,0 +1,215 @@
+# ServiceNow Adapter
+
+Ingests ServiceNow audit and system logs into LimaCharlie by polling the
+[ServiceNow REST Table API](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_TableAPI.html)
+(`GET /api/now/v2/table/{tableName}`). Events are forwarded in their original
+ServiceNow JSON form — the adapter does not reshape payloads.
+
+ServiceNow keeps its audit telemetry in plain platform tables, so the adapter
+is **generic by design**: each *feed* is one table plus an optional
+[encoded query](https://www.servicenow.com/docs/r/zurich/platform-user-interface/c_EncodedQueryStrings.html)
+filter. Collecting another table is a configuration change, not a code change.
+
+By default the adapter collects **`sys_audit`** — ServiceNow's field-level
+change history (who changed what, with old and new values) for every audited
+table. Other security-relevant tables are easily added as feeds:
+
+| Table | What it carries | Caveat |
+| --- | --- | --- |
+| `sys_audit` | Field-level change history of audited records (the default feed). | Insert-only; no rotation. |
+| `syslog_transaction` | Every transaction against the instance (UI, REST, scheduled jobs) with user, URL and source IP. | **High volume.** Rotates away after ~8 weeks. |
+| `sysevent` | The event log/queue, including login activity (`login`, `login.failed`, `external.authentication.succeeded`/`failed`, ...). | Rotates after ~7 days; filter with `query`. |
+| `syslog` | System log (warnings/errors from instance processes). | Rotates after ~8 weeks. |
+| `sys_outbound_http_log` | Outbound REST/SOAP requests made by the instance. | |
+
+## Authentication
+
+The adapter authenticates with **HTTP Basic auth** (`username` / `password`).
+Use a dedicated service account.
+
+The account must satisfy the polled tables' ACLs. Out of the box, `sys_audit`
+is readable by the `admin` and `security_admin` roles
+([Exploring Auditing](https://www.servicenow.com/docs/r/zurich/platform-security/exploring-auditing.html));
+many deployments instead create a custom read-only role/ACL for the
+integration account — work with your ServiceNow administrator.
+
+> ⚠️ ServiceNow applies `sysparm_limit` **before** ACL evaluation, so an
+> account with partial read access silently receives partial pages. The
+> adapter follows the API's `Link: rel="next"` header (not page sizes) and is
+> correct either way, but an account that can read the whole table avoids
+> wasted requests and surprises.
+
+An authentication/authorization failure (HTTP 401/403) stops the adapter so a
+misconfiguration is surfaced loudly; 403 can mean either bad credentials or
+missing table ACLs.
+
+## Deployment Configurations
+
+All adapters support the same `client_options`:
+
+- `client_options.identity.oid`: the LimaCharlie Organization ID (OID).
+- `client_options.identity.installation_key`: the LimaCharlie Installation Key.
+- `client_options.platform`: the type of data ingested, use `json`.
+- `client_options.sensor_seed_key`: an arbitrary name for this adapter which
+  Sensor IDs (SID) are generated from.
+
+### Adapter-specific Options
+
+Adapter Type: `servicenow`
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `instance` | yes* | ServiceNow instance name; the adapter talks to `https://<instance>.service-now.com`. *Required unless `base_url` is set. |
+| `base_url` | no | Full instance root override, e.g. `https://example.service-now.com`. |
+| `username` | yes | Service-account user for HTTP Basic auth. |
+| `password` | yes | Service-account password. |
+| `feeds` | no | List of tables to poll (see [Feed fields](#feed-fields)). Default: the `sys_audit` table. |
+| `page_size` | no | Records per page (`sysparm_limit`). Default `1000`, maximum `10000`. |
+| `poll_interval` | no | Wait between polls of a feed, as a Go duration in **nanoseconds**. Default `60000000000` (1 minute). |
+| `backfill` | no | How far back the first poll reaches. Default 15 minutes. |
+| `dedupe_ttl` | no | How long a record id is remembered to suppress re-shipping. Default 7 days. |
+| `retry_base_delay` / `max_retry_delay` / `max_retry_attempts` | no | Transient-failure retry tuning. |
+
+### Feed fields
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `table` | yes | ServiceNow table to read, e.g. `sys_audit`, `syslog_transaction`, `sysevent`. |
+| `name` | no | Labels the feed and becomes the `EventType` of every shipped event. Defaults to `table`. Must be unique within `feeds`. |
+| `query` | no | ServiceNow encoded query ANDed in front of the adapter's incremental time filter, e.g. `tablename=incident` or `name=login`. Column names, operators and values are case-sensitive. |
+| `fields` | no | Comma-separated `sysparm_fields` restriction. Must include the feed's timestamp and id fields. |
+| `timestamp_field` | no | Event-time column used for the incremental checkpoint and the shipped event time. Default `sys_created_on`. |
+| `id_field` | no | Stable identifier used for deduplication. Default `sys_id`. |
+| `max_pages` | no | Caps pages fetched per poll. Default `100`. The cap loses nothing: the next poll resumes from the advanced checkpoint. |
+
+## What the data looks like
+
+Each record ships verbatim under an `EventType` matching the feed's `name`. A
+`sys_audit` record looks like:
+
+```json
+{
+  "sys_id": "b1c3d2e4f5a601001a2b3c4d5e6f7a8b",
+  "tablename": "incident",
+  "fieldname": "assigned_to",
+  "documentkey": "9d385017c611228701d22104cc95c371",
+  "user": "jane.doe",
+  "oldvalue": "46d44a5dc0a8010e0000c8b06e0b1971",
+  "newvalue": "5137153cc611227c000bbd1bd8cd2007",
+  "reason": "",
+  "record_checkpoint": "7",
+  "internal_checkpoint": "",
+  "sys_created_on": "2026-06-11 09:14:33",
+  "sys_created_by": "jane.doe"
+}
+```
+
+`sys_created_on` is the database value, always **UTC**, in
+`yyyy-MM-dd HH:mm:ss` form — the adapter requests
+`sysparm_display_value=false` so values are locale-independent, and
+`sysparm_exclude_reference_link=true` so reference fields are plain sys_ids.
+
+## How polling works
+
+Each feed keeps a per-feed **checkpoint** on its timestamp column. Every poll
+queries `<timestamp_field> >= <checkpoint>` ordered oldest-first
+(`ORDERBY`), walking pages with `sysparm_offset`/`sysparm_limit` until the
+API stops advertising a `Link: rel="next"` header. The checkpoint then
+advances to the newest record processed:
+
+- A poll that fails midway does **not** advance the checkpoint — the same
+  range is retried on the next interval, so failures never open a gap.
+- The checkpoint filter is inclusive (`>=`), so records at the boundary are
+  re-read; an in-memory deduper keyed on `sys_id` ships each record exactly
+  once.
+- A poll capped by `max_pages` still advances the checkpoint to the last
+  record processed, so the next poll picks up exactly where it left off.
+
+Transient API failures (HTTP 5xx, 429, network errors) are retried with
+exponential backoff, honoring a 429's `Retry-After` delay. ServiceNow
+instances have no default REST rate limit, but administrators can configure
+[rate limit rules](https://www.servicenow.com/docs/r/zurich/api-reference/rest-api-explorer/inbound-REST-API-rate-limiting.html).
+
+Note that the rotating tables (`syslog*` ~8 weeks, `sysevent` ~7 days) bound
+how far `backfill` can usefully reach.
+
+### Push alternative
+
+ServiceNow's [Log Export Service](https://www.servicenow.com/docs/r/zurich/platform-security/les-intro.html)
+can stream `sys_audit`, `syslog`, `syslog_transaction` and
+`sys_outbound_http_log` over Kafka (Hermes), but it requires a Store app,
+an entitlement, and a MID server or Kafka consumer — this adapter's polling
+needs none of that. Customers already licensed for LES can route it into
+LimaCharlie through a webhook/Kafka bridge instead.
+
+## CLI Deployment
+
+```bash
+chmod +x /path/to/lc_adapter
+
+/path/to/lc_adapter servicenow \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=json \
+  client_options.sensor_seed_key=servicenow \
+  instance=example \
+  username=$SERVICENOW_USERNAME \
+  password=$SERVICENOW_PASSWORD
+```
+
+## Infrastructure as Code Deployment
+
+```yaml
+# For cloud sensor deployment, store credentials as hive secrets:
+#
+#   password: "hive://secret/servicenow-password"
+
+sensor_type: "servicenow"
+servicenow:
+  instance: "example"
+  username: "lc.collector"
+  password: "hive://secret/servicenow-password"
+  client_options:
+    identity:
+      oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      installation_key: "YOUR_LC_INSTALLATION_KEY_SERVICENOW"
+    hostname: "servicenow-adapter"
+    platform: "json"
+    sensor_seed_key: "servicenow-sensor"
+```
+
+### Custom feeds
+
+Override `feeds` to add tables or replace the default entirely. The list is
+**replacing**, not merging — re-declare `sys_audit` if you want to keep it.
+The example below keeps the default and adds login telemetry and the
+transaction log:
+
+```yaml
+servicenow:
+  instance: "example"
+  username: "lc.collector"
+  password: "hive://secret/servicenow-password"
+  feeds:
+    - table: sys_audit
+    - name: login_events
+      table: sysevent
+      query: "name=login^ORname=login.failed"
+    - name: transactions
+      table: syslog_transaction
+  client_options:
+    identity:
+      oid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      installation_key: "YOUR_LC_INSTALLATION_KEY_SERVICENOW"
+    platform: "json"
+    sensor_seed_key: "servicenow-sensor"
+```
+
+## API Docs
+
+- [Table API reference](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_TableAPI.html)
+- [Sys Audit table](https://www.servicenow.com/docs/r/zurich/platform-security/c_UnderstandingTheSysAuditTable.html)
+- [Transaction logs](https://www.servicenow.com/docs/r/zurich/platform-security/r_TransactionLogs.html)
+- [Login events in the event queue](https://www.servicenow.com/docs/r/zurich/platform-security/authentication/r_EventQueueLoginEvents.html)
+- [Log history / table rotation](https://www.servicenow.com/docs/r/zurich/platform-security/r_LogHistory.html)
+- [Inbound REST API rate limiting](https://www.servicenow.com/docs/r/zurich/api-reference/rest-api-explorer/inbound-REST-API-rate-limiting.html)

--- a/servicenow/api.go
+++ b/servicenow/api.go
@@ -1,0 +1,176 @@
+package usp_servicenow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// HTTPError represents a non-2xx response from the ServiceNow REST API. It
+// carries the status code so callers can classify the error (retry vs. give
+// up) without having to parse error strings, and the Retry-After delay when
+// the instance rate-limits the request (HTTP 429).
+type HTTPError struct {
+	StatusCode int
+	URL        string
+	Body       string
+	RetryAfter time.Duration
+}
+
+func (e *HTTPError) Error() string {
+	body := e.Body
+	if len(body) > 512 {
+		body = body[:512] + "..."
+	}
+	return fmt.Sprintf("unexpected status code %d for %q: %s", e.StatusCode, e.URL, body)
+}
+
+// isTransientError reports whether an error is worth retrying.
+//
+// Transient (retry):
+//   - HTTP 5xx server errors
+//   - HTTP 429 Too Many Requests (an instance rate-limit rule fired)
+//   - network errors (timeouts, connection refused, DNS failures, ...)
+//
+// Permanent (do not retry):
+//   - HTTP 4xx other than 429 (bad request, auth failure, not found, ...)
+//   - context cancellation (intentional shutdown)
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 500 && httpErr.StatusCode <= 599 {
+			return true
+		}
+		if httpErr.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+		return false
+	}
+
+	// Context cancellation is an intentional shutdown, not a transient blip.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Anything that failed before we got a response (DNS, dial, timeout, ...)
+	// is reported by Do() and wrapped with this prefix; treat it as transient.
+	if strings.Contains(err.Error(), "failed to execute request") {
+		return true
+	}
+
+	return false
+}
+
+// ServiceNowClient is a thin wrapper around the ServiceNow REST Table API
+// (GET /api/now/v2/table/{tableName}). The v2 endpoint is used because it
+// returns HTTP 200 with an empty result array when a valid query matches
+// nothing, where v1 returns a misleading 404.
+type ServiceNowClient struct {
+	baseURL    string
+	username   string
+	password   string
+	httpClient *http.Client
+}
+
+// NewServiceNowClient builds a client. baseURL is the instance root, e.g.
+// "https://example.service-now.com".
+func NewServiceNowClient(baseURL, username, password string) *ServiceNowClient {
+	return &ServiceNowClient{
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		username: username,
+		password: password,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout: 10 * time.Second,
+				}).Dial,
+			},
+		},
+	}
+}
+
+// GetTable fetches one page of a table. It returns the raw response body and
+// whether the response advertises a further page via a Link rel="next"
+// header. The Link header -- not the page's record count -- is the reliable
+// end-of-data signal: ServiceNow applies sysparm_limit *before* ACL
+// evaluation, so a page can legitimately come back short (or empty) while
+// more records remain.
+func (c *ServiceNowClient) GetTable(ctx context.Context, table string, params url.Values) ([]byte, bool, error) {
+	u := fmt.Sprintf("%s/api/now/v2/table/%s?%s", c.baseURL, url.PathEscape(table), params.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create request %q: %v", u, err)
+	}
+
+	req.SetBasicAuth(c.username, c.password)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to execute request %q: %v", u, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read response %q: %v", u, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, &HTTPError{
+			StatusCode: resp.StatusCode,
+			URL:        u,
+			Body:       string(respBody),
+			RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
+		}
+	}
+
+	return respBody, hasNextLink(resp.Header), nil
+}
+
+// Close releases idle connections held by the underlying transport.
+func (c *ServiceNowClient) Close() {
+	c.httpClient.CloseIdleConnections()
+}
+
+// hasNextLink reports whether a response's Link header(s) advertise a
+// rel="next" page, e.g.:
+//
+//	Link: <https://example.service-now.com/api/now/v2/table/sys_audit?sysparm_offset=100&sysparm_limit=100>;rel="next"
+func hasNextLink(h http.Header) bool {
+	for _, link := range h.Values("Link") {
+		for _, part := range strings.Split(link, ",") {
+			if strings.Contains(part, `rel="next"`) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// parseRetryAfter parses a Retry-After header value expressed in seconds (the
+// form ServiceNow's rate limiter emits). An absent or unparseable value
+// yields 0, meaning "no specific delay requested".
+func parseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	secs, err := strconv.Atoi(v)
+	if err != nil || secs < 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
+}

--- a/servicenow/api.go
+++ b/servicenow/api.go
@@ -93,9 +93,14 @@ func NewServiceNowClient(baseURL, username, password string) *ServiceNowClient {
 		httpClient: &http.Client{
 			Timeout: 60 * time.Second,
 			Transport: &http.Transport{
-				Dial: (&net.Dialer{
+				DialContext: (&net.Dialer{
 					Timeout: 10 * time.Second,
-				}).Dial,
+				}).DialContext,
+				// All feeds poll the same instance host concurrently; keep
+				// enough warm connections that each poll does not pay a fresh
+				// TLS handshake (the stdlib default of 2 per host would).
+				MaxIdleConnsPerHost: 8,
+				IdleConnTimeout:     5 * time.Minute,
 			},
 		},
 	}

--- a/servicenow/client.go
+++ b/servicenow/client.go
@@ -1,0 +1,649 @@
+// Package usp_servicenow implements a USP adapter for ServiceNow audit and
+// system logs, pulled through the ServiceNow REST Table API
+// (GET /api/now/v2/table/{tableName}).
+//
+// ServiceNow keeps its audit telemetry in plain platform tables -- field-level
+// change history in sys_audit, per-transaction activity in syslog_transaction,
+// system events (including login activity) in sysevent, and so on. The adapter
+// models a "feed" as one such table plus an optional encoded-query filter, so
+// collecting an additional table is purely a matter of configuration -- no
+// code change required.
+//
+// Each feed is polled incrementally: records are queried in ascending
+// sys_created_on order from a per-feed checkpoint, and the checkpoint only
+// advances once a poll completes, so transient failures never open a gap. The
+// checkpoint query is inclusive (>=) and a per-feed deduper keyed on sys_id
+// absorbs the records re-read at the checkpoint boundary.
+//
+// Events are forwarded to LimaCharlie in their original ServiceNow JSON form;
+// the adapter does not reshape payloads.
+package usp_servicenow
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	defaultPageSize         = 1000
+	maxPageSize             = 10000
+	defaultPollInterval     = 1 * time.Minute
+	defaultBackfill         = 15 * time.Minute
+	defaultDedupeTTL        = 7 * 24 * time.Hour
+	dedupeBucketWindow      = 1 * time.Hour
+	defaultMaxPages         = 100
+	defaultTimestampField   = "sys_created_on"
+	defaultIDField          = "sys_id"
+	defaultMaxRetryAttempts = 3
+	defaultRetryBaseDelay   = 5 * time.Second
+	defaultMaxRetryDelay    = 30 * time.Second
+
+	shipTimeout = 10 * time.Second
+
+	// serviceNowTimeLayout is the format the Table API uses for date/time
+	// values: "yyyy-MM-dd HH:mm:ss". With the default
+	// sysparm_display_value=false, these are the database values, which are
+	// always UTC.
+	serviceNowTimeLayout = "2006-01-02 15:04:05"
+)
+
+// timestampLayouts are the time formats accepted for a record's timestamp
+// field. The Table API emits "yyyy-MM-dd HH:mm:ss" (UTC); the RFC 3339 forms
+// are accepted defensively for customized fields.
+var timestampLayouts = []string{
+	serviceNowTimeLayout,
+	time.RFC3339Nano,
+	time.RFC3339,
+}
+
+// ServiceNowFeed describes a single ServiceNow table to poll. New event types
+// are added by appending feeds -- no code change.
+type ServiceNowFeed struct {
+	// Name labels the feed and becomes the EventType of every shipped event.
+	// Defaults to Table.
+	Name string `json:"name" yaml:"name"`
+
+	// Table is the ServiceNow table to read, e.g. "sys_audit",
+	// "syslog_transaction", "sysevent".
+	Table string `json:"table" yaml:"table"`
+
+	// Query is an optional ServiceNow encoded query ANDed in front of the
+	// adapter's own incremental time filter, e.g. "tablename=incident" or
+	// "name=login^ORname=login.failed". Column names, operators and values
+	// are case-sensitive.
+	Query string `json:"query" yaml:"query"`
+
+	// Fields, when set, is sent as sysparm_fields to restrict the columns
+	// returned (comma-separated). It must include the feed's timestamp and id
+	// fields or incremental polling and deduplication degrade.
+	Fields string `json:"fields" yaml:"fields"`
+
+	// TimestampField is the record's event-time column, used both for the
+	// incremental checkpoint filter and the shipped event time. Defaults to
+	// "sys_created_on" -- the right choice for the insert-only log tables
+	// this adapter targets.
+	TimestampField string `json:"timestamp_field" yaml:"timestamp_field"`
+
+	// IDField is the record's stable identifier, used for deduplication.
+	// Defaults to "sys_id".
+	IDField string `json:"id_field" yaml:"id_field"`
+
+	// MaxPages caps how many pages are fetched per poll. The cap does not
+	// lose data: records are walked in ascending time order and the
+	// checkpoint advances to the last record processed, so a capped poll
+	// simply resumes where it left off on the next interval. Defaults to 100.
+	MaxPages int `json:"max_pages" yaml:"max_pages"`
+}
+
+// ServiceNowConfig is the adapter configuration.
+type ServiceNowConfig struct {
+	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+	// Instance is the ServiceNow instance name, used to build the API root:
+	// https://<instance>.service-now.com
+	Instance string `json:"instance" yaml:"instance"`
+
+	// BaseURL fully overrides the API root. When set, Instance is ignored.
+	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// Username / Password authenticate against the instance with HTTP Basic
+	// auth (a dedicated service account is recommended). The account needs
+	// read access to the polled tables -- sys_audit is readable by the admin
+	// and security_admin roles out of the box.
+	Username string `json:"username" yaml:"username"`
+	Password string `json:"password" yaml:"password"`
+
+	// Feeds is the set of ServiceNow tables to poll. When empty, the adapter
+	// defaults to the sys_audit table (field-level change history).
+	Feeds []ServiceNowFeed `json:"feeds" yaml:"feeds"`
+
+	// PageSize is the number of records requested per page (sysparm_limit).
+	// Default 1000, maximum 10000.
+	PageSize int `json:"page_size" yaml:"page_size"`
+
+	// PollInterval is the wait between polls of a feed. Default 1 minute.
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+
+	// Backfill is how far back the first poll reaches. Default 15 minutes.
+	Backfill time.Duration `json:"backfill" yaml:"backfill"`
+
+	// DedupeTTL is how long a record's identifier is remembered to suppress
+	// re-shipping it on subsequent polls. Default 7 days.
+	DedupeTTL time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
+
+	// Retry tuning for transient API failures.
+	RetryBaseDelay   time.Duration `json:"retry_base_delay" yaml:"retry_base_delay"`
+	MaxRetryDelay    time.Duration `json:"max_retry_delay" yaml:"max_retry_delay"`
+	MaxRetryAttempts int           `json:"max_retry_attempts" yaml:"max_retry_attempts"`
+
+	// Deduper, when set, replaces the built-in in-memory deduper. It is not
+	// settable through a config file; it exists as a seam for tests and for
+	// embedders that want to supply a shared deduper.
+	Deduper utils.Deduper `json:"-" yaml:"-"`
+}
+
+// defaultFeeds returns the out-of-the-box feed set: the sys_audit table,
+// ServiceNow's field-level change history (who changed what, with old/new
+// values). Other security-relevant tables -- syslog_transaction (every
+// user/API transaction with source IP), sysevent (login activity), syslog --
+// are added through the Feeds configuration; syslog_transaction in particular
+// is high-volume, so it is deliberately not collected by default.
+func defaultFeeds() []ServiceNowFeed {
+	return []ServiceNowFeed{
+		{
+			Name:  "sys_audit",
+			Table: "sys_audit",
+		},
+	}
+}
+
+func (c *ServiceNowConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+	if c.Username == "" {
+		return errors.New("missing username")
+	}
+	if c.Password == "" {
+		return errors.New("missing password")
+	}
+
+	c.BaseURL = strings.TrimSpace(c.BaseURL)
+	c.Instance = strings.TrimSpace(c.Instance)
+	if c.BaseURL == "" && c.Instance == "" {
+		return errors.New("missing instance (or base_url)")
+	}
+
+	if c.PageSize <= 0 {
+		c.PageSize = defaultPageSize
+	}
+	if c.PageSize > maxPageSize {
+		c.PageSize = maxPageSize
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
+	if c.Backfill <= 0 {
+		c.Backfill = defaultBackfill
+	}
+	if c.DedupeTTL <= 0 {
+		c.DedupeTTL = defaultDedupeTTL
+	}
+	if c.RetryBaseDelay <= 0 {
+		c.RetryBaseDelay = defaultRetryBaseDelay
+	}
+	if c.MaxRetryDelay <= 0 {
+		c.MaxRetryDelay = defaultMaxRetryDelay
+	}
+	if c.MaxRetryAttempts <= 0 {
+		c.MaxRetryAttempts = defaultMaxRetryAttempts
+	}
+
+	if len(c.Feeds) == 0 {
+		c.Feeds = defaultFeeds()
+	}
+	seenNames := make(map[string]struct{}, len(c.Feeds))
+	for i := range c.Feeds {
+		f := &c.Feeds[i]
+		f.Table = strings.TrimSpace(f.Table)
+		if f.Table == "" {
+			return fmt.Errorf("feed %d: missing table", i)
+		}
+		f.Name = strings.TrimSpace(f.Name)
+		if f.Name == "" {
+			f.Name = f.Table
+		}
+		if _, ok := seenNames[f.Name]; ok {
+			return fmt.Errorf("feed %q: duplicate name", f.Name)
+		}
+		seenNames[f.Name] = struct{}{}
+		if f.TimestampField == "" {
+			f.TimestampField = defaultTimestampField
+		}
+		if f.IDField == "" {
+			f.IDField = defaultIDField
+		}
+		if f.MaxPages <= 0 {
+			f.MaxPages = defaultMaxPages
+		}
+	}
+	return nil
+}
+
+// uspSink is the subset of *uspclient.Client the adapter depends on.
+// Expressing it as an interface lets tests substitute an in-memory sink for
+// the real LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
+// ServiceNowAdapter polls one or more ServiceNow tables and ships their
+// records to LimaCharlie.
+type ServiceNowAdapter struct {
+	conf        ServiceNowConfig
+	uspClient   uspSink
+	client      *ServiceNowClient
+	deduper     utils.Deduper
+	ownsDeduper bool
+
+	chStopped chan struct{}
+	wgSenders sync.WaitGroup
+	doStop    *utils.Event
+
+	closeOnce sync.Once
+	closeErr  error
+
+	ctx context.Context
+}
+
+// NewServiceNowAdapter creates a ServiceNow adapter wired to LimaCharlie.
+func NewServiceNowAdapter(ctx context.Context, conf ServiceNowConfig) (*ServiceNowAdapter, chan struct{}, error) {
+	return newServiceNowAdapter(ctx, conf, nil)
+}
+
+// newServiceNowAdapter is the implementation behind NewServiceNowAdapter.
+// When sink is non-nil it is used in place of a real LimaCharlie client --
+// the seam tests use to capture shipped events.
+func newServiceNowAdapter(ctx context.Context, conf ServiceNowConfig, sink uspSink) (*ServiceNowAdapter, chan struct{}, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	a := &ServiceNowAdapter{
+		conf:   conf,
+		ctx:    ctx,
+		doStop: utils.NewEvent(),
+	}
+
+	// The checkpoint query is inclusive (>=), so the records sitting exactly
+	// at the checkpoint are re-read on the next poll; the deduper is what
+	// keeps them from shipping twice.
+	a.deduper = conf.Deduper
+	if a.deduper == nil {
+		window := dedupeBucketWindow
+		if window > conf.DedupeTTL {
+			window = conf.DedupeTTL
+		}
+		deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("servicenow: deduper: %v", err)
+		}
+		a.deduper = deduper
+		a.ownsDeduper = true
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			if a.ownsDeduper {
+				a.deduper.Close()
+			}
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
+	}
+
+	a.client = NewServiceNowClient(resolveBaseURL(conf), conf.Username, conf.Password)
+	a.chStopped = make(chan struct{})
+
+	for _, feed := range conf.Feeds {
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf("servicenow: starting feed %q -> table %s", feed.Name, feed.Table))
+		a.wgSenders.Add(1)
+		go a.runFeed(feed)
+	}
+
+	go func() {
+		a.wgSenders.Wait()
+		close(a.chStopped)
+	}()
+
+	return a, a.chStopped, nil
+}
+
+// Close stops the adapter. It is idempotent: repeated calls are no-ops and
+// return the result of the first call.
+func (a *ServiceNowAdapter) Close() error {
+	a.closeOnce.Do(func() {
+		a.conf.ClientOptions.DebugLog("servicenow: closing")
+		a.doStop.Set()
+		a.wgSenders.Wait()
+		err1 := a.uspClient.Drain(1 * time.Minute)
+		_, err2 := a.uspClient.Close()
+		a.client.Close()
+		if a.ownsDeduper {
+			a.deduper.Close()
+		}
+		if err1 != nil {
+			a.closeErr = err1
+		} else {
+			a.closeErr = err2
+		}
+	})
+	return a.closeErr
+}
+
+// resolveBaseURL computes the ServiceNow instance root from the config.
+func resolveBaseURL(conf ServiceNowConfig) string {
+	if conf.BaseURL != "" {
+		return strings.TrimRight(conf.BaseURL, "/")
+	}
+	return fmt.Sprintf("https://%s.service-now.com", strings.Trim(conf.Instance, "/"))
+}
+
+// runFeed polls a single feed forever, until the adapter is asked to stop.
+// The feed's checkpoint starts Backfill in the past and only moves forward
+// when a poll succeeds, so a failed poll is simply retried over the same
+// range on the next interval -- no gap.
+func (a *ServiceNowAdapter) runFeed(feed ServiceNowFeed) {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("servicenow: feed %q stopped", feed.Name))
+
+	checkpoint := time.Now().UTC().Add(-a.conf.Backfill)
+
+	isFirstRun := true
+	for isFirstRun || !a.doStop.WaitFor(a.conf.PollInterval) {
+		isFirstRun = false
+		checkpoint = a.pollFeed(feed, checkpoint)
+	}
+}
+
+// pollFeed fetches one feed once, walking pages from the checkpoint in
+// ascending time order, and returns the new checkpoint.
+//
+// The end-of-data signal is the Link rel="next" header, not the page's record
+// count: ServiceNow applies sysparm_limit before ACL evaluation, so a short
+// or even empty page can still be followed by more records.
+//
+// The returned checkpoint is the timestamp of the newest record processed.
+// Because records are walked oldest-first, stopping early (MaxPages) is safe:
+// everything up to the new checkpoint has been processed and the next poll
+// resumes from there. On failure the original checkpoint is returned so the
+// range is retried.
+func (a *ServiceNowAdapter) pollFeed(feed ServiceNowFeed, checkpoint time.Time) time.Time {
+	nSeen := 0
+	nShipped := 0
+	maxSeen := checkpoint
+
+	for pageNumber := 1; !a.doStop.IsSet(); pageNumber++ {
+		if pageNumber > feed.MaxPages {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"servicenow: feed %q hit max_pages=%d this poll; the remaining records "+
+					"will be collected on the next poll from the advanced checkpoint",
+				feed.Name, feed.MaxPages))
+			break
+		}
+
+		offset := (pageNumber - 1) * a.conf.PageSize
+		items, hasNext, ok := a.fetchPage(feed, checkpoint, offset)
+		if !ok {
+			// The error has already been reported; abandon this poll without
+			// advancing the checkpoint so the same range is retried.
+			return checkpoint
+		}
+
+		for _, item := range items {
+			nSeen++
+			if raw := item.FindOneString(feed.TimestampField); raw != "" {
+				if t, ok := parseTimestamp(raw); ok && t.After(maxSeen) {
+					maxSeen = t
+				}
+			}
+			if a.deduper.CheckAndAdd(a.dedupeKey(feed, item)) {
+				continue
+			}
+			if !a.ship(feed, item) {
+				return checkpoint
+			}
+			nShipped++
+		}
+
+		if !hasNext {
+			break
+		}
+	}
+
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"servicenow: feed %q poll complete (seen=%d shipped=%d checkpoint=%s)",
+		feed.Name, nSeen, nShipped, maxSeen.Format(serviceNowTimeLayout)))
+	return maxSeen
+}
+
+// fetchPage requests one page of a feed, retrying transient failures with
+// exponential backoff (honoring Retry-After on HTTP 429). The bool result is
+// false when the poll should be abandoned (a permanent error, or the adapter
+// is stopping).
+func (a *ServiceNowAdapter) fetchPage(feed ServiceNowFeed, checkpoint time.Time, offset int) ([]utils.Dict, bool, bool) {
+	params := a.buildParams(feed, checkpoint, offset)
+
+	var raw []byte
+	var hasNext bool
+	var err error
+	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
+		if a.doStop.IsSet() {
+			return nil, false, false
+		}
+
+		raw, hasNext, err = a.client.GetTable(a.ctx, feed.Table, params)
+		if err == nil {
+			break
+		}
+
+		if !isTransientError(err) {
+			a.conf.ClientOptions.OnError(fmt.Errorf("servicenow: feed %q request failed: %v", feed.Name, err))
+			// An authentication/authorization failure affects every feed, so
+			// stop the whole adapter rather than spin uselessly. Other
+			// permanent errors (e.g. a misnamed table) are isolated to this
+			// feed: abandon the poll but keep the adapter alive.
+			var httpErr *HTTPError
+			if errors.As(err, &httpErr) &&
+				(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
+				// ServiceNow reports both bad credentials and missing table
+				// ACLs this way; surface both possibilities. Reading sys_audit
+				// requires the admin or security_admin role (or a custom ACL).
+				a.conf.ClientOptions.OnError(fmt.Errorf(
+					"servicenow: HTTP %d -- credentials rejected or the account lacks read "+
+						"access to table %q. Verify username/password and that the account's "+
+						"roles satisfy the table's ACLs (sys_audit requires admin or "+
+						"security_admin out of the box).", httpErr.StatusCode, feed.Table))
+				a.doStop.Set()
+			}
+			return nil, false, false
+		}
+
+		if attempt+1 >= a.conf.MaxRetryAttempts {
+			break
+		}
+		delay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
+		if delay > a.conf.MaxRetryDelay {
+			delay = a.conf.MaxRetryDelay
+		}
+		// A rate-limited instance tells us exactly how long to back off;
+		// honor it even past the configured cap.
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && httpErr.RetryAfter > delay {
+			delay = httpErr.RetryAfter
+		}
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"servicenow: feed %q transient error (attempt %d/%d), retrying in %v: %v",
+			feed.Name, attempt+1, a.conf.MaxRetryAttempts, delay, err))
+		if a.doStop.WaitFor(delay) {
+			return nil, false, false
+		}
+	}
+	if err != nil {
+		a.conf.ClientOptions.OnError(fmt.Errorf(
+			"servicenow: feed %q failed after %d attempts: %v", feed.Name, a.conf.MaxRetryAttempts, err))
+		return nil, false, false
+	}
+
+	items, err := extractResult(raw)
+	if err != nil {
+		a.conf.ClientOptions.OnError(fmt.Errorf("servicenow: feed %q response parse error: %v", feed.Name, err))
+		return nil, false, false
+	}
+	return items, hasNext, true
+}
+
+// buildParams assembles the Table API query parameters for one page of a
+// feed: the feed's own encoded-query filter ANDed with the incremental
+// checkpoint filter, ascending time order, and offset pagination. Database
+// (UTC) values are requested rather than display values, and reference-field
+// link objects are excluded, so payloads are stable regardless of the service
+// account's locale.
+func (a *ServiceNowAdapter) buildParams(feed ServiceNowFeed, checkpoint time.Time, offset int) url.Values {
+	query := ""
+	if feed.Query != "" {
+		query = feed.Query + "^"
+	}
+	query += fmt.Sprintf("%s>=%s^ORDERBY%s",
+		feed.TimestampField, checkpoint.UTC().Format(serviceNowTimeLayout), feed.TimestampField)
+
+	params := url.Values{}
+	params.Set("sysparm_query", query)
+	params.Set("sysparm_limit", strconv.Itoa(a.conf.PageSize))
+	params.Set("sysparm_offset", strconv.Itoa(offset))
+	params.Set("sysparm_display_value", "false")
+	params.Set("sysparm_exclude_reference_link", "true")
+	if feed.Fields != "" {
+		params.Set("sysparm_fields", feed.Fields)
+	}
+	return params
+}
+
+// ship forwards a single record to LimaCharlie. It returns false if the
+// adapter should stop (an unrecoverable shipping error).
+func (a *ServiceNowAdapter) ship(feed ServiceNowFeed, item utils.Dict) bool {
+	msg := &protocol.DataMessage{
+		JsonPayload: item,
+		EventType:   feed.Name,
+		TimestampMs: a.eventTime(feed, item),
+	}
+	if err := a.uspClient.Ship(msg, shipTimeout); err != nil {
+		if err == uspclient.ErrorBufferFull {
+			a.conf.ClientOptions.OnWarning("servicenow: stream falling behind")
+			err = a.uspClient.Ship(msg, 1*time.Hour)
+		}
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("servicenow: Ship(): %v", err))
+			a.doStop.Set()
+			return false
+		}
+	}
+	return true
+}
+
+// eventTime extracts the record's event time, falling back to now when the
+// configured timestamp field is absent or unparseable.
+func (a *ServiceNowAdapter) eventTime(feed ServiceNowFeed, item utils.Dict) uint64 {
+	if raw := item.FindOneString(feed.TimestampField); raw != "" {
+		if t, ok := parseTimestamp(raw); ok {
+			return uint64(t.UnixMilli())
+		}
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+			"servicenow: feed %q unparseable timestamp %q at field %q", feed.Name, raw, feed.TimestampField))
+	}
+	return uint64(time.Now().UnixMilli())
+}
+
+// dedupeKey returns a stable deduplication key for a record, namespaced by
+// feed so identifiers cannot collide across feeds.
+func (a *ServiceNowAdapter) dedupeKey(feed ServiceNowFeed, item utils.Dict) string {
+	return feed.Name + "|" + recordID(feed, item)
+}
+
+// recordID resolves a record's identifier: the feed's IDField (sys_id by
+// default), with a content-hash fallback so deduplication still works for a
+// record missing it (e.g. a restrictive sysparm_fields).
+func recordID(feed ServiceNowFeed, item utils.Dict) string {
+	if id := item.FindOneString(feed.IDField); id != "" {
+		return id
+	}
+	if b, err := json.Marshal(item); err == nil {
+		sum := sha256.Sum256(b)
+		return "sha256:" + hex.EncodeToString(sum[:])
+	}
+	return ""
+}
+
+// extractResult parses a Table API response: a JSON object whose "result" key
+// holds the array of records. Each record is decoded with
+// utils.UnmarshalCleanJSON, which preserves integer precision (no float
+// coercion) so payloads round-trip faithfully. A record that is not a
+// non-empty JSON object is skipped rather than failing the whole page.
+func extractResult(raw []byte) ([]utils.Dict, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	var envelope struct {
+		Result []json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &envelope); err != nil {
+		return nil, fmt.Errorf("invalid JSON response: %v", err)
+	}
+	if envelope.Result == nil && !strings.Contains(trimmed, `"result"`) {
+		return nil, errors.New(`response object has no "result" array`)
+	}
+
+	items := make([]utils.Dict, 0, len(envelope.Result))
+	for _, r := range envelope.Result {
+		m, err := utils.UnmarshalCleanJSON(string(r))
+		if err != nil || len(m) == 0 {
+			continue
+		}
+		items = append(items, utils.Dict(m))
+	}
+	return items, nil
+}
+
+func parseTimestamp(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range timestampLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}

--- a/servicenow/client.go
+++ b/servicenow/client.go
@@ -20,6 +20,7 @@
 package usp_servicenow
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -43,6 +44,7 @@ const (
 	maxPageSize             = 10000
 	defaultPollInterval     = 1 * time.Minute
 	defaultBackfill         = 15 * time.Minute
+	defaultCheckpointLag    = 5 * time.Minute
 	defaultDedupeTTL        = 7 * 24 * time.Hour
 	dedupeBucketWindow      = 1 * time.Hour
 	defaultMaxPages         = 100
@@ -141,6 +143,15 @@ type ServiceNowConfig struct {
 	// Backfill is how far back the first poll reaches. Default 15 minutes.
 	Backfill time.Duration `json:"backfill" yaml:"backfill"`
 
+	// CheckpointLag is how long the checkpoint trails the clock. A row can
+	// become visible in the Table API some time after its timestamp (it is
+	// stamped when written but only queryable once its transaction commits,
+	// and instance nodes can disagree on the time); a row that appears more
+	// than CheckpointLag late may be missed. Larger values re-read more
+	// recent records per poll (the deduper absorbs the overlap). Default 5
+	// minutes.
+	CheckpointLag time.Duration `json:"checkpoint_lag" yaml:"checkpoint_lag"`
+
 	// DedupeTTL is how long a record's identifier is remembered to suppress
 	// re-shipping it on subsequent polls. Default 7 days.
 	DedupeTTL time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
@@ -200,6 +211,9 @@ func (c *ServiceNowConfig) Validate() error {
 	if c.Backfill <= 0 {
 		c.Backfill = defaultBackfill
 	}
+	if c.CheckpointLag <= 0 {
+		c.CheckpointLag = defaultCheckpointLag
+	}
 	if c.DedupeTTL <= 0 {
 		c.DedupeTTL = defaultDedupeTTL
 	}
@@ -239,6 +253,18 @@ func (c *ServiceNowConfig) Validate() error {
 		}
 		if f.MaxPages <= 0 {
 			f.MaxPages = defaultMaxPages
+		}
+		if f.Fields != "" {
+			cols := map[string]bool{}
+			for _, col := range strings.Split(f.Fields, ",") {
+				cols[strings.TrimSpace(col)] = true
+			}
+			// Without these two columns the checkpoint silently freezes and
+			// deduplication degrades to content hashes -- reject early.
+			if !cols[f.TimestampField] || !cols[f.IDField] {
+				return fmt.Errorf("feed %q: fields must include timestamp_field (%s) and id_field (%s)",
+					f.Name, f.TimestampField, f.IDField)
+			}
 		}
 	}
 	return nil
@@ -386,71 +412,120 @@ func (a *ServiceNowAdapter) runFeed(feed ServiceNowFeed) {
 }
 
 // pollFeed fetches one feed once, walking pages from the checkpoint in
-// ascending time order, and returns the new checkpoint.
+// ascending (timestamp, id) order, and returns the new checkpoint.
 //
 // The end-of-data signal is the Link rel="next" header, not the page's record
 // count: ServiceNow applies sysparm_limit before ACL evaluation, so a short
 // or even empty page can still be followed by more records.
 //
-// The returned checkpoint is the timestamp of the newest record processed.
-// Because records are walked oldest-first, stopping early (MaxPages) is safe:
-// everything up to the new checkpoint has been processed and the next poll
-// resumes from there. On failure the original checkpoint is returned so the
-// range is retried.
+// Checkpoint semantics:
+//
+//   - A failed or interrupted poll returns the original checkpoint so the
+//     same range is retried -- failures never open a gap.
+//   - A completed walk has processed every record currently visible at or
+//     after the checkpoint, so the checkpoint advances to now-CheckpointLag:
+//     anything older than that is guaranteed visible by the lag model, and
+//     anything newer is re-read on later polls (the deduper absorbs the
+//     overlap). Advancing on the clock -- not on record timestamps -- also
+//     walks the checkpoint past an idle feed's boundary records, so they are
+//     not re-fetched forever.
+//   - A walk capped by MaxPages has NOT seen everything: it resumes from the
+//     newest record actually processed (clamped to now-CheckpointLag in case
+//     of future-dated records). Records are walked oldest-first, so nothing
+//     before that is missed.
 func (a *ServiceNowAdapter) pollFeed(feed ServiceNowFeed, checkpoint time.Time) time.Time {
 	nSeen := 0
 	nShipped := 0
 	maxSeen := checkpoint
+	capped := false
 
-	for pageNumber := 1; !a.doStop.IsSet(); pageNumber++ {
+	for pageNumber := 1; ; pageNumber++ {
+		if a.doStop.IsSet() {
+			return checkpoint
+		}
 		if pageNumber > feed.MaxPages {
-			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
-				"servicenow: feed %q hit max_pages=%d this poll; the remaining records "+
-					"will be collected on the next poll from the advanced checkpoint",
-				feed.Name, feed.MaxPages))
+			capped = true
 			break
 		}
 
 		offset := (pageNumber - 1) * a.conf.PageSize
-		items, hasNext, ok := a.fetchPage(feed, checkpoint, offset)
+		page, ok := a.fetchPage(feed, checkpoint, offset)
 		if !ok {
 			// The error has already been reported; abandon this poll without
 			// advancing the checkpoint so the same range is retried.
 			return checkpoint
 		}
 
-		for _, item := range items {
+		for _, item := range page.items {
 			nSeen++
-			if raw := item.FindOneString(feed.TimestampField); raw != "" {
-				if t, ok := parseTimestamp(raw); ok && t.After(maxSeen) {
-					maxSeen = t
-				}
+			rawTs := item.FindOneString(feed.TimestampField)
+			ts, tsOK := parseTimestamp(rawTs)
+			if tsOK && ts.After(maxSeen) {
+				maxSeen = ts
 			}
 			if a.deduper.CheckAndAdd(a.dedupeKey(feed, item)) {
 				continue
 			}
-			if !a.ship(feed, item) {
+			eventMs := uint64(time.Now().UnixMilli())
+			if tsOK {
+				eventMs = uint64(ts.UnixMilli())
+			} else if rawTs != "" {
+				a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+					"servicenow: feed %q unparseable timestamp %q at field %q", feed.Name, rawTs, feed.TimestampField))
+			}
+			if !a.ship(feed, item, eventMs) {
 				return checkpoint
 			}
 			nShipped++
 		}
 
-		if !hasNext {
+		if !page.hasNext {
 			break
 		}
 	}
 
+	lagged := time.Now().UTC().Add(-a.conf.CheckpointLag)
+	newCheckpoint := lagged
+	if capped {
+		if maxSeen.Before(lagged) {
+			newCheckpoint = maxSeen
+		}
+		if maxSeen.Equal(checkpoint) {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"servicenow: feed %q hit max_pages=%d without being able to advance the "+
+					"checkpoint: more than max_pages*page_size records share the timestamp %q. "+
+					"Raise max_pages or page_size, or narrow the feed's query, or records past "+
+					"the cap will never be collected",
+				feed.Name, feed.MaxPages, checkpoint.Format(serviceNowTimeLayout)))
+		} else {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"servicenow: feed %q hit max_pages=%d this poll; the remaining records "+
+					"will be collected on the next poll from the advanced checkpoint",
+				feed.Name, feed.MaxPages))
+		}
+	}
+	if newCheckpoint.Before(checkpoint) {
+		newCheckpoint = checkpoint
+	}
+
 	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
 		"servicenow: feed %q poll complete (seen=%d shipped=%d checkpoint=%s)",
-		feed.Name, nSeen, nShipped, maxSeen.Format(serviceNowTimeLayout)))
-	return maxSeen
+		feed.Name, nSeen, nShipped, newCheckpoint.Format(serviceNowTimeLayout)))
+	return newCheckpoint
+}
+
+// pageResult is one fetched page: its records and whether the API advertised
+// a further page via Link rel="next".
+type pageResult struct {
+	items   []utils.Dict
+	hasNext bool
 }
 
 // fetchPage requests one page of a feed, retrying transient failures with
 // exponential backoff (honoring Retry-After on HTTP 429). The bool result is
 // false when the poll should be abandoned (a permanent error, or the adapter
 // is stopping).
-func (a *ServiceNowAdapter) fetchPage(feed ServiceNowFeed, checkpoint time.Time, offset int) ([]utils.Dict, bool, bool) {
+func (a *ServiceNowAdapter) fetchPage(feed ServiceNowFeed, checkpoint time.Time, offset int) (pageResult, bool) {
 	params := a.buildParams(feed, checkpoint, offset)
 
 	var raw []byte
@@ -458,7 +533,7 @@ func (a *ServiceNowAdapter) fetchPage(feed ServiceNowFeed, checkpoint time.Time,
 	var err error
 	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
 		if a.doStop.IsSet() {
-			return nil, false, false
+			return pageResult{}, false
 		}
 
 		raw, hasNext, err = a.client.GetTable(a.ctx, feed.Table, params)
@@ -468,24 +543,32 @@ func (a *ServiceNowAdapter) fetchPage(feed ServiceNowFeed, checkpoint time.Time,
 
 		if !isTransientError(err) {
 			a.conf.ClientOptions.OnError(fmt.Errorf("servicenow: feed %q request failed: %v", feed.Name, err))
-			// An authentication/authorization failure affects every feed, so
-			// stop the whole adapter rather than spin uselessly. Other
-			// permanent errors (e.g. a misnamed table) are isolated to this
-			// feed: abandon the poll but keep the adapter alive.
 			var httpErr *HTTPError
-			if errors.As(err, &httpErr) &&
-				(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
-				// ServiceNow reports both bad credentials and missing table
-				// ACLs this way; surface both possibilities. Reading sys_audit
-				// requires the admin or security_admin role (or a custom ACL).
-				a.conf.ClientOptions.OnError(fmt.Errorf(
-					"servicenow: HTTP %d -- credentials rejected or the account lacks read "+
-						"access to table %q. Verify username/password and that the account's "+
-						"roles satisfy the table's ACLs (sys_audit requires admin or "+
-						"security_admin out of the box).", httpErr.StatusCode, feed.Table))
-				a.doStop.Set()
+			if errors.As(err, &httpErr) {
+				switch httpErr.StatusCode {
+				case http.StatusUnauthorized:
+					// Rejected credentials affect every feed: stop the whole
+					// adapter rather than burn the account with retries.
+					a.conf.ClientOptions.OnError(fmt.Errorf(
+						"servicenow: HTTP 401 -- credentials rejected; verify username/password. " +
+							"Stopping the adapter."))
+					a.doStop.Set()
+				case http.StatusForbidden:
+					// 403 is how ServiceNow reports a per-table ACL denial:
+					// the credentials are valid but this table is not
+					// readable. That is feed-local -- keep the other feeds
+					// (and this feed's polling, in case the ACL gets fixed)
+					// alive rather than killing the adapter.
+					a.conf.ClientOptions.OnError(fmt.Errorf(
+						"servicenow: HTTP 403 -- the account lacks read access to table %q "+
+							"(missing role or ACL; sys_audit requires admin or security_admin "+
+							"out of the box). The feed will keep retrying every poll_interval.",
+						feed.Table))
+				}
 			}
-			return nil, false, false
+			// Other permanent errors (e.g. a misnamed table) are isolated to
+			// this feed: abandon the poll but keep the adapter alive.
+			return pageResult{}, false
 		}
 
 		if attempt+1 >= a.conf.MaxRetryAttempts {
@@ -505,36 +588,48 @@ func (a *ServiceNowAdapter) fetchPage(feed ServiceNowFeed, checkpoint time.Time,
 			"servicenow: feed %q transient error (attempt %d/%d), retrying in %v: %v",
 			feed.Name, attempt+1, a.conf.MaxRetryAttempts, delay, err))
 		if a.doStop.WaitFor(delay) {
-			return nil, false, false
+			return pageResult{}, false
 		}
 	}
 	if err != nil {
 		a.conf.ClientOptions.OnError(fmt.Errorf(
 			"servicenow: feed %q failed after %d attempts: %v", feed.Name, a.conf.MaxRetryAttempts, err))
-		return nil, false, false
+		return pageResult{}, false
 	}
 
 	items, err := extractResult(raw)
 	if err != nil {
 		a.conf.ClientOptions.OnError(fmt.Errorf("servicenow: feed %q response parse error: %v", feed.Name, err))
-		return nil, false, false
+		return pageResult{}, false
 	}
-	return items, hasNext, true
+	return pageResult{items: items, hasNext: hasNext}, true
 }
 
 // buildParams assembles the Table API query parameters for one page of a
 // feed: the feed's own encoded-query filter ANDed with the incremental
-// checkpoint filter, ascending time order, and offset pagination. Database
-// (UTC) values are requested rather than display values, and reference-field
-// link objects are excluded, so payloads are stable regardless of the service
-// account's locale.
+// checkpoint filter, ascending (timestamp, id) order, and offset pagination.
+// Database (UTC) values are requested rather than display values, and
+// reference-field link objects are excluded, so payloads are stable
+// regardless of the service account's locale.
+//
+// The id ORDERBY tiebreaker is load-bearing: timestamps have one-second
+// granularity and each page is an independent query, so without a total
+// order, records sharing a second have no stable position across page
+// fetches and one could fall through a page boundary -- skipped permanently
+// once the checkpoint advances. With the tiebreaker, a mid-walk insert can
+// only shift records to later offsets, producing re-reads the deduper
+// absorbs, never skips.
 func (a *ServiceNowAdapter) buildParams(feed ServiceNowFeed, checkpoint time.Time, offset int) url.Values {
 	query := ""
 	if feed.Query != "" {
 		query = feed.Query + "^"
 	}
-	query += fmt.Sprintf("%s>=%s^ORDERBY%s",
-		feed.TimestampField, checkpoint.UTC().Format(serviceNowTimeLayout), feed.TimestampField)
+	idField := feed.IDField
+	if idField == "" {
+		idField = defaultIDField
+	}
+	query += fmt.Sprintf("%s>=%s^ORDERBY%s^ORDERBY%s",
+		feed.TimestampField, checkpoint.UTC().Format(serviceNowTimeLayout), feed.TimestampField, idField)
 
 	params := url.Values{}
 	params.Set("sysparm_query", query)
@@ -550,11 +645,11 @@ func (a *ServiceNowAdapter) buildParams(feed ServiceNowFeed, checkpoint time.Tim
 
 // ship forwards a single record to LimaCharlie. It returns false if the
 // adapter should stop (an unrecoverable shipping error).
-func (a *ServiceNowAdapter) ship(feed ServiceNowFeed, item utils.Dict) bool {
+func (a *ServiceNowAdapter) ship(feed ServiceNowFeed, item utils.Dict, eventMs uint64) bool {
 	msg := &protocol.DataMessage{
 		JsonPayload: item,
 		EventType:   feed.Name,
-		TimestampMs: a.eventTime(feed, item),
+		TimestampMs: eventMs,
 	}
 	if err := a.uspClient.Ship(msg, shipTimeout); err != nil {
 		if err == uspclient.ErrorBufferFull {
@@ -568,19 +663,6 @@ func (a *ServiceNowAdapter) ship(feed ServiceNowFeed, item utils.Dict) bool {
 		}
 	}
 	return true
-}
-
-// eventTime extracts the record's event time, falling back to now when the
-// configured timestamp field is absent or unparseable.
-func (a *ServiceNowAdapter) eventTime(feed ServiceNowFeed, item utils.Dict) uint64 {
-	if raw := item.FindOneString(feed.TimestampField); raw != "" {
-		if t, ok := parseTimestamp(raw); ok {
-			return uint64(t.UnixMilli())
-		}
-		a.conf.ClientOptions.DebugLog(fmt.Sprintf(
-			"servicenow: feed %q unparseable timestamp %q at field %q", feed.Name, raw, feed.TimestampField))
-	}
-	return uint64(time.Now().UnixMilli())
 }
 
 // dedupeKey returns a stable deduplication key for a record, namespaced by
@@ -604,28 +686,33 @@ func recordID(feed ServiceNowFeed, item utils.Dict) string {
 }
 
 // extractResult parses a Table API response: a JSON object whose "result" key
-// holds the array of records. Each record is decoded with
-// utils.UnmarshalCleanJSON, which preserves integer precision (no float
-// coercion) so payloads round-trip faithfully. A record that is not a
-// non-empty JSON object is skipped rather than failing the whole page.
+// holds the array of records ("result": null is treated as an empty page; a
+// missing key is an error -- it means the body is not a Table API envelope).
+// Each record is decoded with utils.UnmarshalCleanJSON, which preserves
+// integer precision (no float coercion) so payloads round-trip faithfully. A
+// record that is not a non-empty JSON object is skipped rather than failing
+// the whole page.
 func extractResult(raw []byte) ([]utils.Dict, error) {
-	trimmed := strings.TrimSpace(string(raw))
-	if trimmed == "" {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
 		return nil, nil
 	}
 
-	var envelope struct {
-		Result []json.RawMessage `json:"result"`
-	}
-	if err := json.Unmarshal([]byte(trimmed), &envelope); err != nil {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &envelope); err != nil {
 		return nil, fmt.Errorf("invalid JSON response: %v", err)
 	}
-	if envelope.Result == nil && !strings.Contains(trimmed, `"result"`) {
-		return nil, errors.New(`response object has no "result" array`)
+	arrRaw, ok := envelope["result"]
+	if !ok {
+		return nil, fmt.Errorf(`response object has no "result" key (keys: %v)`, keysOf(envelope))
+	}
+	var arr []json.RawMessage
+	if err := json.Unmarshal(arrRaw, &arr); err != nil {
+		return nil, fmt.Errorf(`response "result" is not an array: %v`, err)
 	}
 
-	items := make([]utils.Dict, 0, len(envelope.Result))
-	for _, r := range envelope.Result {
+	items := make([]utils.Dict, 0, len(arr))
+	for _, r := range arr {
 		m, err := utils.UnmarshalCleanJSON(string(r))
 		if err != nil || len(m) == 0 {
 			continue
@@ -633,6 +720,14 @@ func extractResult(raw []byte) ([]utils.Dict, error) {
 		items = append(items, utils.Dict(m))
 	}
 	return items, nil
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func parseTimestamp(s string) (time.Time, bool) {

--- a/servicenow/client_test.go
+++ b/servicenow/client_test.go
@@ -1,0 +1,669 @@
+package usp_servicenow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real
+// LimaCharlie connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// auditFeed is the single sys_audit feed used by integration tests.
+func auditFeed() []ServiceNowFeed {
+	return []ServiceNowFeed{{
+		Name:  "sys_audit",
+		Table: "sys_audit",
+	}}
+}
+
+// auditItem builds a minimal sys_audit-shaped record.
+func auditItem(id, createdOn string) map[string]interface{} {
+	return map[string]interface{}{
+		"sys_id":         id,
+		"tablename":      "incident",
+		"fieldname":      "state",
+		"oldvalue":       "1",
+		"newvalue":       "2",
+		"sys_created_on": createdOn,
+		"sys_created_by": "jane.doe",
+	}
+}
+
+func resultEnvelope(items []map[string]interface{}) map[string]interface{} {
+	if items == nil {
+		items = []map[string]interface{}{}
+	}
+	return map[string]interface{}{"result": items}
+}
+
+// --- unit tests -------------------------------------------------------------
+
+func TestExtractResult(t *testing.T) {
+	t.Run("result envelope", func(t *testing.T) {
+		items, err := extractResult([]byte(`{"result":[{"sys_id":"a"},{"sys_id":"b"}]}`))
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, "a", items[0].FindOneString("sys_id"))
+		assert.Equal(t, "b", items[1].FindOneString("sys_id"))
+	})
+
+	t.Run("empty result array", func(t *testing.T) {
+		items, err := extractResult([]byte(`{"result":[]}`))
+		require.NoError(t, err)
+		assert.Empty(t, items)
+	})
+
+	t.Run("missing result key errors", func(t *testing.T) {
+		_, err := extractResult([]byte(`{"rows":[]}`))
+		assert.Error(t, err)
+	})
+
+	t.Run("empty body yields no items", func(t *testing.T) {
+		items, err := extractResult([]byte("   "))
+		require.NoError(t, err)
+		assert.Empty(t, items)
+	})
+
+	t.Run("non-json errors", func(t *testing.T) {
+		_, err := extractResult([]byte(`not json`))
+		assert.Error(t, err)
+	})
+
+	t.Run("large integers keep precision", func(t *testing.T) {
+		items, err := extractResult([]byte(`{"result":[{"big":123456789012345678}]}`))
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		v, ok := items[0].GetInt("big")
+		require.True(t, ok)
+		assert.Equal(t, uint64(123456789012345678), v)
+	})
+
+	t.Run("non-object records are skipped, valid ones kept", func(t *testing.T) {
+		items, err := extractResult([]byte(`{"result":[{"sys_id":"a"},"junk",123,null,{"sys_id":"b"}]}`))
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, "a", items[0].FindOneString("sys_id"))
+		assert.Equal(t, "b", items[1].FindOneString("sys_id"))
+	})
+}
+
+func TestRecordID(t *testing.T) {
+	t.Run("uses configured id field", func(t *testing.T) {
+		feed := ServiceNowFeed{IDField: "sys_id"}
+		assert.Equal(t, "abc", recordID(feed, utils.Dict{"sys_id": "abc", "documentkey": "other"}))
+	})
+
+	t.Run("content hash fallback is stable and distinct", func(t *testing.T) {
+		feed := ServiceNowFeed{IDField: "sys_id"}
+		a1 := recordID(feed, utils.Dict{"foo": "bar"})
+		a2 := recordID(feed, utils.Dict{"foo": "bar"})
+		b := recordID(feed, utils.Dict{"foo": "baz"})
+		assert.Equal(t, a1, a2)
+		assert.NotEqual(t, a1, b)
+		assert.Contains(t, a1, "sha256:")
+	})
+}
+
+func TestResolveBaseURL(t *testing.T) {
+	assert.Equal(t, "https://example.service-now.com",
+		resolveBaseURL(ServiceNowConfig{Instance: "example"}))
+	assert.Equal(t, "https://custom.example.com",
+		resolveBaseURL(ServiceNowConfig{BaseURL: "https://custom.example.com/"}))
+	// base_url wins over instance.
+	assert.Equal(t, "https://custom.example.com",
+		resolveBaseURL(ServiceNowConfig{Instance: "example", BaseURL: "https://custom.example.com"}))
+}
+
+func TestBuildParams(t *testing.T) {
+	a := &ServiceNowAdapter{conf: ServiceNowConfig{PageSize: 50}}
+	checkpoint := time.Date(2026, 6, 11, 9, 14, 33, 0, time.UTC)
+
+	t.Run("incremental filter, order and pagination", func(t *testing.T) {
+		feed := ServiceNowFeed{Table: "sys_audit", TimestampField: "sys_created_on"}
+		params := a.buildParams(feed, checkpoint, 100)
+		assert.Equal(t, "sys_created_on>=2026-06-11 09:14:33^ORDERBYsys_created_on",
+			params.Get("sysparm_query"))
+		assert.Equal(t, "50", params.Get("sysparm_limit"))
+		assert.Equal(t, "100", params.Get("sysparm_offset"))
+		assert.Equal(t, "false", params.Get("sysparm_display_value"),
+			"database (UTC) values must be requested, not display values")
+		assert.Equal(t, "true", params.Get("sysparm_exclude_reference_link"))
+		assert.Empty(t, params.Get("sysparm_fields"))
+	})
+
+	t.Run("feed query is ANDed in front of the time filter", func(t *testing.T) {
+		feed := ServiceNowFeed{
+			Table:          "sysevent",
+			Query:          "name=login",
+			TimestampField: "sys_created_on",
+		}
+		params := a.buildParams(feed, checkpoint, 0)
+		assert.Equal(t, "name=login^sys_created_on>=2026-06-11 09:14:33^ORDERBYsys_created_on",
+			params.Get("sysparm_query"))
+	})
+
+	t.Run("fields restriction is forwarded", func(t *testing.T) {
+		feed := ServiceNowFeed{
+			Table:          "sys_audit",
+			Fields:         "sys_id,sys_created_on,fieldname",
+			TimestampField: "sys_created_on",
+		}
+		params := a.buildParams(feed, checkpoint, 0)
+		assert.Equal(t, "sys_id,sys_created_on,fieldname", params.Get("sysparm_fields"))
+	})
+}
+
+func TestParseTimestamp(t *testing.T) {
+	t.Run("table api format is parsed as UTC", func(t *testing.T) {
+		ts, ok := parseTimestamp("2026-06-11 09:14:33")
+		require.True(t, ok)
+		assert.Equal(t, time.Date(2026, 6, 11, 9, 14, 33, 0, time.UTC), ts)
+	})
+
+	for _, c := range []string{
+		"2026-06-11T09:14:33Z",
+		"2026-06-11T09:14:33.123456Z",
+	} {
+		_, ok := parseTimestamp(c)
+		assert.True(t, ok, "expected %q to parse", c)
+	}
+	_, ok := parseTimestamp("not a date")
+	assert.False(t, ok)
+}
+
+func TestHasNextLink(t *testing.T) {
+	h := http.Header{}
+	assert.False(t, hasNextLink(h))
+
+	h.Set("Link", `<https://x.service-now.com/api/now/v2/table/sys_audit?sysparm_offset=0&sysparm_limit=100>;rel="first"`)
+	assert.False(t, hasNextLink(h))
+
+	h.Set("Link", `<https://x.service-now.com/api/now/v2/table/sys_audit?sysparm_offset=100&sysparm_limit=100>;rel="next",<https://x.service-now.com/api/now/v2/table/sys_audit?sysparm_offset=400&sysparm_limit=100>;rel="last"`)
+	assert.True(t, hasNextLink(h))
+
+	h = http.Header{}
+	h.Add("Link", `<https://x/api?sysparm_offset=0>;rel="prev"`)
+	h.Add("Link", `<https://x/api?sysparm_offset=200>;rel="next"`)
+	assert.True(t, hasNextLink(h))
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	assert.Equal(t, 30*time.Second, parseRetryAfter("30"))
+	assert.Equal(t, time.Duration(0), parseRetryAfter(""))
+	assert.Equal(t, time.Duration(0), parseRetryAfter("soon"))
+	assert.Equal(t, time.Duration(0), parseRetryAfter("-5"))
+}
+
+func TestIsTransientError(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		isTransient bool
+	}{
+		{"500", &HTTPError{StatusCode: 500}, true},
+		{"503", &HTTPError{StatusCode: 503}, true},
+		{"429", &HTTPError{StatusCode: 429}, true},
+		{"401", &HTTPError{StatusCode: 401}, false},
+		{"403", &HTTPError{StatusCode: 403}, false},
+		{"404", &HTTPError{StatusCode: 404}, false},
+		{"400", &HTTPError{StatusCode: 400}, false},
+		{"network", fmt.Errorf("failed to execute request %q: connection refused", "x"), true},
+		{"context canceled", context.Canceled, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.isTransient, isTransientError(c.err))
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("requires username", func(t *testing.T) {
+		c := ServiceNowConfig{ClientOptions: testClientOptions(t), Password: "p", Instance: "example"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires password", func(t *testing.T) {
+		c := ServiceNowConfig{ClientOptions: testClientOptions(t), Username: "u", Instance: "example"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires instance or base_url", func(t *testing.T) {
+		c := ServiceNowConfig{ClientOptions: testClientOptions(t), Username: "u", Password: "p"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("applies defaults and the default feed set", func(t *testing.T) {
+		c := ServiceNowConfig{ClientOptions: testClientOptions(t), Username: "u", Password: "p", Instance: "example"}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, defaultPageSize, c.PageSize)
+		assert.Equal(t, defaultPollInterval, c.PollInterval)
+		assert.Equal(t, defaultBackfill, c.Backfill)
+
+		require.Len(t, c.Feeds, 1)
+		f := c.Feeds[0]
+		assert.Equal(t, "sys_audit", f.Name)
+		assert.Equal(t, "sys_audit", f.Table)
+		assert.Equal(t, defaultTimestampField, f.TimestampField)
+		assert.Equal(t, defaultIDField, f.IDField)
+		assert.Equal(t, defaultMaxPages, f.MaxPages)
+	})
+
+	t.Run("page size is capped at the platform maximum", func(t *testing.T) {
+		c := ServiceNowConfig{ClientOptions: testClientOptions(t), Username: "u", Password: "p", Instance: "example", PageSize: 50000}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, maxPageSize, c.PageSize)
+	})
+
+	t.Run("feed name defaults to its table", func(t *testing.T) {
+		c := ServiceNowConfig{
+			ClientOptions: testClientOptions(t), Username: "u", Password: "p", Instance: "example",
+			Feeds: []ServiceNowFeed{{Table: "syslog_transaction"}},
+		}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, "syslog_transaction", c.Feeds[0].Name)
+	})
+
+	t.Run("rejects feed without table", func(t *testing.T) {
+		c := ServiceNowConfig{
+			ClientOptions: testClientOptions(t), Username: "u", Password: "p", Instance: "example",
+			Feeds: []ServiceNowFeed{{Name: "x"}},
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("rejects duplicate feed names", func(t *testing.T) {
+		c := ServiceNowConfig{
+			ClientOptions: testClientOptions(t), Username: "u", Password: "p", Instance: "example",
+			Feeds: []ServiceNowFeed{
+				{Name: "x", Table: "sys_audit"},
+				{Name: "x", Table: "sysevent"},
+			},
+		}
+		assert.Error(t, c.Validate())
+	})
+}
+
+// --- integration tests ------------------------------------------------------
+
+// recordedRequest captures what the adapter sent on one API call.
+type recordedRequest struct {
+	path   string
+	query  url.Values
+	user   string
+	pass   string
+	method string
+}
+
+// recordingServer replies with a fixed dataset and records every request.
+type recordingServer struct {
+	mu       sync.Mutex
+	requests []recordedRequest
+	items    []map[string]interface{}
+}
+
+func (s *recordingServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user, pass, _ := r.BasicAuth()
+		s.mu.Lock()
+		s.requests = append(s.requests, recordedRequest{
+			path:   r.URL.Path,
+			query:  r.URL.Query(),
+			user:   user,
+			pass:   pass,
+			method: r.Method,
+		})
+		items := s.items
+		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resultEnvelope(items))
+	}
+}
+
+func (s *recordingServer) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.requests)
+}
+
+func (s *recordingServer) request(i int) recordedRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requests[i]
+}
+
+// TestRequestShape verifies the adapter hits the v2 Table API endpoint with
+// Basic auth and the expected query parameters.
+func TestRequestShape(t *testing.T) {
+	srv := &recordingServer{items: []map[string]interface{}{
+		auditItem("a", "2026-06-11 09:14:33"),
+	}}
+	server := httptest.NewServer(srv.handler())
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: testClientOptions(t),
+		Username:      "lc.collector",
+		Password:      "s3cret",
+		BaseURL:       server.URL,
+		PollInterval:  200 * time.Millisecond,
+		Feeds:         auditFeed(),
+	}
+	adapter, chStopped, err := NewServiceNowAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return srv.count() >= 1 },
+		3*time.Second, 20*time.Millisecond, "adapter never called the API")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped unexpectedly")
+	default:
+	}
+
+	req := srv.request(0)
+	assert.Equal(t, http.MethodGet, req.method)
+	assert.Equal(t, "/api/now/v2/table/sys_audit", req.path)
+	assert.Equal(t, "lc.collector", req.user)
+	assert.Equal(t, "s3cret", req.pass)
+	assert.Equal(t, strconv.Itoa(defaultPageSize), req.query.Get("sysparm_limit"))
+	assert.Equal(t, "0", req.query.Get("sysparm_offset"))
+	assert.Equal(t, "false", req.query.Get("sysparm_display_value"))
+	assert.Equal(t, "true", req.query.Get("sysparm_exclude_reference_link"))
+
+	q := req.query.Get("sysparm_query")
+	assert.Contains(t, q, "sys_created_on>=")
+	assert.True(t, strings.HasSuffix(q, "^ORDERBYsys_created_on"),
+		"records must be requested oldest-first for checkpointing, got %q", q)
+}
+
+// TestCheckpointAdvances verifies the incremental filter moves forward to the
+// newest record seen, and that a poll returning nothing leaves it unchanged.
+func TestCheckpointAdvances(t *testing.T) {
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	newest := base.Add(2 * time.Second).Format(serviceNowTimeLayout)
+	srv := &recordingServer{items: []map[string]interface{}{
+		auditItem("a", base.Format(serviceNowTimeLayout)),
+		auditItem("b", newest),
+	}}
+	server := httptest.NewServer(srv.handler())
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: testClientOptions(t),
+		Username:      "u",
+		Password:      "p",
+		BaseURL:       server.URL,
+		Backfill:      2 * time.Hour,
+		PollInterval:  40 * time.Millisecond,
+		Feeds:         auditFeed(),
+	}
+	adapter, _, err := NewServiceNowAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return srv.count() >= 3 },
+		5*time.Second, 20*time.Millisecond)
+	require.NoError(t, adapter.Close())
+
+	// Poll 1 starts from the backfill checkpoint; every later poll must
+	// filter from the newest record's timestamp, inclusively.
+	for i := 1; i < 3; i++ {
+		q := srv.request(i).query.Get("sysparm_query")
+		assert.Equal(t, fmt.Sprintf("sys_created_on>=%s^ORDERBYsys_created_on", newest), q,
+			"poll %d should resume from the newest seen record", i)
+	}
+}
+
+// TestMaxPagesCapResumes verifies a poll stops at max_pages and that the next
+// poll resumes from the advanced checkpoint instead of starting over.
+func TestMaxPagesCapResumes(t *testing.T) {
+	const pageSize = 2
+
+	var mu sync.Mutex
+	var requests []url.Values
+	// Records are stamped just ahead of the initial checkpoint so the
+	// checkpoint tracks the newest record served, on any day this test runs.
+	base := time.Now().UTC().Truncate(time.Second)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.URL.Query())
+		n := len(requests)
+		mu.Unlock()
+
+		// Always serve a full page of ever-newer records and advertise more,
+		// so only max_pages can end a poll's walk.
+		items := []map[string]interface{}{
+			auditItem(fmt.Sprintf("rec-%d-1", n), base.Add(time.Duration(2*n)*time.Second).Format(serviceNowTimeLayout)),
+			auditItem(fmt.Sprintf("rec-%d-2", n), base.Add(time.Duration(2*n+1)*time.Second).Format(serviceNowTimeLayout)),
+		}
+		w.Header().Set("Link", fmt.Sprintf(`<%s>;rel="next"`, r.URL.String()))
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resultEnvelope(items))
+	}))
+	defer server.Close()
+
+	var maxPagesWarned atomic.Bool
+	opts := testClientOptions(t)
+	opts.OnWarning = func(msg string) {
+		t.Logf("WRN: %s", msg)
+		if strings.Contains(msg, "max_pages") {
+			maxPagesWarned.Store(true)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: opts,
+		Username:      "u",
+		Password:      "p",
+		BaseURL:       server.URL,
+		PageSize:      pageSize,
+		PollInterval:  60 * time.Millisecond,
+		Feeds: []ServiceNowFeed{
+			{Name: "capped", Table: "sys_audit", MaxPages: 3},
+		},
+	}
+	adapter, _, err := NewServiceNowAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, maxPagesWarned.Load, 5*time.Second, 20*time.Millisecond,
+		"adapter should warn when max_pages is reached")
+	// Wait for the second poll to start.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(requests) >= 4
+	}, 5*time.Second, 20*time.Millisecond)
+	require.NoError(t, adapter.Close())
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Poll 1 is exactly 3 pages (max_pages) at offsets 0, 2, 4.
+	for i := 0; i < 3; i++ {
+		assert.Equal(t, strconv.Itoa(i*pageSize), requests[i].Get("sysparm_offset"),
+			"request %d offset", i)
+	}
+
+	// Poll 2 restarts pagination but from an advanced checkpoint: the newest
+	// timestamp served during poll 1 (request 3 carried base+7s).
+	assert.Equal(t, "0", requests[3].Get("sysparm_offset"), "a new poll restarts offsets")
+	wantCheckpoint := base.Add(7 * time.Second).Format(serviceNowTimeLayout)
+	assert.Equal(t,
+		fmt.Sprintf("sys_created_on>=%s^ORDERBYsys_created_on", wantCheckpoint),
+		requests[3].Get("sysparm_query"),
+		"the capped poll must advance the checkpoint to the last record processed")
+}
+
+// TestTransientErrorRetry verifies the adapter retries 5xx responses rather
+// than terminating, and that the failed poll does not advance the checkpoint.
+func TestTransientErrorRetry(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestCount.Add(1) <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"message":"internal error","detail":null},"status":"failure"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":[]}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions:  testClientOptions(t),
+		Username:       "u",
+		Password:       "p",
+		BaseURL:        server.URL,
+		PollInterval:   100 * time.Millisecond,
+		RetryBaseDelay: 20 * time.Millisecond,
+		MaxRetryDelay:  40 * time.Millisecond,
+		Feeds:          auditFeed(),
+	}
+	adapter, chStopped, err := NewServiceNowAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped on a transient error - it should have retried")
+	default:
+	}
+	assert.GreaterOrEqual(t, requestCount.Load(), int32(3), "expected retries then success")
+	assert.False(t, adapter.doStop.IsSet())
+}
+
+// TestPermanentAuthErrorStops verifies a 401/403 stops the whole adapter.
+func TestPermanentAuthErrorStops(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"error":{"message":"Insufficient rights","detail":null},"status":"failure"}`))
+			}))
+			defer server.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			conf := ServiceNowConfig{
+				ClientOptions: testClientOptions(t),
+				Username:      "u",
+				Password:      "bad",
+				BaseURL:       server.URL,
+				PollInterval:  100 * time.Millisecond,
+				Feeds:         auditFeed(),
+			}
+			adapter, chStopped, err := NewServiceNowAdapter(ctx, conf)
+			require.NoError(t, err)
+			defer adapter.Close()
+
+			select {
+			case <-chStopped:
+				// Expected: an auth failure terminates the adapter.
+			case <-time.After(3 * time.Second):
+				t.Fatalf("adapter should have stopped on HTTP %d", status)
+			}
+			assert.True(t, adapter.doStop.IsSet())
+		})
+	}
+}
+
+// TestRetryAfterIsHonored verifies a 429's Retry-After delay is respected
+// (the second attempt does not fire before the requested delay elapses).
+func TestRetryAfterIsHonored(t *testing.T) {
+	var mu sync.Mutex
+	var times []time.Time
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		times = append(times, time.Now())
+		n := len(times)
+		mu.Unlock()
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"message":"Rate limit exceeded","detail":null},"status":"failure"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":[]}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions:  testClientOptions(t),
+		Username:       "u",
+		Password:       "p",
+		BaseURL:        server.URL,
+		PollInterval:   1 * time.Hour, // only the initial poll runs during the test
+		RetryBaseDelay: 10 * time.Millisecond,
+		MaxRetryDelay:  20 * time.Millisecond,
+		Feeds:          auditFeed(),
+	}
+	adapter, _, err := NewServiceNowAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(times) >= 2
+	}, 5*time.Second, 20*time.Millisecond, "expected a retry after the 429")
+
+	mu.Lock()
+	defer mu.Unlock()
+	gap := times[1].Sub(times[0])
+	assert.GreaterOrEqual(t, gap, 1*time.Second,
+		"the retry must wait at least the Retry-After delay, waited %v", gap)
+}

--- a/servicenow/client_test.go
+++ b/servicenow/client_test.go
@@ -87,6 +87,27 @@ func TestExtractResult(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("null result is an empty page", func(t *testing.T) {
+		items, err := extractResult([]byte(`{"result": null}`))
+		require.NoError(t, err)
+		assert.Empty(t, items)
+	})
+
+	t.Run("result substring in a value does not mask a missing key", func(t *testing.T) {
+		_, err := extractResult([]byte(`{"error":{"message":"no result for query","detail":"\"result\""},"status":"failure"}`))
+		assert.Error(t, err)
+	})
+
+	t.Run("nested result key is not the envelope", func(t *testing.T) {
+		_, err := extractResult([]byte(`{"data":{"result":[{"sys_id":"a"}]}}`))
+		assert.Error(t, err)
+	})
+
+	t.Run("non-array result errors", func(t *testing.T) {
+		_, err := extractResult([]byte(`{"result":{"sys_id":"a"}}`))
+		assert.Error(t, err)
+	})
+
 	t.Run("empty body yields no items", func(t *testing.T) {
 		items, err := extractResult([]byte("   "))
 		require.NoError(t, err)
@@ -150,7 +171,7 @@ func TestBuildParams(t *testing.T) {
 	t.Run("incremental filter, order and pagination", func(t *testing.T) {
 		feed := ServiceNowFeed{Table: "sys_audit", TimestampField: "sys_created_on"}
 		params := a.buildParams(feed, checkpoint, 100)
-		assert.Equal(t, "sys_created_on>=2026-06-11 09:14:33^ORDERBYsys_created_on",
+		assert.Equal(t, "sys_created_on>=2026-06-11 09:14:33^ORDERBYsys_created_on^ORDERBYsys_id",
 			params.Get("sysparm_query"))
 		assert.Equal(t, "50", params.Get("sysparm_limit"))
 		assert.Equal(t, "100", params.Get("sysparm_offset"))
@@ -167,8 +188,15 @@ func TestBuildParams(t *testing.T) {
 			TimestampField: "sys_created_on",
 		}
 		params := a.buildParams(feed, checkpoint, 0)
-		assert.Equal(t, "name=login^sys_created_on>=2026-06-11 09:14:33^ORDERBYsys_created_on",
+		assert.Equal(t, "name=login^sys_created_on>=2026-06-11 09:14:33^ORDERBYsys_created_on^ORDERBYsys_id",
 			params.Get("sysparm_query"))
+	})
+
+	t.Run("id field is the pagination tiebreaker", func(t *testing.T) {
+		feed := ServiceNowFeed{Table: "sysevent", TimestampField: "sys_created_on", IDField: "uniq"}
+		params := a.buildParams(feed, checkpoint, 0)
+		assert.True(t, strings.HasSuffix(params.Get("sysparm_query"), "^ORDERBYsys_created_on^ORDERBYuniq"),
+			"got %q", params.Get("sysparm_query"))
 	})
 
 	t.Run("fields restriction is forwarded", func(t *testing.T) {
@@ -269,6 +297,7 @@ func TestValidate(t *testing.T) {
 		assert.Equal(t, defaultPageSize, c.PageSize)
 		assert.Equal(t, defaultPollInterval, c.PollInterval)
 		assert.Equal(t, defaultBackfill, c.Backfill)
+		assert.Equal(t, defaultCheckpointLag, c.CheckpointLag)
 
 		require.Len(t, c.Feeds, 1)
 		f := c.Feeds[0]
@@ -300,6 +329,28 @@ func TestValidate(t *testing.T) {
 			Feeds: []ServiceNowFeed{{Name: "x"}},
 		}
 		assert.Error(t, c.Validate())
+	})
+
+	t.Run("rejects a fields list missing the timestamp or id column", func(t *testing.T) {
+		for _, fields := range []string{
+			"tablename,fieldname,newvalue", // missing both
+			"sys_id,tablename",             // missing timestamp
+			"sys_created_on,tablename",     // missing id
+		} {
+			c := ServiceNowConfig{
+				ClientOptions: testClientOptions(t), Username: "u", Password: "p", Instance: "example",
+				Feeds: []ServiceNowFeed{{Table: "sys_audit", Fields: fields}},
+			}
+			assert.Error(t, c.Validate(), "fields=%q must be rejected", fields)
+		}
+	})
+
+	t.Run("accepts a fields list carrying the timestamp and id columns", func(t *testing.T) {
+		c := ServiceNowConfig{
+			ClientOptions: testClientOptions(t), Username: "u", Password: "p", Instance: "example",
+			Feeds: []ServiceNowFeed{{Table: "sys_audit", Fields: "sys_id, sys_created_on, tablename"}},
+		}
+		assert.NoError(t, c.Validate())
 	})
 
 	t.Run("rejects duplicate feed names", func(t *testing.T) {
@@ -408,18 +459,37 @@ func TestRequestShape(t *testing.T) {
 
 	q := req.query.Get("sysparm_query")
 	assert.Contains(t, q, "sys_created_on>=")
-	assert.True(t, strings.HasSuffix(q, "^ORDERBYsys_created_on"),
-		"records must be requested oldest-first for checkpointing, got %q", q)
+	assert.True(t, strings.HasSuffix(q, "^ORDERBYsys_created_on^ORDERBYsys_id"),
+		"records must be requested oldest-first with an id tiebreaker, got %q", q)
 }
 
-// TestCheckpointAdvances verifies the incremental filter moves forward to the
-// newest record seen, and that a poll returning nothing leaves it unchanged.
+// queryCheckpoint extracts and parses the checkpoint timestamp from a
+// captured sysparm_query.
+func queryCheckpoint(t *testing.T, q string) time.Time {
+	t.Helper()
+	start := strings.Index(q, "sys_created_on>=")
+	require.GreaterOrEqual(t, start, 0, "no checkpoint filter in %q", q)
+	rest := q[start+len("sys_created_on>="):]
+	end := strings.Index(rest, "^")
+	require.Greater(t, end, 0, "unterminated checkpoint filter in %q", q)
+	ts, err := time.Parse(serviceNowTimeLayout, rest[:end])
+	require.NoError(t, err, "unparseable checkpoint in %q", q)
+	return ts
+}
+
+// TestCheckpointAdvances verifies a completed poll advances the incremental
+// filter to now-CheckpointLag: past every record already collected (so an
+// idle feed stops re-reading its boundary forever) but no further than the
+// lag allows (so late-visible records are still caught).
 func TestCheckpointAdvances(t *testing.T) {
-	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
-	newest := base.Add(2 * time.Second).Format(serviceNowTimeLayout)
+	const lag = 30 * time.Minute
+
+	testStart := time.Now().UTC()
+	base := testStart.Add(-time.Hour).Truncate(time.Second)
+	newest := base.Add(2 * time.Second)
 	srv := &recordingServer{items: []map[string]interface{}{
 		auditItem("a", base.Format(serviceNowTimeLayout)),
-		auditItem("b", newest),
+		auditItem("b", newest.Format(serviceNowTimeLayout)),
 	}}
 	server := httptest.NewServer(srv.handler())
 	defer server.Close()
@@ -433,6 +503,7 @@ func TestCheckpointAdvances(t *testing.T) {
 		Password:      "p",
 		BaseURL:       server.URL,
 		Backfill:      2 * time.Hour,
+		CheckpointLag: lag,
 		PollInterval:  40 * time.Millisecond,
 		Feeds:         auditFeed(),
 	}
@@ -444,12 +515,19 @@ func TestCheckpointAdvances(t *testing.T) {
 		5*time.Second, 20*time.Millisecond)
 	require.NoError(t, adapter.Close())
 
-	// Poll 1 starts from the backfill checkpoint; every later poll must
-	// filter from the newest record's timestamp, inclusively.
+	// Poll 1 starts from the backfill checkpoint.
+	cp0 := queryCheckpoint(t, srv.request(0).query.Get("sysparm_query"))
+	assert.True(t, cp0.Before(base), "poll 1 must start from the backfill checkpoint, got %v", cp0)
+
+	// Later polls run from an advanced checkpoint: past the records already
+	// collected (records are an hour old, far older than the lag), but
+	// trailing the clock by at least CheckpointLag.
 	for i := 1; i < 3; i++ {
-		q := srv.request(i).query.Get("sysparm_query")
-		assert.Equal(t, fmt.Sprintf("sys_created_on>=%s^ORDERBYsys_created_on", newest), q,
-			"poll %d should resume from the newest seen record", i)
+		cp := queryCheckpoint(t, srv.request(i).query.Get("sysparm_query"))
+		assert.True(t, cp.After(newest),
+			"poll %d should have advanced past the collected records, got %v", i, cp)
+		assert.False(t, cp.After(time.Now().UTC().Add(-lag).Add(2*time.Second)),
+			"poll %d checkpoint %v must trail the clock by ~CheckpointLag", i, cp)
 	}
 }
 
@@ -460,9 +538,10 @@ func TestMaxPagesCapResumes(t *testing.T) {
 
 	var mu sync.Mutex
 	var requests []url.Values
-	// Records are stamped just ahead of the initial checkpoint so the
-	// checkpoint tracks the newest record served, on any day this test runs.
-	base := time.Now().UTC().Truncate(time.Second)
+	// Records are an hour old: newer than the 2h backfill checkpoint but
+	// older than now-CheckpointLag, so a capped poll resumes from the newest
+	// record processed (not from the lagged clock), on any day this test runs.
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
@@ -499,6 +578,8 @@ func TestMaxPagesCapResumes(t *testing.T) {
 		Username:      "u",
 		Password:      "p",
 		BaseURL:       server.URL,
+		Backfill:      2 * time.Hour,
+		CheckpointLag: 1 * time.Minute,
 		PageSize:      pageSize,
 		PollInterval:  60 * time.Millisecond,
 		Feeds: []ServiceNowFeed{
@@ -533,9 +614,59 @@ func TestMaxPagesCapResumes(t *testing.T) {
 	assert.Equal(t, "0", requests[3].Get("sysparm_offset"), "a new poll restarts offsets")
 	wantCheckpoint := base.Add(7 * time.Second).Format(serviceNowTimeLayout)
 	assert.Equal(t,
-		fmt.Sprintf("sys_created_on>=%s^ORDERBYsys_created_on", wantCheckpoint),
+		fmt.Sprintf("sys_created_on>=%s^ORDERBYsys_created_on^ORDERBYsys_id", wantCheckpoint),
 		requests[3].Get("sysparm_query"),
 		"the capped poll must advance the checkpoint to the last record processed")
+}
+
+// TestMaxPagesStuckWarns verifies the distinct loud warning when a capped
+// poll cannot advance the checkpoint at all (more than max_pages*page_size
+// records share one timestamp), instead of the misleading "will be collected
+// next poll" message.
+func TestMaxPagesStuckWarns(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Full pages of records all older than the initial checkpoint (the
+		// mock ignores the filter), so maxSeen never moves; Link always
+		// advertises more.
+		items := []map[string]interface{}{
+			auditItem("a", "2000-01-01 00:00:01"),
+			auditItem("b", "2000-01-01 00:00:01"),
+		}
+		w.Header().Set("Link", fmt.Sprintf(`<%s>;rel="next"`, r.URL.String()))
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resultEnvelope(items))
+	}))
+	defer server.Close()
+
+	var stuckWarned atomic.Bool
+	opts := testClientOptions(t)
+	opts.OnWarning = func(msg string) {
+		t.Logf("WRN: %s", msg)
+		if strings.Contains(msg, "without being able to advance") {
+			stuckWarned.Store(true)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: opts,
+		Username:      "u",
+		Password:      "p",
+		BaseURL:       server.URL,
+		PageSize:      2,
+		PollInterval:  1 * time.Hour, // only the initial poll runs during the test
+		Feeds: []ServiceNowFeed{
+			{Name: "stuck", Table: "sys_audit", MaxPages: 2},
+		},
+	}
+	adapter, _, err := NewServiceNowAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, stuckWarned.Load, 5*time.Second, 20*time.Millisecond,
+		"adapter should warn loudly when the checkpoint cannot advance at the cap")
 }
 
 // TestTransientErrorRetry verifies the adapter retries 5xx responses rather
@@ -581,40 +712,78 @@ func TestTransientErrorRetry(t *testing.T) {
 	assert.False(t, adapter.doStop.IsSet())
 }
 
-// TestPermanentAuthErrorStops verifies a 401/403 stops the whole adapter.
-func TestPermanentAuthErrorStops(t *testing.T) {
-	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(`{"error":{"message":"Insufficient rights","detail":null},"status":"failure"}`))
-			}))
-			defer server.Close()
+// TestUnauthorizedStops verifies rejected credentials (HTTP 401) stop the
+// whole adapter.
+func TestUnauthorizedStops(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"User Not Authenticated","detail":null},"status":"failure"}`))
+	}))
+	defer server.Close()
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
-			conf := ServiceNowConfig{
-				ClientOptions: testClientOptions(t),
-				Username:      "u",
-				Password:      "bad",
-				BaseURL:       server.URL,
-				PollInterval:  100 * time.Millisecond,
-				Feeds:         auditFeed(),
-			}
-			adapter, chStopped, err := NewServiceNowAdapter(ctx, conf)
-			require.NoError(t, err)
-			defer adapter.Close()
-
-			select {
-			case <-chStopped:
-				// Expected: an auth failure terminates the adapter.
-			case <-time.After(3 * time.Second):
-				t.Fatalf("adapter should have stopped on HTTP %d", status)
-			}
-			assert.True(t, adapter.doStop.IsSet())
-		})
+	conf := ServiceNowConfig{
+		ClientOptions: testClientOptions(t),
+		Username:      "u",
+		Password:      "bad",
+		BaseURL:       server.URL,
+		PollInterval:  100 * time.Millisecond,
+		Feeds:         auditFeed(),
 	}
+	adapter, chStopped, err := NewServiceNowAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	select {
+	case <-chStopped:
+		// Expected: rejected credentials terminate the adapter.
+	case <-time.After(3 * time.Second):
+		t.Fatal("adapter should have stopped on HTTP 401")
+	}
+	assert.True(t, adapter.doStop.IsSet())
+}
+
+// TestForbiddenKeepsAdapterAlive verifies a 403 -- ServiceNow's per-table ACL
+// denial -- does not stop the adapter: the feed ships nothing but keeps
+// retrying on the poll interval (the ACL may be fixed live, and other feeds
+// must not be killed by one table's missing role).
+func TestForbiddenKeepsAdapterAlive(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"message":"Insufficient rights to query records","detail":null},"status":"failure"}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: testClientOptions(t),
+		Username:      "u",
+		Password:      "p",
+		BaseURL:       server.URL,
+		PollInterval:  50 * time.Millisecond,
+		Feeds:         auditFeed(),
+	}
+	adapter, chStopped, err := NewServiceNowAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The feed must keep polling across intervals (one request per poll: the
+	// 403 is permanent, not retried within a poll).
+	require.Eventually(t, func() bool { return requestCount.Load() >= 3 },
+		5*time.Second, 20*time.Millisecond, "the feed should keep retrying every poll_interval")
+
+	select {
+	case <-chStopped:
+		t.Fatal("a per-table 403 must not stop the adapter")
+	default:
+	}
+	assert.False(t, adapter.doStop.IsSet())
 }
 
 // TestRetryAfterIsHonored verifies a 429's Retry-After delay is respected

--- a/servicenow/mock_test.go
+++ b/servicenow/mock_test.go
@@ -1,0 +1,627 @@
+package usp_servicenow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock ServiceNow REST
+// Table API, capturing the exact messages it ships so their content -- event
+// type, timestamp and verbatim payload -- can be asserted.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock ServiceNow Table API ------------------------------------------------
+
+// mockServiceNow is an in-memory stand-in for the ServiceNow REST Table API.
+// It honours the Table API contract the adapter relies on:
+//
+//   - GET /api/now/v2/table/{tableName} with HTTP Basic authentication;
+//   - sysparm_query with "^"-joined conditions: "field=value" equality,
+//     "field>=value" comparison (chronological for the fixed-width
+//     "yyyy-MM-dd HH:mm:ss" format), and an ORDERBY<field> clause;
+//   - sysparm_offset / sysparm_limit pagination over the *matching* set;
+//   - a {"result": [...]} envelope, an X-Total-Count header, and a Link
+//     rel="next" header whenever more matching records remain;
+//   - like the real API, ACL filtering (the aclHidden set) is applied *after*
+//     sysparm_limit slicing, so a page can come back short -- or empty --
+//     while the Link header still advertises a next page.
+type mockServiceNow struct {
+	mu        sync.Mutex
+	username  string
+	password  string
+	tables    map[string][]utils.Dict // table name -> records
+	aclHidden map[string]bool         // sys_ids removed from pages post-pagination
+	requests  int
+}
+
+func newMockServiceNow(username, password string) *mockServiceNow {
+	return &mockServiceNow{
+		username:  username,
+		password:  password,
+		tables:    map[string][]utils.Dict{},
+		aclHidden: map[string]bool{},
+	}
+}
+
+func (m *mockServiceNow) setTable(table string, records []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tables[table] = records
+}
+
+// appendRecord adds a record to a table, as the real platform would when a
+// new audit row is inserted.
+func (m *mockServiceNow) appendRecord(table string, record utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tables[table] = append(m.tables[table], record)
+}
+
+func (m *mockServiceNow) hideFromACL(sysID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.aclHidden[sysID] = true
+}
+
+func (m *mockServiceNow) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+// queryCondition is one parsed "^"-separated element of a sysparm_query.
+type queryCondition struct {
+	field string
+	op    string // "=" or ">="
+	value string
+}
+
+// parseEncodedQuery splits a sysparm_query into its conditions and its
+// ORDERBY field.
+func parseEncodedQuery(q string) (conds []queryCondition, orderBy string) {
+	for _, part := range strings.Split(q, "^") {
+		if part == "" {
+			continue
+		}
+		if f, ok := strings.CutPrefix(part, "ORDERBY"); ok {
+			orderBy = f
+			continue
+		}
+		if i := strings.Index(part, ">="); i > 0 {
+			conds = append(conds, queryCondition{field: part[:i], op: ">=", value: part[i+2:]})
+			continue
+		}
+		if i := strings.Index(part, "="); i > 0 {
+			conds = append(conds, queryCondition{field: part[:i], op: "=", value: part[i+1:]})
+		}
+	}
+	return conds, orderBy
+}
+
+func matchesConditions(record utils.Dict, conds []queryCondition) bool {
+	for _, c := range conds {
+		v := record.FindOneString(c.field)
+		switch c.op {
+		case "=":
+			if v != c.value {
+				return false
+			}
+		case ">=":
+			// Lexicographic comparison is chronological for the fixed-width
+			// "yyyy-MM-dd HH:mm:ss" format, which is how the real platform
+			// compares date/time values too.
+			if v < c.value {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (m *mockServiceNow) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.requests++
+		m.mu.Unlock()
+
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// The Table API authenticates with HTTP Basic auth. The error
+		// envelope mirrors the platform's.
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != m.username || pass != m.password {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"message":"User Not Authenticated","detail":"Required to provide Auth information"},"status":"failure"}`))
+			return
+		}
+
+		table, ok := strings.CutPrefix(r.URL.Path, "/api/now/v2/table/")
+		if !ok || table == "" || strings.Contains(table, "/") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"Invalid table","detail":null},"status":"failure"}`))
+			return
+		}
+
+		q := r.URL.Query()
+		conds, orderBy := parseEncodedQuery(q.Get("sysparm_query"))
+		limit := 10000 // the platform's documented default sysparm_limit
+		if v, err := strconv.Atoi(q.Get("sysparm_limit")); err == nil && v > 0 {
+			limit = v
+		}
+		offset := 0
+		if v, err := strconv.Atoi(q.Get("sysparm_offset")); err == nil && v > 0 {
+			offset = v
+		}
+
+		m.mu.Lock()
+		records := m.tables[table]
+		matching := make([]utils.Dict, 0, len(records))
+		for _, rec := range records {
+			if matchesConditions(rec, conds) {
+				matching = append(matching, rec)
+			}
+		}
+		hidden := make(map[string]bool, len(m.aclHidden))
+		for k, v := range m.aclHidden {
+			hidden[k] = v
+		}
+		m.mu.Unlock()
+
+		if orderBy != "" {
+			sort.SliceStable(matching, func(i, j int) bool {
+				return matching[i].FindOneString(orderBy) < matching[j].FindOneString(orderBy)
+			})
+		}
+
+		total := len(matching)
+
+		// Slice the page by offset/limit *before* ACL filtering, exactly like
+		// the real platform ("This limit is applied before ACL evaluation").
+		var page []utils.Dict
+		if offset < total {
+			end := offset + limit
+			if end > total {
+				end = total
+			}
+			page = matching[offset:end]
+		}
+		visible := make([]utils.Dict, 0, len(page))
+		for _, rec := range page {
+			if !hidden[rec.FindOneString("sys_id")] {
+				visible = append(visible, rec)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", strconv.Itoa(total))
+		if offset+limit < total {
+			next := *r.URL
+			nq := next.Query()
+			nq.Set("sysparm_offset", strconv.Itoa(offset+limit))
+			next.RawQuery = nq.Encode()
+			w.Header().Set("Link", fmt.Sprintf(`<%s>;rel="next"`, next.String()))
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"result": visible})
+	}
+}
+
+// --- realistic record fixtures ------------------------------------------------
+
+// snTime renders a time in the Table API's "yyyy-MM-dd HH:mm:ss" UTC format.
+func snTime(t time.Time) string {
+	return t.UTC().Format(serviceNowTimeLayout)
+}
+
+// realisticSysAudit returns a record shaped like a real sys_audit row as the
+// Table API returns it: the documented audit columns, every value a plain
+// string (sys_audit has no reference-link objects), UTC timestamps.
+func realisticSysAudit(n int, createdOn string) utils.Dict {
+	return utils.Dict{
+		"sys_id":              fmt.Sprintf("b1c3d2e4f5a601001a2b3c4d5e6f%04x", n),
+		"tablename":           "incident",
+		"fieldname":           "assigned_to",
+		"documentkey":         "9d385017c611228701d22104cc95c371",
+		"user":                "jane.doe",
+		"oldvalue":            "46d44a5dc0a8010e0000c8b06e0b1971",
+		"newvalue":            "5137153cc611227c000bbd1bd8cd2007",
+		"reason":              "",
+		"record_checkpoint":   "7",
+		"internal_checkpoint": "",
+		"sys_created_on":      createdOn,
+		"sys_created_by":      "jane.doe",
+	}
+}
+
+// realisticSysEvent returns a record shaped like a sysevent (event log) row
+// for a login event.
+func realisticSysEvent(n int, name, createdOn string) utils.Dict {
+	return utils.Dict{
+		"sys_id":         fmt.Sprintf("e9f8a7b6c5d401001a2b3c4d5e6f%04x", n),
+		"name":           name,
+		"parm1":          "jane.doe",
+		"parm2":          "203.0.113.10",
+		"table":          "sys_user",
+		"instance":       "",
+		"state":          "processed",
+		"process_on":     createdOn,
+		"processed":      createdOn,
+		"queue":          "",
+		"uri":            "/login.do",
+		"sys_created_on": createdOn,
+		"sys_created_by": "system",
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestMockSysAuditEndToEnd drives the adapter against the mock API and asserts
+// the exact events shipped: event type, timestamp parsed from the record's
+// sys_created_on, and the payload preserved verbatim.
+func TestMockSysAuditEndToEnd(t *testing.T) {
+	mock := newMockServiceNow("lc.collector", "s3cret")
+	base := time.Now().UTC().Add(-time.Hour)
+	want := []utils.Dict{
+		realisticSysAudit(1, snTime(base)),
+		realisticSysAudit(2, snTime(base.Add(1*time.Second))),
+		realisticSysAudit(3, snTime(base.Add(2*time.Second))),
+	}
+	mock.setTable("sys_audit", want)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: testClientOptions(t),
+		Username:      "lc.collector",
+		Password:      "s3cret",
+		BaseURL:       server.URL,
+		Backfill:      2 * time.Hour,
+		PollInterval:  40 * time.Millisecond,
+	}
+	adapter, _, err := newServiceNowAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 audit records to ship")
+
+	// Re-polling must not re-ship: the count stays at 3.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "records were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		assert.Equal(t, "sys_audit", msg.EventType)
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["sys_id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	for _, src := range want {
+		id := src["sys_id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "record %s was not shipped", id)
+
+		// The event timestamp is parsed from sys_created_on, as UTC.
+		ts, perr := time.Parse(serviceNowTimeLayout, src["sys_created_on"].(string))
+		require.NoError(t, perr)
+		assert.Equal(t, uint64(ts.UnixMilli()), msg.TimestampMs,
+			"event time should come from the record's sys_created_on")
+
+		// The payload is shipped verbatim.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original ServiceNow record")
+	}
+}
+
+// TestMockNewRecordShippedOnce verifies a record inserted mid-run is shipped
+// exactly once, and already-shipped records are never re-sent even though the
+// inclusive checkpoint re-reads the boundary.
+func TestMockNewRecordShippedOnce(t *testing.T) {
+	mock := newMockServiceNow("u", "p")
+	base := time.Now().UTC().Add(-time.Hour)
+	mock.setTable("sys_audit", []utils.Dict{
+		realisticSysAudit(1, snTime(base)),
+		realisticSysAudit(2, snTime(base.Add(1*time.Second))),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: testClientOptions(t),
+		Username:      "u",
+		Password:      "p",
+		BaseURL:       server.URL,
+		Backfill:      2 * time.Hour,
+		PollInterval:  30 * time.Millisecond,
+	}
+	adapter, _, err := newServiceNowAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new audit row is inserted, newer than everything shipped so far.
+	mock.appendRecord("sys_audit", realisticSysAudit(3, snTime(time.Now().UTC())))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new record should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["sys_id"].(string)]++
+	}
+	for id, n := range shippedPerID {
+		assert.Equal(t, 1, n, "record %s must ship exactly once", id)
+	}
+	assert.Len(t, shippedPerID, 3)
+}
+
+// TestMockPaginationFullDataset verifies a dataset larger than one page is
+// walked completely -- following the Link rel="next" header -- and every
+// record is shipped exactly once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const total = 250
+
+	mock := newMockServiceNow("u", "p")
+	base := time.Now().UTC().Add(-time.Hour)
+	records := make([]utils.Dict, total)
+	for i := 0; i < total; i++ {
+		records[i] = realisticSysAudit(i, snTime(base.Add(time.Duration(i)*time.Second)))
+	}
+	mock.setTable("sys_audit", records)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: testClientOptions(t),
+		Username:      "u",
+		Password:      "p",
+		BaseURL:       server.URL,
+		Backfill:      2 * time.Hour,
+		PageSize:      100, // 250 records => 3 pages
+		PollInterval:  50 * time.Millisecond,
+	}
+	adapter, _, err := newServiceNowAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 25*time.Millisecond, "all paginated records should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["sys_id"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct record should be shipped once")
+}
+
+// TestMockACLShortPageStillWalks reproduces the Table API's documented
+// behaviour of applying sysparm_limit *before* ACL evaluation: the first page
+// comes back shorter than the page size (ACL-hidden rows removed) while the
+// Link header still advertises a next page. The adapter must keep walking and
+// ship every visible record.
+func TestMockACLShortPageStillWalks(t *testing.T) {
+	const total = 20
+
+	mock := newMockServiceNow("u", "p")
+	base := time.Now().UTC().Add(-time.Hour)
+	records := make([]utils.Dict, total)
+	for i := 0; i < total; i++ {
+		records[i] = realisticSysAudit(i, snTime(base.Add(time.Duration(i)*time.Second)))
+	}
+	mock.setTable("sys_audit", records)
+	// Hide most of page 1 (records 0..9): it comes back with 2 visible rows
+	// -- far short of the page size -- but more data exists on page 2.
+	for i := 0; i < 8; i++ {
+		mock.hideFromACL(records[i].FindOneString("sys_id"))
+	}
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: testClientOptions(t),
+		Username:      "u",
+		Password:      "p",
+		BaseURL:       server.URL,
+		Backfill:      2 * time.Hour,
+		PageSize:      10, // 20 records => 2 pages
+		PollInterval:  40 * time.Millisecond,
+	}
+	adapter, _, err := newServiceNowAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// 20 records minus 8 ACL-hidden ones = 12 visible records, 10 of which
+	// sit on page 2 -- only reachable if a short page does not end the walk.
+	require.Eventually(t, func() bool { return sink.count() == 12 },
+		5*time.Second, 20*time.Millisecond,
+		"a short (ACL-filtered) page must not end the walk while Link advertises more")
+	require.Never(t, func() bool { return sink.count() != 12 },
+		300*time.Millisecond, 30*time.Millisecond)
+}
+
+// TestMockMultipleFeeds verifies that several feeds collect concurrently,
+// each event is tagged with its feed's name, and a feed's encoded-query
+// filter is applied.
+func TestMockMultipleFeeds(t *testing.T) {
+	mock := newMockServiceNow("u", "p")
+	base := time.Now().UTC().Add(-time.Hour)
+	mock.setTable("sys_audit", []utils.Dict{
+		realisticSysAudit(1, snTime(base)),
+		realisticSysAudit(2, snTime(base.Add(1*time.Second))),
+	})
+	mock.setTable("sysevent", []utils.Dict{
+		realisticSysEvent(1, "login", snTime(base)),
+		realisticSysEvent(2, "login.failed", snTime(base.Add(1*time.Second))),
+		realisticSysEvent(3, "login", snTime(base.Add(2*time.Second))),
+		// Filtered out by the feed's query: not a login event.
+		realisticSysEvent(4, "metric.update", snTime(base.Add(3*time.Second))),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: testClientOptions(t),
+		Username:      "u",
+		Password:      "p",
+		BaseURL:       server.URL,
+		Backfill:      2 * time.Hour,
+		PollInterval:  40 * time.Millisecond,
+		Feeds: []ServiceNowFeed{
+			{
+				Name:  "sys_audit",
+				Table: "sys_audit",
+			},
+			{
+				Name:  "login_events",
+				Table: "sysevent",
+				Query: "name=login",
+			},
+			{
+				Name:  "failed_logins",
+				Table: "sysevent",
+				Query: "name=login.failed",
+			},
+		},
+	}
+	adapter, _, err := newServiceNowAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 5 },
+		5*time.Second, 20*time.Millisecond)
+	require.Never(t, func() bool { return sink.count() != 5 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	byType := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		byType[msg.EventType]++
+	}
+	assert.Equal(t, map[string]int{"sys_audit": 2, "login_events": 2, "failed_logins": 1}, byType)
+}
+
+// TestMockRejectsBadCredentials verifies the adapter stops, and ships
+// nothing, when the mock API rejects the supplied credentials.
+func TestMockRejectsBadCredentials(t *testing.T) {
+	mock := newMockServiceNow("u", "correct-password")
+	mock.setTable("sys_audit", []utils.Dict{
+		realisticSysAudit(1, snTime(time.Now().UTC())),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ServiceNowConfig{
+		ClientOptions: testClientOptions(t),
+		Username:      "u",
+		Password:      "wrong-password",
+		BaseURL:       server.URL,
+		PollInterval:  50 * time.Millisecond,
+	}
+	adapter, chStopped, err := newServiceNowAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	select {
+	case <-chStopped:
+		// Expected: rejected credentials stop the adapter.
+	case <-time.After(3 * time.Second):
+		t.Fatal("adapter should stop when the API rejects the credentials")
+	}
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	assert.GreaterOrEqual(t, mock.requestCount(), 1, "the adapter should have called the API")
+}


### PR DESCRIPTION
## What

A new `servicenow` USP adapter that ingests ServiceNow audit and system logs by polling the [ServiceNow REST Table API](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_TableAPI.html) (`GET /api/now/v2/table/{tableName}`).

The adapter is generic by design: each *feed* is one platform table plus an optional encoded-query filter, so collecting another table is purely configuration. Default feed set: `sys_audit` (field-level change history). The README documents how to add `syslog_transaction` (transaction log with source IPs), `sysevent` (login events), `syslog`, and `sys_outbound_http_log` — the same table set ServiceNow's own Log Export Service targets.

## Auth

HTTP Basic auth with a dedicated service account. Reading `sys_audit` requires `admin`/`security_admin` out of the box (or a custom ACL). Rejected credentials (401) stop the adapter; a per-table ACL denial (403) is feed-local — the feed keeps retrying each poll while other feeds keep collecting.

## How it works

- Per-feed incremental checkpoint on `sys_created_on` (UTC `yyyy-MM-dd HH:mm:ss`), querying oldest-first **with the id column as an ORDERBY tiebreaker** (timestamps have one-second granularity; without a total order a record could slip through a page boundary between page fetches).
- A completed poll advances the checkpoint to `now - checkpoint_lag` (default 5m), leaving room for records that become query-visible after their timestamp (slow transactions, node clock skew); a failed poll does not advance it, so the range is retried. The clock-based advance also walks an idle feed past its boundary records instead of re-reading them forever.
- Pagination follows the `Link: rel="next"` header rather than page sizes — ServiceNow applies `sysparm_limit` **before** ACL evaluation, so short/empty pages are not an end-of-data signal.
- Overlap re-reads are absorbed by a `sys_id`-keyed deduper; delivery is at-least-once (in-memory state: a restart re-ships up to `backfill`).
- `max_pages` caps a poll's work without losing data (resumes from the newest record processed, clamped to the lagged clock), with a distinct loud warning if a single-second burst exceeds `max_pages × page_size` and the checkpoint cannot advance.
- Transient failures (5xx/429/network) retry with exponential backoff, honoring `Retry-After`; payloads ship verbatim with `sysparm_display_value=false` + `sysparm_exclude_reference_link=true` for locale-independent, plain-sys_id records.

## Push alternative considered

ServiceNow does offer a push path — the Log Export Service streaming over Hermes/Kafka — but it requires a Store app install, a paid entitlement, and a MID server or Kafka consumer on the customer side, so polling the Table API is the right default. Noted in the README.

## Testing

- Full mock-backed end-to-end suite (`servicenow/mock_test.go`): an `httptest` server reproducing the Table API (Basic auth, encoded-query filtering, offset/limit pagination, `{"result": [...]}` envelope, `X-Total-Count`/`Link` headers, and pre-ACL limit slicing). Tests cover verbatim payload/event-type/timestamp shipping, no re-ship on re-poll, mid-run insert ships once, 250-record multi-page walk, ACL-shortened pages, multi-feed tagging with query filters, and bad credentials stopping the adapter without shipping.
- Unit + integration tests for config validation, query building (including the ORDERBY tiebreaker), checkpoint advancement and lag (including under a `max_pages` cap and the stuck-at-cap warning), 401-stops vs 403-keeps-polling, retry semantics, and `Retry-After`.
- `go test ./servicenow/...` passes, including with `-race -count=2`; `go build ./...` passes.
- A self-review pass (multi-angle) was run over the diff; the findings (pagination tie-order data loss, late-visibility checkpoint loss, envelope-detection false negatives, 403 blast radius, idle-feed re-ship after dedup TTL expiry) are fixed in the second commit.
- **Not live-verified**: no ServiceNow instance credentials were available, so the mock is built strictly from the documented API shapes (doc links in `servicenow/README.md`). Follow-up: validate against a real instance (e.g. a PDI) and adjust fixtures if reality diverges.

## Follow-ups

- OAuth 2.0 (client credentials) as an alternative to Basic auth.
- A dedicated `servicenow` platform value (currently documented with `client_options.platform=json`).
- Optional persistent checkpoint/dedup state for gapless restarts beyond `backfill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)