### PR TITLE
Add mock-backed test suites for 21 untested adapters

### DIFF
--- a/bitwarden/client.go
+++ b/bitwarden/client.go
@@ -25,6 +25,18 @@ const (
 	eventsBaseURLEU = "https://api.bitwarden.eu"
 )
 
+// defaultPollInterval is how long fetchEvents idles between polling cycles.
+const defaultPollInterval = 30 * time.Second
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type BitwardenConfig struct {
 	ClientOptions    uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 	ClientID         string                  `json:"client_id" yaml:"client_id"`
@@ -75,7 +87,7 @@ func (c *BitwardenConfig) Validate() error {
 
 type BitwardenAdapter struct {
 	conf          BitwardenConfig
-	uspClient     *uspclient.Client
+	uspClient     uspSink
 	httpClient    *http.Client
 	chStopped     chan struct{}
 	wgSenders     sync.WaitGroup
@@ -87,19 +99,27 @@ type BitwardenAdapter struct {
 	eventsBaseURL string
 	tokenEndpoint string
 	lastStartDate *time.Time
+	pollInterval  time.Duration
 }
 
 func NewBitwardenAdapter(ctx context.Context, conf BitwardenConfig) (*BitwardenAdapter, chan struct{}, error) {
+	return newBitwardenAdapter(ctx, conf, nil)
+}
+
+// newBitwardenAdapter is the implementation behind NewBitwardenAdapter. When
+// sink is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newBitwardenAdapter(ctx context.Context, conf BitwardenConfig, sink uspSink) (*BitwardenAdapter, chan struct{}, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, nil, err
 	}
 
-	var err error
 	a := &BitwardenAdapter{
-		conf:      conf,
-		ctx:       context.Background(),
-		doStop:    utils.NewEvent(),
-		chStopped: make(chan struct{}),
+		conf:         conf,
+		ctx:          context.Background(),
+		doStop:       utils.NewEvent(),
+		chStopped:    make(chan struct{}),
+		pollInterval: defaultPollInterval,
 	}
 
 	// Set URLs: use custom URLs if provided, otherwise use region-specific URLs
@@ -114,9 +134,14 @@ func NewBitwardenAdapter(ctx context.Context, conf BitwardenConfig) (*BitwardenA
 		a.tokenEndpoint = tokenEndpointUS
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -224,7 +249,7 @@ func (a *BitwardenAdapter) fetchEvents() {
 	defer a.wgSenders.Done()
 	defer a.conf.ClientOptions.DebugLog("Bitwarden event collection stopping")
 
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// Capture end time before fetching to avoid gaps
 		endTime := time.Now()
 

--- a/bitwarden/client_test.go
+++ b/bitwarden/client_test.go
@@ -1,0 +1,191 @@
+package usp_bitwarden
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// startTestAdapter builds an adapter against the mock with an injected capture
+// sink and a short poll interval, then starts the fetch goroutine exactly as
+// the real constructor does. The production poll interval is 30s (longer than
+// the whole test package is allowed to run), so tests wire the struct directly
+// the way 1password's tests do.
+func startTestAdapter(t *testing.T, mockURL string, sink uspSink, pollInterval time.Duration, clientID, clientSecret string) *BitwardenAdapter {
+	t.Helper()
+	conf := BitwardenConfig{
+		ClientOptions:    testClientOptions(t),
+		ClientID:         clientID,
+		ClientSecret:     clientSecret,
+		TokenEndpointURL: mockURL + "/connect/token",
+		EventsBaseURL:    mockURL,
+	}
+	require.NoError(t, conf.Validate())
+
+	a := &BitwardenAdapter{
+		conf:          conf,
+		ctx:           context.Background(),
+		doStop:        utils.NewEvent(),
+		chStopped:     make(chan struct{}),
+		uspClient:     sink,
+		httpClient:    &http.Client{Timeout: 5 * time.Second},
+		tokenEndpoint: conf.TokenEndpointURL,
+		eventsBaseURL: conf.EventsBaseURL,
+		pollInterval:  pollInterval,
+	}
+
+	a.wgSenders.Add(1)
+	go a.fetchEvents()
+	go func() {
+		a.wgSenders.Wait()
+		close(a.chStopped)
+	}()
+	return a
+}
+
+// stop tears a test adapter down without the production Close()'s 1-minute
+// drain budget (the capture sink drains instantly anyway).
+func (a *BitwardenAdapter) stop() {
+	a.doStop.Set()
+	a.wgSenders.Wait()
+	a.httpClient.CloseIdleConnections()
+}
+
+// --- unit tests ---------------------------------------------------------------
+
+func TestValidate(t *testing.T) {
+	t.Run("requires client_id", func(t *testing.T) {
+		c := BitwardenConfig{ClientOptions: testClientOptions(t), ClientSecret: "s"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires client_secret", func(t *testing.T) {
+		c := BitwardenConfig{ClientOptions: testClientOptions(t), ClientID: "i"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("region defaults to us", func(t *testing.T) {
+		c := BitwardenConfig{ClientOptions: testClientOptions(t), ClientID: "i", ClientSecret: "s"}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, "us", c.Region)
+	})
+
+	t.Run("accepts eu region", func(t *testing.T) {
+		c := BitwardenConfig{ClientOptions: testClientOptions(t), ClientID: "i", ClientSecret: "s", Region: "eu"}
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("rejects unknown region", func(t *testing.T) {
+		c := BitwardenConfig{ClientOptions: testClientOptions(t), ClientID: "i", ClientSecret: "s", Region: "apac"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("custom token endpoint requires events base url", func(t *testing.T) {
+		c := BitwardenConfig{
+			ClientOptions: testClientOptions(t), ClientID: "i", ClientSecret: "s",
+			TokenEndpointURL: "https://bitwarden.example.com/connect/token",
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("custom events base url requires token endpoint", func(t *testing.T) {
+		c := BitwardenConfig{
+			ClientOptions: testClientOptions(t), ClientID: "i", ClientSecret: "s",
+			EventsBaseURL: "https://bitwarden.example.com",
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("custom urls conflict with region", func(t *testing.T) {
+		c := BitwardenConfig{
+			ClientOptions: testClientOptions(t), ClientID: "i", ClientSecret: "s",
+			Region:           "us",
+			TokenEndpointURL: "https://bitwarden.example.com/connect/token",
+			EventsBaseURL:    "https://bitwarden.example.com",
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("both custom urls accepted", func(t *testing.T) {
+		c := BitwardenConfig{
+			ClientOptions: testClientOptions(t), ClientID: "i", ClientSecret: "s",
+			TokenEndpointURL: "https://bitwarden.example.com/connect/token",
+			EventsBaseURL:    "https://bitwarden.example.com",
+		}
+		assert.NoError(t, c.Validate())
+		assert.Empty(t, c.Region)
+	})
+}
+
+// TestConstructorURLResolution verifies the constructor seam resolves the
+// token/events endpoints from the config exactly as production does, and that
+// the adapter shuts down cleanly through Close().
+func TestConstructorURLResolution(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("defaults to US cloud", func(t *testing.T) {
+		conf := BitwardenConfig{ClientOptions: testClientOptions(t), ClientID: "i", ClientSecret: "s"}
+		a, chStopped, err := newBitwardenAdapter(ctx, conf, &captureSink{})
+		require.NoError(t, err)
+		assert.Equal(t, "https://identity.bitwarden.com/connect/token", a.tokenEndpoint)
+		assert.Equal(t, "https://api.bitwarden.com", a.eventsBaseURL)
+		assert.Equal(t, defaultPollInterval, a.pollInterval)
+		require.NoError(t, a.Close())
+		select {
+		case <-chStopped:
+		case <-time.After(5 * time.Second):
+			t.Fatal("adapter did not stop after Close")
+		}
+	})
+
+	t.Run("eu region uses EU cloud", func(t *testing.T) {
+		conf := BitwardenConfig{ClientOptions: testClientOptions(t), ClientID: "i", ClientSecret: "s", Region: "eu"}
+		a, _, err := newBitwardenAdapter(ctx, conf, &captureSink{})
+		require.NoError(t, err)
+		defer a.Close()
+		assert.Equal(t, "https://identity.bitwarden.eu/connect/token", a.tokenEndpoint)
+		assert.Equal(t, "https://api.bitwarden.eu", a.eventsBaseURL)
+	})
+
+	t.Run("custom urls win", func(t *testing.T) {
+		conf := BitwardenConfig{
+			ClientOptions: testClientOptions(t), ClientID: "i", ClientSecret: "s",
+			TokenEndpointURL: "https://bitwarden.example.com/connect/token",
+			EventsBaseURL:    "https://bitwarden.example.com",
+		}
+		a, _, err := newBitwardenAdapter(ctx, conf, &captureSink{})
+		require.NoError(t, err)
+		defer a.Close()
+		assert.Equal(t, "https://bitwarden.example.com/connect/token", a.tokenEndpoint)
+		assert.Equal(t, "https://bitwarden.example.com", a.eventsBaseURL)
+	})
+
+	t.Run("invalid config rejected", func(t *testing.T) {
+		conf := BitwardenConfig{ClientOptions: testClientOptions(t)}
+		_, _, err := newBitwardenAdapter(ctx, conf, &captureSink{})
+		assert.Error(t, err)
+	})
+}

--- a/bitwarden/mock_test.go
+++ b/bitwarden/mock_test.go
@@ -1,0 +1,583 @@
+package usp_bitwarden
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock of the Bitwarden
+// Public (Events) API and its Identity OAuth2 endpoint, capturing the exact
+// messages it ships so their content -- timestamp and verbatim payload -- can
+// be asserted without live credentials.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Bitwarden API -----------------------------------------------------
+
+// mockPageSize mirrors the real API, which returns at most 50 event logs per
+// page and a continuationToken when more are available.
+const mockPageSize = 50
+
+// mockBitwarden is an in-memory stand-in for the two Bitwarden endpoints the
+// adapter uses:
+//
+//   - POST /connect/token -- the Identity OAuth2 endpoint. It validates the
+//     client_credentials exchange (grant type, scope, client id/secret, form
+//     encoding) the way the real identity server does and issues bearer
+//     tokens, returning 400 invalid_client on a bad secret.
+//   - GET /public/events -- the Events API. It requires a previously issued
+//     bearer token, filters the in-memory dataset by the start/end query
+//     parameters, paginates with an opaque continuationToken, and returns the
+//     real {"object":"list","data":[...],"continuationToken":...} envelope.
+//
+// Time filtering treats the window as (start, end]: the adapter always sends
+// start equal to the end of its previous cycle, so half-open windows are what
+// make its checkpointing exactly-once.
+type mockBitwarden struct {
+	mu           sync.Mutex
+	clientID     string
+	clientSecret string
+
+	events []utils.Dict // each carries a "date" field, RFC3339Nano
+
+	issuedTokens   map[string]bool
+	tokenSeq       int
+	tokenExpiresIn int // seconds; default 3600 like the real API
+
+	cursors   map[string][]utils.Dict // continuationToken -> remaining records
+	cursorSeq int
+
+	rejectBearer bool // when true, /public/events answers 401 to any token
+
+	tokenRequests        int
+	eventRequests        int
+	continuationRequests int
+}
+
+func newMockBitwarden(clientID, clientSecret string) *mockBitwarden {
+	return &mockBitwarden{
+		clientID:       clientID,
+		clientSecret:   clientSecret,
+		issuedTokens:   map[string]bool{},
+		cursors:        map[string][]utils.Dict{},
+		tokenExpiresIn: 3600,
+	}
+}
+
+func (m *mockBitwarden) setEvents(events []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = events
+}
+
+// addEvent appends a new event, as the real API would surface one that just
+// occurred.
+func (m *mockBitwarden) addEvent(e utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, e)
+}
+
+func (m *mockBitwarden) tokenRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests
+}
+
+func (m *mockBitwarden) eventRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.eventRequests
+}
+
+func (m *mockBitwarden) continuationRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.continuationRequests
+}
+
+func (m *mockBitwarden) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/connect/token", m.handleToken)
+	mux.HandleFunc("/public/events", m.handleEvents)
+	return mux
+}
+
+func (m *mockBitwarden) handleToken(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.tokenRequests++
+	m.mu.Unlock()
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !strings.Contains(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{"error": "invalid_request"})
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{"error": "invalid_request"})
+		return
+	}
+	if r.PostFormValue("grant_type") != "client_credentials" {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{"error": "unsupported_grant_type"})
+		return
+	}
+	if r.PostFormValue("scope") != "api.organization" {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{"error": "invalid_scope"})
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if r.PostFormValue("client_id") != m.clientID || r.PostFormValue("client_secret") != m.clientSecret {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"error": "invalid_client",
+		})
+		return
+	}
+
+	m.tokenSeq++
+	token := fmt.Sprintf("mock-access-token-%d", m.tokenSeq)
+	m.issuedTokens[token] = true
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"access_token": token,
+		"expires_in":   m.tokenExpiresIn,
+		"token_type":   "Bearer",
+		"scope":        "api.organization",
+	})
+}
+
+func (m *mockBitwarden) handleEvents(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.eventRequests++
+	m.mu.Unlock()
+
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	m.mu.Lock()
+	authorized := m.issuedTokens[token] && !m.rejectBearer
+	m.mu.Unlock()
+	if !authorized {
+		writeJSON(w, http.StatusUnauthorized, map[string]interface{}{
+			"object":  "error",
+			"message": "The current user is not authorized.",
+		})
+		return
+	}
+
+	q := r.URL.Query()
+	var matched []utils.Dict
+
+	if ct := q.Get("continuationToken"); ct != "" {
+		m.mu.Lock()
+		m.continuationRequests++
+		remaining, ok := m.cursors[ct]
+		delete(m.cursors, ct)
+		m.mu.Unlock()
+		if !ok {
+			writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+				"object":  "error",
+				"message": "Invalid continuation token.",
+			})
+			return
+		}
+		matched = remaining
+	} else {
+		var start, end time.Time
+		var hasStart, hasEnd bool
+		if s := q.Get("start"); s != "" {
+			t, err := time.Parse(time.RFC3339, s)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+					"object":  "error",
+					"message": "Invalid start date.",
+				})
+				return
+			}
+			start, hasStart = t, true
+		}
+		if s := q.Get("end"); s != "" {
+			t, err := time.Parse(time.RFC3339, s)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+					"object":  "error",
+					"message": "Invalid end date.",
+				})
+				return
+			}
+			end, hasEnd = t, true
+		}
+
+		m.mu.Lock()
+		for _, e := range m.events {
+			d, ok := eventDate(e)
+			if !ok {
+				continue
+			}
+			if hasStart && !d.After(start) {
+				continue // window is half-open: (start, end]
+			}
+			if hasEnd && d.After(end) {
+				continue
+			}
+			matched = append(matched, e)
+		}
+		m.mu.Unlock()
+	}
+
+	page := matched
+	var next interface{} // null when there are no further pages
+	if len(matched) > mockPageSize {
+		page = matched[:mockPageSize]
+		m.mu.Lock()
+		m.cursorSeq++
+		ct := fmt.Sprintf("mock-continuation-%d", m.cursorSeq)
+		m.cursors[ct] = matched[mockPageSize:]
+		m.mu.Unlock()
+		next = ct
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"object":            "list",
+		"data":              page,
+		"continuationToken": next,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// eventDate parses an event's "date" field.
+func eventDate(e utils.Dict) (time.Time, bool) {
+	s, _ := e["date"].(string)
+	if s == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// --- realistic event fixtures -------------------------------------------------
+
+// realisticBitwardenEvent returns a record shaped like a real Bitwarden
+// organization event: the documented field set with its mix of int enums
+// (type, device), strings (ids, ipAddress) and nulls, and the API's
+// sub-second-precision date format. All identifiers are clearly fake.
+func realisticBitwardenEvent(eventType int, itemID string, date time.Time) utils.Dict {
+	return utils.Dict{
+		"object":         "event",
+		"type":           eventType, // e.g. 1000 user_loggedin, 1107 cipher_clientviewed
+		"itemId":         itemID,
+		"collectionId":   nil,
+		"groupId":        nil,
+		"policyId":       nil,
+		"memberId":       "11111111-1111-1111-1111-111111111111",
+		"actingUserId":   "22222222-2222-2222-2222-222222222222",
+		"installationId": nil,
+		"date":           date.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"),
+		"device":         9, // ChromeBrowser
+		"ipAddress":      "198.51.100.10",
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+const (
+	testMockClientID     = "organization.33333333-3333-3333-3333-333333333333"
+	testMockClientSecret = "fake-test-client-secret"
+)
+
+// --- tests --------------------------------------------------------------------
+
+// TestMockEventsEndToEnd drives the adapter against the mock API and asserts
+// the exact messages shipped: the payload preserved verbatim (nulls, int enums
+// and string ids included), an ingestion-time TimestampMs, no EventType (the
+// adapter does not set one), a single cached OAuth token, and that re-polling
+// the time-windowed API does not re-ship anything.
+func TestMockEventsEndToEnd(t *testing.T) {
+	mock := newMockBitwarden(testMockClientID, testMockClientSecret)
+	now := time.Now()
+	want := []utils.Dict{
+		realisticBitwardenEvent(1000, "aaaaaaaa-1111-1111-1111-000000000001", now.Add(-10*time.Minute)),
+		realisticBitwardenEvent(1107, "aaaaaaaa-1111-1111-1111-000000000002", now.Add(-8*time.Minute)),
+		realisticBitwardenEvent(1115, "aaaaaaaa-1111-1111-1111-000000000003", now.Add(-5*time.Minute)),
+	}
+	mock.setEvents(want)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	startMs := uint64(time.Now().UnixMilli())
+	sink := &captureSink{}
+	a := startTestAdapter(t, server.URL, sink, 50*time.Millisecond, testMockClientID, testMockClientSecret)
+	defer a.stop()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 events to ship")
+
+	// Re-polling must not re-ship: later polls query (lastEnd, now] windows
+	// that exclude the already-collected events.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		400*time.Millisecond, 30*time.Millisecond, "events were re-shipped on a later poll")
+
+	// The OAuth token is requested once and then cached for its lifetime.
+	assert.Equal(t, 1, mock.tokenRequestCount(), "token should be fetched once and cached")
+	assert.GreaterOrEqual(t, mock.eventRequestCount(), 2, "the adapter should keep polling")
+
+	endMs := uint64(time.Now().UnixMilli())
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		// The adapter ships raw events without an EventType, and stamps them
+		// with ingestion time (not the event's own date).
+		assert.Empty(t, msg.EventType, "bitwarden adapter does not set an EventType")
+		assert.GreaterOrEqual(t, msg.TimestampMs, startMs)
+		assert.LessOrEqual(t, msg.TimestampMs, endMs)
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["itemId"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	for _, src := range want {
+		id := src["itemId"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "event %s was not shipped", id)
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Bitwarden event verbatim")
+	}
+}
+
+// TestMockMidRunEventShipsExactlyOnce verifies an event appearing after the
+// first poll is picked up by a subsequent start/end window and shipped exactly
+// once, while already-shipped events are never re-sent.
+func TestMockMidRunEventShipsExactlyOnce(t *testing.T) {
+	mock := newMockBitwarden(testMockClientID, testMockClientSecret)
+	now := time.Now()
+	mock.setEvents([]utils.Dict{
+		realisticBitwardenEvent(1000, "aaaaaaaa-1111-1111-1111-00000000000a", now.Add(-10*time.Minute)),
+		realisticBitwardenEvent(1107, "aaaaaaaa-1111-1111-1111-00000000000b", now.Add(-9*time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	a := startTestAdapter(t, server.URL, sink, 50*time.Millisecond, testMockClientID, testMockClientSecret)
+	defer a.stop()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "initial events should ship")
+
+	// A new event occurs mid-run. The adapter formats its start/end query
+	// parameters at second precision, so it can take up to ~1s of polls before
+	// a window covers the new event -- but it must then ship exactly once.
+	mock.addEvent(realisticBitwardenEvent(1114, "aaaaaaaa-1111-1111-1111-00000000000c", time.Now()))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new event should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		500*time.Millisecond, 30*time.Millisecond, "the new event must not ship twice")
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["itemId"].(string)]++
+	}
+	assert.Equal(t, map[string]int{
+		"aaaaaaaa-1111-1111-1111-00000000000a": 1,
+		"aaaaaaaa-1111-1111-1111-00000000000b": 1,
+		"aaaaaaaa-1111-1111-1111-00000000000c": 1,
+	}, shippedPerID, "every event must ship exactly once")
+}
+
+// TestMockPaginationFullDataset verifies a dataset larger than the API's page
+// size is fully consumed through the continuationToken mechanism within a
+// single poll cycle, with every event shipped exactly once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const total = 120 // 3 pages at the API's 50-per-page limit
+
+	mock := newMockBitwarden(testMockClientID, testMockClientSecret)
+	events := make([]utils.Dict, total)
+	base := time.Now().Add(-time.Hour)
+	for i := 0; i < total; i++ {
+		events[i] = realisticBitwardenEvent(
+			1107,
+			fmt.Sprintf("aaaaaaaa-1111-1111-1111-%012d", i),
+			base.Add(time.Duration(i)*time.Second))
+	}
+	mock.setEvents(events)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	a := startTestAdapter(t, server.URL, sink, 50*time.Millisecond, testMockClientID, testMockClientSecret)
+	defer a.stop()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		5*time.Second, 20*time.Millisecond, "all paginated events should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		400*time.Millisecond, 30*time.Millisecond, "no event may ship twice")
+
+	assert.GreaterOrEqual(t, mock.continuationRequestCount(), 2,
+		"the adapter should have followed the continuation token for pages 2 and 3")
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["itemId"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct event should be shipped once")
+}
+
+// TestMockBadCredentialsShipNothing verifies that when the identity endpoint
+// rejects the client credentials, nothing ships and the events endpoint is
+// never reached. This adapter's behavior on bad credentials is to keep
+// retrying on its poll interval (it does not stop), so the test also asserts
+// it stays alive and keeps re-attempting the token exchange.
+func TestMockBadCredentialsShipNothing(t *testing.T) {
+	mock := newMockBitwarden(testMockClientID, testMockClientSecret)
+	mock.setEvents([]utils.Dict{
+		realisticBitwardenEvent(1000, "aaaaaaaa-1111-1111-1111-000000000001", time.Now().Add(-time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	a := startTestAdapter(t, server.URL, sink, 50*time.Millisecond, testMockClientID, "wrong-secret")
+	defer a.stop()
+
+	require.Eventually(t, func() bool { return mock.tokenRequestCount() >= 3 },
+		5*time.Second, 20*time.Millisecond, "the adapter should keep retrying the token exchange")
+
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	assert.Equal(t, 0, mock.eventRequestCount(), "the events endpoint should never be reached without a token")
+	select {
+	case <-a.chStopped:
+		t.Fatal("bad credentials should not stop this adapter; it retries each poll")
+	default:
+	}
+	assert.False(t, a.doStop.IsSet())
+}
+
+// TestMockUnauthorizedEventsKeepsPolling verifies that a 401 from the events
+// endpoint (e.g. a revoked token) ships nothing, keeps the adapter alive, and
+// does not advance its time checkpoint (it keeps retrying).
+func TestMockUnauthorizedEventsKeepsPolling(t *testing.T) {
+	mock := newMockBitwarden(testMockClientID, testMockClientSecret)
+	mock.rejectBearer = true
+	mock.setEvents([]utils.Dict{
+		realisticBitwardenEvent(1000, "aaaaaaaa-1111-1111-1111-000000000001", time.Now().Add(-time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	a := startTestAdapter(t, server.URL, sink, 50*time.Millisecond, testMockClientID, testMockClientSecret)
+	defer a.stop()
+
+	require.Eventually(t, func() bool { return mock.eventRequestCount() >= 3 },
+		5*time.Second, 20*time.Millisecond, "the adapter should keep polling through 401s")
+
+	assert.Equal(t, 0, sink.count(), "nothing should ship when the events endpoint rejects the token")
+	select {
+	case <-a.chStopped:
+		t.Fatal("a 401 from the events endpoint should not stop this adapter")
+	default:
+	}
+
+	// Once the token is honored again, the backlog ships: the checkpoint was
+	// never advanced by the failing polls, so the first successful poll still
+	// has no start/end window and collects everything.
+	mock.mu.Lock()
+	mock.rejectBearer = false
+	mock.mu.Unlock()
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the event should ship once the API accepts the token again")
+}
+
+// TestMockTokenRefresh verifies the adapter requests a fresh OAuth token when
+// the previous one is about to expire (the adapter refreshes within a 5 minute
+// buffer of expiry) and keeps collecting events across token rotations.
+func TestMockTokenRefresh(t *testing.T) {
+	mock := newMockBitwarden(testMockClientID, testMockClientSecret)
+	mock.tokenExpiresIn = 1 // always inside the adapter's 5-minute refresh buffer
+	now := time.Now()
+	mock.setEvents([]utils.Dict{
+		realisticBitwardenEvent(1000, "aaaaaaaa-1111-1111-1111-000000000001", now.Add(-10*time.Minute)),
+		realisticBitwardenEvent(1107, "aaaaaaaa-1111-1111-1111-000000000002", now.Add(-9*time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	a := startTestAdapter(t, server.URL, sink, 50*time.Millisecond, testMockClientID, testMockClientSecret)
+	defer a.stop()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "events should ship despite short-lived tokens")
+	require.Eventually(t, func() bool { return mock.tokenRequestCount() >= 3 },
+		5*time.Second, 20*time.Millisecond, "near-expiry tokens should be refreshed on each poll")
+	require.Never(t, func() bool { return sink.count() != 2 },
+		400*time.Millisecond, 30*time.Millisecond, "token refreshes must not cause re-shipping")
+}

--- a/bitwarden/mock_test.go
+++ b/bitwarden/mock_test.go
@@ -56,7 +56,8 @@ func (s *captureSink) snapshot() []*protocol.DataMessage {
 // --- mock Bitwarden API -----------------------------------------------------
 
 // mockPageSize mirrors the real API, which returns at most 50 event logs per
-// page and a continuationToken when more are available.
+// page (the default PageOptions.PageSize in bitwarden/server) and a
+// continuationToken when more are available.
 const mockPageSize = 50
 
 // mockBitwarden is an in-memory stand-in for the two Bitwarden endpoints the
@@ -68,12 +69,19 @@ const mockPageSize = 50
 //     tokens, returning 400 invalid_client on a bad secret.
 //   - GET /public/events -- the Events API. It requires a previously issued
 //     bearer token, filters the in-memory dataset by the start/end query
-//     parameters, paginates with an opaque continuationToken, and returns the
-//     real {"object":"list","data":[...],"continuationToken":...} envelope.
+//     parameters (defaulting to the last 30 days when absent, as documented),
+//     paginates with an opaque continuationToken, and returns the documented
+//     {"object":"list","data":[...],"continuationToken":...} envelope.
 //
-// Time filtering treats the window as (start, end]: the adapter always sends
-// start equal to the end of its previous cycle, so half-open windows are what
-// make its checkpointing exactly-once.
+// Time filtering treats the window as [start, end], inclusive on both ends.
+// The official docs don't state boundary inclusivity, but both event-store
+// implementations in bitwarden/server filter Date >= start AND Date <= end
+// (SQL: Event_ReadPageByOrganizationId.sql; Azure Tables: reversed-tick
+// RowKey le/ge in TableStorage/EventRepository.cs). The adapter reuses each
+// cycle's end as the next start (truncated to whole seconds by RFC3339
+// formatting), so only an event stamped exactly on that whole-second boundary
+// could ever be returned in two windows; the sub-second fixture timestamps in
+// these tests never hit that edge.
 type mockBitwarden struct {
 	mu           sync.Mutex
 	clientID     string
@@ -205,9 +213,11 @@ func (m *mockBitwarden) handleEvents(w http.ResponseWriter, r *http.Request) {
 	authorized := m.issuedTokens[token] && !m.rejectBearer
 	m.mu.Unlock()
 	if !authorized {
+		// ErrorResponseModel shape; "Unauthorized." is the message the API's
+		// exception filter uses for 401s.
 		writeJSON(w, http.StatusUnauthorized, map[string]interface{}{
 			"object":  "error",
-			"message": "The current user is not authorized.",
+			"message": "Unauthorized.",
 		})
 		return
 	}
@@ -255,16 +265,24 @@ func (m *mockBitwarden) handleEvents(w http.ResponseWriter, r *http.Request) {
 			end, hasEnd = t, true
 		}
 
+		// "If no filters are provided, it will return the last 30 days of
+		// event for the organization" (official API reference). The server
+		// defaults to start = today-30d, end = end of today (UTC) whenever
+		// either bound is missing (EventFilterRequestModel.ToDateRange).
+		if !hasStart || !hasEnd {
+			today := time.Now().UTC().Truncate(24 * time.Hour)
+			start = today.AddDate(0, 0, -30)
+			end = today.AddDate(0, 0, 1).Add(-time.Millisecond)
+		}
+
 		m.mu.Lock()
 		for _, e := range m.events {
 			d, ok := eventDate(e)
 			if !ok {
 				continue
 			}
-			if hasStart && !d.After(start) {
-				continue // window is half-open: (start, end]
-			}
-			if hasEnd && d.After(end) {
+			// Inclusive on both ends, like the real event stores.
+			if d.Before(start) || d.After(end) {
 				continue
 			}
 			matched = append(matched, e)
@@ -313,23 +331,26 @@ func eventDate(e utils.Dict) (time.Time, bool) {
 // --- realistic event fixtures -------------------------------------------------
 
 // realisticBitwardenEvent returns a record shaped like a real Bitwarden
-// organization event: the documented field set with its mix of int enums
-// (type, device), strings (ids, ipAddress) and nulls, and the API's
-// sub-second-precision date format. All identifiers are clearly fake.
+// organization event: the documented EventResponseModel field set with its mix
+// of int enums (type, device), strings (uuids, ipAddress) and nulls, and a
+// sub-second-precision date. All identifiers are clearly fake.
 func realisticBitwardenEvent(eventType int, itemID string, date time.Time) utils.Dict {
 	return utils.Dict{
-		"object":         "event",
-		"type":           eventType, // e.g. 1000 user_loggedin, 1107 cipher_clientviewed
-		"itemId":         itemID,
-		"collectionId":   nil,
-		"groupId":        nil,
-		"policyId":       nil,
-		"memberId":       "11111111-1111-1111-1111-111111111111",
-		"actingUserId":   "22222222-2222-2222-2222-222222222222",
-		"installationId": nil,
-		"date":           date.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"),
-		"device":         9, // ChromeBrowser
-		"ipAddress":      "198.51.100.10",
+		"object":           "event",
+		"type":             eventType, // e.g. 1000 User_LoggedIn, 1107 Cipher_ClientViewed
+		"itemId":           itemID,
+		"collectionId":     nil,
+		"groupId":          nil,
+		"policyId":         nil,
+		"memberId":         "11111111-1111-1111-1111-111111111111",
+		"actingUserId":     "22222222-2222-2222-2222-222222222222",
+		"installationId":   nil,
+		"date":             date.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"),
+		"device":           9, // DeviceType 9 = ChromeBrowser
+		"ipAddress":        "198.51.100.10",
+		"secretId":         nil,
+		"projectId":        nil,
+		"serviceAccountId": nil,
 	}
 }
 
@@ -373,8 +394,8 @@ func TestMockEventsEndToEnd(t *testing.T) {
 	require.Eventually(t, func() bool { return sink.count() == 3 },
 		5*time.Second, 20*time.Millisecond, "expected all 3 events to ship")
 
-	// Re-polling must not re-ship: later polls query (lastEnd, now] windows
-	// that exclude the already-collected events.
+	// Re-polling must not re-ship: later polls query [lastEnd, now] windows
+	// whose start is after the fixtures' dates.
 	require.Never(t, func() bool { return sink.count() != 3 },
 		400*time.Millisecond, 30*time.Millisecond, "events were re-shipped on a later poll")
 
@@ -547,7 +568,8 @@ func TestMockUnauthorizedEventsKeepsPolling(t *testing.T) {
 
 	// Once the token is honored again, the backlog ships: the checkpoint was
 	// never advanced by the failing polls, so the first successful poll still
-	// has no start/end window and collects everything.
+	// sends no start/end and gets the API's default last-30-days window,
+	// which covers the fixture.
 	mock.mu.Lock()
 	mock.rejectBearer = false
 	mock.mu.Unlock()

--- a/box/client.go
+++ b/box/client.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	boxBaseURL    = "https://api.box.com/2.0/events"
-	tokenEndpoint = "https://api.box.com/oauth2/token"
+	defaultBoxEventsURL = "https://api.box.com/2.0/events"
+	defaultBoxTokenURL  = "https://api.box.com/oauth2/token"
+	defaultPollInterval = 30 * time.Second
 )
 
 type BoxConfig struct {
@@ -28,6 +29,19 @@ type BoxConfig struct {
 	ClientID      string                  `json:"client_id" yaml:"client_id"`
 	ClientSecret  string                  `json:"client_secret" yaml:"client_secret"`
 	SubjectID     string                  `json:"subject_id" yaml:"subject_id"`
+
+	// EventsURL overrides the Box enterprise events endpoint. Empty means the
+	// public API: https://api.box.com/2.0/events
+	EventsURL string `json:"events_url" yaml:"events_url"`
+
+	// TokenURL overrides the Box OAuth2 token endpoint. Empty means the
+	// public endpoint: https://api.box.com/oauth2/token
+	TokenURL string `json:"token_url" yaml:"token_url"`
+
+	// PollInterval overrides the wait between polls of the events endpoint
+	// (default 30s). It is not settable through a config file; it exists as a
+	// seam for tests.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *BoxConfig) Validate() error {
@@ -41,10 +55,22 @@ func (c *BoxConfig) Validate() error {
 	return nil
 }
 
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type BoxAdapter struct {
 	conf           BoxConfig
-	uspClient      *uspclient.Client
+	uspClient      uspSink
 	httpClient     *http.Client
+	eventsURL      string
+	tokenURL       string
+	pollInterval   time.Duration
 	chStopped      chan struct{}
 	wgSenders      sync.WaitGroup
 	doStop         *utils.Event
@@ -55,7 +81,13 @@ type BoxAdapter struct {
 }
 
 func NewBoxAdapter(ctx context.Context, conf BoxConfig) (*BoxAdapter, chan struct{}, error) {
-	var err error
+	return newBoxAdapter(ctx, conf, nil)
+}
+
+// newBoxAdapter is the implementation behind NewBoxAdapter. When sink is
+// non-nil it is used in place of a real LimaCharlie client -- the seam tests
+// use to capture shipped events.
+func newBoxAdapter(ctx context.Context, conf BoxConfig, sink uspSink) (*BoxAdapter, chan struct{}, error) {
 	a := &BoxAdapter{
 		conf:           conf,
 		ctx:            context.Background(),
@@ -65,9 +97,27 @@ func NewBoxAdapter(ctx context.Context, conf BoxConfig) (*BoxAdapter, chan struc
 		initialized:    false,
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	a.eventsURL = conf.EventsURL
+	if a.eventsURL == "" {
+		a.eventsURL = defaultBoxEventsURL
+	}
+	a.tokenURL = conf.TokenURL
+	if a.tokenURL == "" {
+		a.tokenURL = defaultBoxTokenURL
+	}
+	a.pollInterval = conf.PollInterval
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -113,7 +163,7 @@ func (a *BoxAdapter) getAccessToken() (string, error) {
 	data.Set("box_subject_type", "enterprise")
 	data.Set("box_subject_id", fmt.Sprintf("%v", a.conf.SubjectID))
 
-	req, err := http.NewRequest("POST", tokenEndpoint, bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequest("POST", a.tokenURL, bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		return "", err
 	}
@@ -155,7 +205,7 @@ func (a *BoxAdapter) fetchEvents() {
 		_ = items // discard
 	}
 
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		items, newStreamPosition, _ := a.makeOneRequest(a.streamPosition)
 		if newStreamPosition != "" {
 			a.streamPosition = newStreamPosition
@@ -193,7 +243,7 @@ func (a *BoxAdapter) makeOneRequest(streamPosition string) ([]utils.Dict, string
 		return nil, streamPosition, err
 	}
 
-	reqUrl := boxBaseURL + "?stream_type=admin_logs"
+	reqUrl := a.eventsURL + "?stream_type=admin_logs"
 	if streamPosition == "now" || streamPosition == "0" {
 		createdAfter := time.Now().UTC().Add(-10 * time.Minute).Format(time.RFC3339)
 		reqUrl += "&created_after=" + createdAfter

--- a/box/client_test.go
+++ b/box/client_test.go
@@ -1,0 +1,77 @@
+package usp_box
+
+import (
+	"testing"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func TestBoxConfigValidate(t *testing.T) {
+	t.Run("complete config validates", func(t *testing.T) {
+		c := BoxConfig{
+			ClientOptions: testClientOptions(t),
+			ClientID:      "test-client-id",
+			ClientSecret:  "test-client-secret",
+			SubjectID:     "1111111111",
+		}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("missing client_id errors", func(t *testing.T) {
+		c := BoxConfig{
+			ClientOptions: testClientOptions(t),
+			ClientSecret:  "test-client-secret",
+			SubjectID:     "1111111111",
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("missing client_secret errors", func(t *testing.T) {
+		c := BoxConfig{
+			ClientOptions: testClientOptions(t),
+			ClientID:      "test-client-id",
+			SubjectID:     "1111111111",
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("missing subject_id errors", func(t *testing.T) {
+		c := BoxConfig{
+			ClientOptions: testClientOptions(t),
+			ClientID:      "test-client-id",
+			ClientSecret:  "test-client-secret",
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("url overrides are optional", func(t *testing.T) {
+		c := BoxConfig{
+			ClientOptions: testClientOptions(t),
+			ClientID:      "test-client-id",
+			ClientSecret:  "test-client-secret",
+			SubjectID:     "1111111111",
+			EventsURL:     "http://127.0.0.1:1/2.0/events",
+			TokenURL:      "http://127.0.0.1:1/oauth2/token",
+		}
+		require.NoError(t, c.Validate())
+	})
+}

--- a/box/mock_test.go
+++ b/box/mock_test.go
@@ -72,7 +72,8 @@ const mockBoxBasePosition = int64(1152922976252290800)
 //     stream_position request returns events recorded after that position.
 //     Every response carries next_stream_position pointing past the last
 //     entry returned (or the unchanged position when there is nothing new),
-//     mirroring the real long-polling stream contract.
+//     mirroring the real stream paging contract
+//     (https://developer.box.com/reference/get-events/).
 type mockBox struct {
 	mu sync.Mutex
 
@@ -181,7 +182,7 @@ func (m *mockBox) handleToken(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error":             "invalid_client",
-			"error_description": "The client credentials are invalid",
+			"error_description": "The client credentials are not valid",
 		})
 		return
 	}
@@ -224,6 +225,7 @@ func (m *mockBox) handleEvents(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve where in the stream this request starts.
 	var idx int
+	usedCreatedAfter := false
 	switch {
 	case q.Get("stream_position") != "":
 		pos, err := strconv.ParseInt(q.Get("stream_position"), 10, 64)
@@ -244,6 +246,7 @@ func (m *mockBox) handleEvents(w http.ResponseWriter, r *http.Request) {
 		}
 	case q.Get("created_after") != "":
 		m.initRequests++
+		usedCreatedAfter = true
 		after, err := time.Parse(time.RFC3339, q.Get("created_after"))
 		if err != nil {
 			writeBoxError(w, http.StatusBadRequest, "bad_request", "invalid created_after")
@@ -272,11 +275,21 @@ func (m *mockBox) handleEvents(w http.ResponseWriter, r *http.Request) {
 		chunk = []utils.Dict{}
 	}
 
+	// next_stream_position is documented as anyOf string|integer
+	// (https://developer.box.com/reference/get-events/ -- the schema example is
+	// the string "1152922976252290886") and live responses use both forms, so
+	// serve the bootstrap (created_after) response as a string and in-stream
+	// responses as an integer to exercise the adapter against both.
+	var nextPos interface{} = mockBoxBasePosition + int64(end)
+	if usedCreatedAfter {
+		nextPos = strconv.FormatInt(mockBoxBasePosition+int64(end), 10)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"chunk_size":           len(chunk),
-		"next_stream_position": mockBoxBasePosition + int64(end),
+		"next_stream_position": nextPos,
 		"entries":              chunk,
 	})
 }
@@ -290,16 +303,19 @@ func writeBoxError(w http.ResponseWriter, status int, code, message string) {
 		"status":     status,
 		"code":       code,
 		"message":    message,
-		"help_url":   "http://developers.box.com/docs/#errors",
-		"request_id": "11111111111111111111",
+		"help_url":   "https://developer.box.com/guides/api-calls/permissions-and-errors/common-errors/",
+		"request_id": "abcdef123456",
 	})
 }
 
 // --- realistic fixtures -------------------------------------------------------
 
 // realisticBoxEvent returns an entry shaped like a real Box enterprise
-// (admin_logs) event: the documented top-level fields, a created_by user mini,
-// a nested source with a parent folder, and mixed scalar types. All
+// (admin_logs) event per the documented Event resource
+// (https://developer.box.com/reference/resources/event/): the documented
+// top-level fields, a created_by user mini, a nested event source with a
+// parent folder mini and owner, a freeform additional_details object with
+// mixed scalar types, and a null session_id (not all events populate it). All
 // identifiers are clearly fake. created_at must be recent (the adapter's
 // dedupe window is one hour).
 func realisticBoxEvent(eventID, eventType string, createdAt time.Time) utils.Dict {
@@ -316,7 +332,6 @@ func realisticBoxEvent(eventID, eventType string, createdAt time.Time) utils.Dic
 		"recorded_at": createdAt.UTC().Add(2 * time.Second).Format(time.RFC3339),
 		"event_type":  eventType,
 		"session_id":  nil,
-		"ip_address":  "203.0.113.10",
 		"source": utils.Dict{
 			"item_type": "file",
 			"item_id":   "1111111111111",

--- a/box/mock_test.go
+++ b/box/mock_test.go
@@ -1,0 +1,606 @@
+package usp_box
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock Box API (OAuth2
+// token endpoint + enterprise events endpoint), capturing the exact messages
+// it ships so their content -- timestamp and verbatim payload -- can be
+// asserted.
+
+// --- in-memory USP sink -------------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Box API -------------------------------------------------------------
+
+// mockBoxBasePosition is an arbitrary realistic Box stream position; the real
+// API hands out large opaque integers, never starting at 0.
+const mockBoxBasePosition = int64(1152922976252290800)
+
+// mockBox is an in-memory stand-in for the Box API as the adapter uses it:
+//
+//   - POST /oauth2/token: validates a client_credentials grant scoped to an
+//     enterprise (box_subject_type/box_subject_id) and issues a bearer token,
+//     exactly like https://api.box.com/oauth2/token.
+//   - GET /2.0/events?stream_type=admin_logs: validates the bearer token and
+//     serves the enterprise event stream. A created_after request (the
+//     adapter's bootstrap) returns events newer than that time; a
+//     stream_position request returns events recorded after that position.
+//     Every response carries next_stream_position pointing past the last
+//     entry returned (or the unchanged position when there is nothing new),
+//     mirroring the real long-polling stream contract.
+type mockBox struct {
+	mu sync.Mutex
+
+	clientID     string
+	clientSecret string
+	subjectID    string
+
+	issuedTokens map[string]bool
+	tokenCounter int
+
+	events     []utils.Dict // ordered admin_logs stream, oldest first
+	chunkLimit int          // max entries per response (Box default: 100)
+
+	// rewindNext, when set, makes the next stream_position request start one
+	// event early, redelivering the last already-served entry once -- the
+	// at-least-once behavior a Box stream consumer must tolerate.
+	rewindNext bool
+
+	tokenRequests int
+	eventRequests int
+	initRequests  int // events requests using created_after (the bootstrap)
+}
+
+func newMockBox(clientID, clientSecret, subjectID string) *mockBox {
+	return &mockBox{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		subjectID:    subjectID,
+		issuedTokens: map[string]bool{},
+		chunkLimit:   100,
+	}
+}
+
+func (m *mockBox) addEvent(e utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, e)
+}
+
+func (m *mockBox) setChunkLimit(n int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.chunkLimit = n
+}
+
+func (m *mockBox) redeliverLastOnce() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rewindNext = true
+}
+
+func (m *mockBox) tokenRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests
+}
+
+func (m *mockBox) eventRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.eventRequests
+}
+
+func (m *mockBox) initRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.initRequests
+}
+
+// server starts an httptest server exposing the mock at the same paths as the
+// real API and returns it (caller closes it).
+func (m *mockBox) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/token", m.handleToken)
+	mux.HandleFunc("/2.0/events", m.handleEvents)
+	return httptest.NewServer(mux)
+}
+
+func (m *mockBox) handleToken(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tokenRequests++
+
+	if r.Method != http.MethodPost {
+		writeBoxError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method Not Allowed")
+		return
+	}
+	if !strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+		writeBoxError(w, http.StatusBadRequest, "bad_request", "expected form-encoded body")
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeBoxError(w, http.StatusBadRequest, "bad_request", "malformed form body")
+		return
+	}
+
+	// The real endpoint rejects anything but a well-formed client_credentials
+	// grant for the enterprise subject.
+	if r.PostForm.Get("grant_type") != "client_credentials" ||
+		r.PostForm.Get("box_subject_type") != "enterprise" ||
+		r.PostForm.Get("box_subject_id") != m.subjectID ||
+		r.PostForm.Get("client_id") != m.clientID ||
+		r.PostForm.Get("client_secret") != m.clientSecret {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "invalid_client",
+			"error_description": "The client credentials are invalid",
+		})
+		return
+	}
+
+	m.tokenCounter++
+	token := fmt.Sprintf("mock-access-token-%d", m.tokenCounter)
+	m.issuedTokens[token] = true
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"access_token":  token,
+		"expires_in":    3600,
+		"restricted_to": []interface{}{},
+		"token_type":    "bearer",
+	})
+}
+
+func (m *mockBox) handleEvents(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.eventRequests++
+
+	if r.Method != http.MethodGet {
+		writeBoxError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method Not Allowed")
+		return
+	}
+
+	token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if token == "" || !m.issuedTokens[token] {
+		writeBoxError(w, http.StatusUnauthorized, "unauthorized", "Unauthorized")
+		return
+	}
+
+	q := r.URL.Query()
+	if q.Get("stream_type") != "admin_logs" {
+		writeBoxError(w, http.StatusBadRequest, "bad_request", "unsupported stream_type")
+		return
+	}
+
+	// Resolve where in the stream this request starts.
+	var idx int
+	switch {
+	case q.Get("stream_position") != "":
+		pos, err := strconv.ParseInt(q.Get("stream_position"), 10, 64)
+		if err != nil {
+			writeBoxError(w, http.StatusBadRequest, "bad_request", "invalid stream_position")
+			return
+		}
+		idx = int(pos - mockBoxBasePosition)
+		if idx < 0 {
+			idx = 0
+		}
+		if idx > len(m.events) {
+			idx = len(m.events)
+		}
+		if m.rewindNext && idx > 0 {
+			idx--
+			m.rewindNext = false
+		}
+	case q.Get("created_after") != "":
+		m.initRequests++
+		after, err := time.Parse(time.RFC3339, q.Get("created_after"))
+		if err != nil {
+			writeBoxError(w, http.StatusBadRequest, "bad_request", "invalid created_after")
+			return
+		}
+		idx = len(m.events)
+		for i, e := range m.events {
+			createdAt, _ := e["created_at"].(string)
+			ts, perr := time.Parse(time.RFC3339, createdAt)
+			if perr == nil && ts.After(after) {
+				idx = i
+				break
+			}
+		}
+	default:
+		writeBoxError(w, http.StatusBadRequest, "bad_request", "missing stream_position or created_after")
+		return
+	}
+
+	end := idx + m.chunkLimit
+	if end > len(m.events) {
+		end = len(m.events)
+	}
+	chunk := m.events[idx:end]
+	if chunk == nil {
+		chunk = []utils.Dict{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"chunk_size":           len(chunk),
+		"next_stream_position": mockBoxBasePosition + int64(end),
+		"entries":              chunk,
+	})
+}
+
+// writeBoxError emits an error body shaped like the real Box API's.
+func writeBoxError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"type":       "error",
+		"status":     status,
+		"code":       code,
+		"message":    message,
+		"help_url":   "http://developers.box.com/docs/#errors",
+		"request_id": "11111111111111111111",
+	})
+}
+
+// --- realistic fixtures -------------------------------------------------------
+
+// realisticBoxEvent returns an entry shaped like a real Box enterprise
+// (admin_logs) event: the documented top-level fields, a created_by user mini,
+// a nested source with a parent folder, and mixed scalar types. All
+// identifiers are clearly fake. created_at must be recent (the adapter's
+// dedupe window is one hour).
+func realisticBoxEvent(eventID, eventType string, createdAt time.Time) utils.Dict {
+	return utils.Dict{
+		"type":     "event",
+		"event_id": eventID,
+		"created_by": utils.Dict{
+			"type":  "user",
+			"id":    "11111111111",
+			"name":  "Jane Example",
+			"login": "jane@example.com",
+		},
+		"created_at":  createdAt.UTC().Format(time.RFC3339),
+		"recorded_at": createdAt.UTC().Add(2 * time.Second).Format(time.RFC3339),
+		"event_type":  eventType,
+		"session_id":  nil,
+		"ip_address":  "203.0.113.10",
+		"source": utils.Dict{
+			"item_type": "file",
+			"item_id":   "1111111111111",
+			"item_name": "quarterly-report.pdf",
+			"parent": utils.Dict{
+				"type": "folder",
+				"id":   "0",
+				"name": "All Files",
+			},
+			"owned_by": utils.Dict{
+				"type":  "user",
+				"id":    "11111111111",
+				"login": "jane@example.com",
+			},
+		},
+		"additional_details": utils.Dict{
+			"size":         1048576,
+			"version_id":   "1111111111112",
+			"service_id":   "1111",
+			"service_name": "Example Integration",
+			"shared_link":  false,
+		},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// --- test scaffolding ---------------------------------------------------------
+
+const (
+	testBoxClientID     = "test-box-client-id"
+	testBoxClientSecret = "test-box-client-secret"
+	testBoxSubjectID    = "1111111111"
+)
+
+// startMockAdapter wires an adapter to the mock server with an injected capture
+// sink and a short poll interval, and registers cleanup. It returns once the
+// adapter has completed its bootstrap request (the created_after call whose
+// results are discarded), so events added afterwards are picked up through the
+// stream_position mechanism.
+func startMockAdapter(t *testing.T, mock *mockBox, serverURL string, sink *captureSink, conf BoxConfig) (*BoxAdapter, chan struct{}) {
+	t.Helper()
+
+	if conf.ClientID == "" {
+		conf.ClientID = testBoxClientID
+	}
+	if conf.ClientSecret == "" {
+		conf.ClientSecret = testBoxClientSecret
+	}
+	if conf.SubjectID == "" {
+		conf.SubjectID = testBoxSubjectID
+	}
+	conf.ClientOptions = testClientOptions(t)
+	conf.EventsURL = serverURL + "/2.0/events"
+	conf.TokenURL = serverURL + "/oauth2/token"
+	if conf.PollInterval <= 0 {
+		conf.PollInterval = 25 * time.Millisecond
+	}
+
+	adapter, chStopped, err := newBoxAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	require.Eventually(t, func() bool { return mock.initRequestCount() >= 1 },
+		5*time.Second, 5*time.Millisecond, "adapter never made its bootstrap created_after request")
+
+	return adapter, chStopped
+}
+
+// --- tests ----------------------------------------------------------------------
+
+// TestBoxEventsEndToEnd drives the adapter against the mock Box API and asserts
+// the exact events shipped: the payload preserved verbatim (nested objects,
+// nulls and arrays included), a ship-time TimestampMs, and an untagged
+// EventType (the Box adapter does not set one). It also asserts the adapter's
+// bootstrap behavior: events that predate startup are not shipped, and every
+// poll performs a fresh, validated token exchange.
+func TestBoxEventsEndToEnd(t *testing.T) {
+	mock := newMockBox(testBoxClientID, testBoxClientSecret, testBoxSubjectID)
+	// An event already in the stream before the adapter starts: the bootstrap
+	// request consumes (and discards) it, so it must never ship.
+	mock.addEvent(realisticBoxEvent("00000000-0000-0000-0000-00000000pre1", "LOGIN", time.Now().Add(-5*time.Minute)))
+
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	_, chStopped := startMockAdapter(t, mock, server.URL, sink, BoxConfig{})
+
+	beforeMs := uint64(time.Now().UnixMilli())
+	want := []utils.Dict{
+		realisticBoxEvent("11111111-1111-1111-1111-111111111101", "LOGIN", time.Now().Add(-3*time.Minute)),
+		realisticBoxEvent("11111111-1111-1111-1111-111111111102", "UPLOAD", time.Now().Add(-2*time.Minute)),
+		realisticBoxEvent("11111111-1111-1111-1111-111111111103", "DELETE", time.Now().Add(-1*time.Minute)),
+	}
+	for _, e := range want {
+		mock.addEvent(e)
+	}
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond, "expected all 3 events to ship")
+
+	// Re-polling must not re-ship: the stream position has advanced past the
+	// shipped events, so the count stays at 3 across many further polls.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 20*time.Millisecond, "events were re-shipped on a later poll")
+
+	afterMs := uint64(time.Now().UnixMilli())
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		require.NotNil(t, msg.JsonPayload)
+		// The Box adapter ships events untagged; the platform comes from the
+		// client options.
+		assert.Equal(t, "", msg.EventType)
+		// The adapter stamps ship time, not the event's created_at.
+		assert.GreaterOrEqual(t, msg.TimestampMs, beforeMs)
+		assert.LessOrEqual(t, msg.TimestampMs, afterMs)
+
+		id, _ := msg.JsonPayload["event_id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+	assert.NotContains(t, byID, "00000000-0000-0000-0000-00000000pre1",
+		"events predating startup are discarded by the bootstrap request")
+
+	for _, src := range want {
+		id := src["event_id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "event %s was not shipped", id)
+		// The payload is shipped verbatim -- nested objects, nulls and mixed
+		// types included.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Box entry")
+	}
+
+	// The adapter authenticates on every poll; each exchange was validated by
+	// the mock (an invalid one would have failed the whole flow).
+	assert.GreaterOrEqual(t, mock.tokenRequestCount(), 2)
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped unexpectedly")
+	default:
+	}
+}
+
+// TestBoxMidRunEventShipsExactlyOnce verifies an event appearing while the
+// adapter is running ships exactly once, and already-shipped events are never
+// re-sent as the stream advances.
+func TestBoxMidRunEventShipsExactlyOnce(t *testing.T) {
+	mock := newMockBox(testBoxClientID, testBoxClientSecret, testBoxSubjectID)
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	startMockAdapter(t, mock, server.URL, sink, BoxConfig{})
+
+	mock.addEvent(realisticBoxEvent("11111111-1111-1111-1111-11111111aaaa", "LOGIN", time.Now().Add(-4*time.Minute)))
+	mock.addEvent(realisticBoxEvent("11111111-1111-1111-1111-11111111bbbb", "DOWNLOAD", time.Now().Add(-3*time.Minute)))
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 10*time.Millisecond)
+
+	// A new admin event occurs mid-run.
+	mock.addEvent(realisticBoxEvent("11111111-1111-1111-1111-11111111cccc", "FAILED_LOGIN", time.Now()))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond, "the mid-run event should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 20*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["event_id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{
+		"11111111-1111-1111-1111-11111111aaaa": 1,
+		"11111111-1111-1111-1111-11111111bbbb": 1,
+		"11111111-1111-1111-1111-11111111cccc": 1,
+	}, shippedPerID, "every event must ship exactly once")
+}
+
+// TestBoxMultiBatchFullyConsumed verifies a dataset larger than one chunk is
+// drained across successive polls -- the stream position advancing chunk by
+// chunk -- with every event shipped exactly once.
+func TestBoxMultiBatchFullyConsumed(t *testing.T) {
+	const total = 8
+
+	mock := newMockBox(testBoxClientID, testBoxClientSecret, testBoxSubjectID)
+	mock.setChunkLimit(3) // 8 events => chunks of 3+3+2
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	startMockAdapter(t, mock, server.URL, sink, BoxConfig{})
+
+	want := map[string]bool{}
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("11111111-1111-1111-1111-1111111111%02d", i)
+		want[id] = true
+		mock.addEvent(realisticBoxEvent(id, "UPLOAD", time.Now().Add(-time.Duration(total-i)*time.Minute)))
+	}
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 10*time.Millisecond, "all chunks should be consumed")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 20*time.Millisecond)
+
+	got := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		got[msg.JsonPayload["event_id"].(string)] = true
+	}
+	assert.Equal(t, want, got, "every distinct event should ship exactly once")
+}
+
+// TestBoxRedeliveryIsDeduped verifies that when the stream redelivers an
+// already-served entry (Box streams are at-least-once), the adapter's dedupe
+// suppresses the duplicate rather than shipping it twice.
+func TestBoxRedeliveryIsDeduped(t *testing.T) {
+	mock := newMockBox(testBoxClientID, testBoxClientSecret, testBoxSubjectID)
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	startMockAdapter(t, mock, server.URL, sink, BoxConfig{})
+
+	mock.addEvent(realisticBoxEvent("11111111-1111-1111-1111-11111111dddd", "LOGIN", time.Now().Add(-2*time.Minute)))
+	mock.addEvent(realisticBoxEvent("11111111-1111-1111-1111-11111111eeee", "DELETE", time.Now().Add(-1*time.Minute)))
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 10*time.Millisecond)
+
+	// The next poll redelivers the last entry; the dedupe map must absorb it.
+	reqsBefore := mock.eventRequestCount()
+	mock.redeliverLastOnce()
+
+	require.Eventually(t, func() bool { return mock.eventRequestCount() >= reqsBefore+2 },
+		5*time.Second, 10*time.Millisecond, "the adapter should keep polling")
+	require.Never(t, func() bool { return sink.count() != 2 },
+		300*time.Millisecond, 20*time.Millisecond, "a redelivered entry must not ship twice")
+}
+
+// TestBoxBadCredentialsShipNothing verifies that when the token endpoint
+// rejects the credentials nothing is ever shipped and the events endpoint is
+// never reached. The Box adapter does not terminate on auth failure -- it
+// keeps retrying the token exchange on its poll interval -- so the test also
+// pins that it stays alive (and quiet) across several polls.
+func TestBoxBadCredentialsShipNothing(t *testing.T) {
+	mock := newMockBox(testBoxClientID, testBoxClientSecret, testBoxSubjectID)
+	mock.addEvent(realisticBoxEvent("11111111-1111-1111-1111-11111111ffff", "LOGIN", time.Now().Add(-1*time.Minute)))
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	conf := BoxConfig{
+		ClientOptions: testClientOptions(t),
+		ClientID:      testBoxClientID,
+		ClientSecret:  "wrong-secret",
+		SubjectID:     testBoxSubjectID,
+		EventsURL:     server.URL + "/2.0/events",
+		TokenURL:      server.URL + "/oauth2/token",
+		PollInterval:  25 * time.Millisecond,
+	}
+	adapter, chStopped, err := newBoxAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// Several polls' worth of rejected token exchanges.
+	require.Eventually(t, func() bool { return mock.tokenRequestCount() >= 3 },
+		5*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, 0, sink.count(), "nothing should ship with bad credentials")
+	assert.Equal(t, 0, mock.eventRequestCount(), "the events endpoint must not be called without a token")
+
+	select {
+	case <-chStopped:
+		t.Fatal("the Box adapter does not stop on auth failure; it retries on its poll interval")
+	default:
+	}
+}

--- a/cato/client.go
+++ b/cato/client.go
@@ -23,6 +23,9 @@ import (
 
 const (
 	defaultWriteTimeout = 60 * 10
+	// defaultGraphqlURL is the Cato Networks GraphQL endpoint used when the
+	// config does not override it.
+	defaultGraphqlURL = "https://api.catonetworks.com/api/v1/graphql2"
 )
 
 var (
@@ -32,6 +35,9 @@ var (
 	start                  time.Time
 	marker                 string
 	configFile             string = "./config.txt"
+	// pollInterval is how long the feed loop waits between eventsFeed calls.
+	// It is a package variable (not a constant) only so tests can shorten it.
+	pollInterval = 1 * time.Minute
 )
 
 type CatoConfig struct {
@@ -39,6 +45,9 @@ type CatoConfig struct {
 	WriteTimeoutSec uint64                  `json:"write_timeout_sec,omitempty" yaml:"write_timeout_sec,omitempty"`
 	ApiKey          string                  `json:"apikey" yaml:"apikey"`
 	AccountId       int                     `json:"accountid" yaml:"accountid"`
+	// Url optionally overrides the Cato GraphQL endpoint. Empty means the
+	// production endpoint (defaultGraphqlURL).
+	Url string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
 func (c *CatoConfig) Validate() error {
@@ -54,12 +63,20 @@ func (c *CatoConfig) Validate() error {
 	return nil
 }
 
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type CatoAdapter struct {
 	conf         CatoConfig
 	wg           sync.WaitGroup
 	isRunning    uint32
 	mRunning     sync.RWMutex
-	uspClient    *uspclient.Client
+	uspClient    uspSink
 	writeTimeout time.Duration
 
 	chStopped chan struct{}
@@ -69,6 +86,13 @@ type CatoAdapter struct {
 }
 
 func NewCatoAdapter(ctx context.Context, conf CatoConfig) (*CatoAdapter, chan struct{}, error) {
+	return newCatoAdapter(ctx, conf, nil)
+}
+
+// newCatoAdapter is the implementation behind NewCatoAdapter. When sink is
+// non-nil it is used in place of a real LimaCharlie client -- the seam tests
+// use to capture shipped events.
+func newCatoAdapter(ctx context.Context, conf CatoConfig, sink uspSink) (*CatoAdapter, chan struct{}, error) {
 	a := &CatoAdapter{
 		conf:      conf,
 		isRunning: 1,
@@ -79,10 +103,14 @@ func NewCatoAdapter(ctx context.Context, conf CatoConfig) (*CatoAdapter, chan st
 	}
 	a.writeTimeout = time.Duration(a.conf.WriteTimeoutSec) * time.Second
 
-	var err error
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.chStopped = make(chan struct{})
@@ -143,6 +171,7 @@ func (a *CatoAdapter) convertStructToMap(obj interface{}) map[string]interface{}
 }
 
 func (a *CatoAdapter) handleEvent(marker *string, account_id string, api_key string) {
+	defer a.wgSenders.Done()
 
 	start = time.Now()
 
@@ -153,6 +182,15 @@ func (a *CatoAdapter) handleEvent(marker *string, account_id string, api_key str
 	totalCount := 0
 
 	for {
+		// Exit if the adapter was asked to stop (test seam; in production
+		// nothing flips isRunning before the process exits).
+		a.mRunning.RLock()
+		running := a.isRunning
+		a.mRunning.RUnlock()
+		if running == 0 {
+			return
+		}
+
 		query := fmt.Sprintf(`{
   eventsFeed(accountIDs:[%q]
     marker:%q
@@ -239,9 +277,18 @@ func (a *CatoAdapter) handleEvent(marker *string, account_id string, api_key str
 		iteration++
 
 		// Add sleep to ensure the request is made every 1 minute
-		time.Sleep(1 * time.Minute)
+		time.Sleep(pollInterval)
 	}
 
+}
+
+// graphqlURL returns the Cato GraphQL endpoint to call: the config override
+// when set, the production endpoint otherwise.
+func (a *CatoAdapter) graphqlURL() string {
+	if a.conf.Url != "" {
+		return a.conf.Url
+	}
+	return defaultGraphqlURL
 }
 
 func (a *CatoAdapter) send(query string, account_id string, api_key string) (bool, map[string]interface{}) {
@@ -266,7 +313,7 @@ func (a *CatoAdapter) send(query string, account_id string, api_key string) (boo
 			continue
 		}
 
-		req, err := http.NewRequest("POST", "https://api.catonetworks.com/api/v1/graphql2", bytes.NewBuffer(jsonData))
+		req, err := http.NewRequest("POST", a.graphqlURL(), bytes.NewBuffer(jsonData))
 		if err != nil {
 			a.conf.ClientOptions.DebugLog(fmt.Sprintf("ERROR %d: %v", retryCount, err))
 			time.Sleep(2 * time.Second)

--- a/cato/client_test.go
+++ b/cato/client_test.go
@@ -1,0 +1,63 @@
+package usp_cato
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestCatoConfigValidate(t *testing.T) {
+	t.Run("requires apikey", func(t *testing.T) {
+		c := CatoConfig{ClientOptions: testClientOptions(t), AccountId: testAccountID}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires accountid", func(t *testing.T) {
+		c := CatoConfig{ClientOptions: testClientOptions(t), ApiKey: testAPIKey}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("accepts a complete config, url optional", func(t *testing.T) {
+		c := CatoConfig{ClientOptions: testClientOptions(t), ApiKey: testAPIKey, AccountId: testAccountID}
+		assert.NoError(t, c.Validate())
+		c.Url = "https://cato-mock.example.com/api/v1/graphql2"
+		assert.NoError(t, c.Validate())
+	})
+}
+
+// TestGraphqlURL guards the production endpoint and the config override.
+func TestGraphqlURL(t *testing.T) {
+	a := &CatoAdapter{}
+	assert.Equal(t, "https://api.catonetworks.com/api/v1/graphql2", a.graphqlURL(),
+		"an empty config must target the production Cato endpoint")
+
+	a.conf.Url = "https://cato-mock.example.com/api/v1/graphql2"
+	assert.Equal(t, "https://cato-mock.example.com/api/v1/graphql2", a.graphqlURL())
+}

--- a/cato/mock_test.go
+++ b/cato/mock_test.go
@@ -15,8 +15,9 @@ package usp_cato
 //   - The {"data":{"eventsFeed":{marker,fetchedCount,accounts:[{id,records:
 //     [{time,fieldsMap}]}]}}} envelope, with an opaque marker cursor that
 //     resumes the feed where the previous call left off.
-//   - GraphQL errors as {"errors":[{"message":...}]} (bad API key, bad
-//     account, rate limiting), which is how Cato reports failures.
+//   - GraphQL errors as HTTP 200 + {"errors":[{"message":...}]} (bad API key
+//     -- "permission denied" -- bad account, rate limiting), which is how
+//     Cato reports failures.
 
 import (
 	"compress/gzip"
@@ -161,14 +162,25 @@ func (m *mockCato) handler() http.HandlerFunc {
 		}
 		assert.Equal(m.t, "application/json", r.Header.Get("Content-Type"))
 
-		// Authentication: the x-api-key header. Cato reports a bad key as a
-		// GraphQL errors envelope, which the adapter detects via the "errors"
-		// key.
+		// Authentication: the x-api-key header. The real API answers a bad key
+		// with HTTP 200 and a GraphQL errors envelope -- verbatim:
+		// {"errors":[{"message":"permission denied","path":["eventsFeed"],
+		// "extensions":{"code":"Code104"}}],"data":{"eventsFeed":null}} --
+		// which the adapter detects via the "errors" key.
 		if r.Header.Get("x-api-key") != m.apiKey {
 			m.mu.Lock()
 			m.authFailures++
 			m.mu.Unlock()
-			writeGzipJSON(m.t, w, errorsEnvelope("Invalid authentication credentials"))
+			writeGzipJSON(m.t, w, map[string]interface{}{
+				"errors": []interface{}{
+					map[string]interface{}{
+						"message":    "permission denied",
+						"path":       []interface{}{"eventsFeed"},
+						"extensions": map[string]interface{}{"code": "Code104"},
+					},
+				},
+				"data": map[string]interface{}{"eventsFeed": nil},
+			})
 			return
 		}
 
@@ -300,7 +312,8 @@ func writeGzipRaw(t *testing.T, w http.ResponseWriter, b []byte) {
 
 // securityEvent returns a record shaped like a real Cato eventsFeed Security /
 // Internet Firewall event: the documented fieldsMap field names with clearly
-// fake values (example.com users, RFC 5737 addresses, all-1s account id).
+// fake values (example.com users, RFC 1918 / RFC 5737 addresses, all-1s
+// account id).
 func securityEvent(i int, ts string) catoRecord {
 	return catoRecord{
 		Time: ts,
@@ -489,9 +502,11 @@ func TestCatoRepollDoesNotReship(t *testing.T) {
 	require.Eventually(t, func() bool { return sink.count() == 3 },
 		5*time.Second, 10*time.Millisecond)
 
-	// Let at least three more polls complete.
-	base := mock.requestCount()
-	require.Eventually(t, func() bool { return mock.requestCount() >= base+3 },
+	// Let at least three more polls complete. Wait on the markers the mock
+	// recorded (not its raw request counter, which is incremented before the
+	// marker is parsed) so the snapshot below is guaranteed to include them.
+	base := len(mock.markers())
+	require.Eventually(t, func() bool { return len(mock.markers()) >= base+3 },
 		5*time.Second, 10*time.Millisecond, "the adapter should keep polling")
 
 	assert.Equal(t, 3, sink.count(), "re-polling must not re-ship events")
@@ -670,7 +685,11 @@ func TestCatoSendBadAPIKey(t *testing.T) {
 	ok, resp := a.send(eventsFeedQuery(mock.accountID, ""), mock.accountID, "wrong-api-key")
 
 	assert.False(t, ok, "a bad API key must fail the call")
-	require.Contains(t, resp, "errors")
+	errs, isList := resp["errors"].([]interface{})
+	require.True(t, isList, "errors must be the GraphQL error list, got %T", resp["errors"])
+	require.Len(t, errs, 1)
+	assert.Equal(t, "permission denied", errs[0].(map[string]interface{})["message"],
+		"the error details Cato returns for a bad key must be preserved")
 	assert.Equal(t, 1, mock.authFailureCount())
 	assert.Equal(t, 1, mock.requestCount(), "a credential rejection must not be retried")
 }

--- a/cato/mock_test.go
+++ b/cato/mock_test.go
@@ -1,0 +1,713 @@
+package usp_cato
+
+// This file exercises the adapter end-to-end against a mock of the Cato
+// Networks GraphQL eventsFeed API (https://api.catonetworks.com/api/v1/graphql2),
+// capturing the exact messages it ships so their content -- verbatim payload,
+// timestamp, marker handling -- can be asserted without live credentials.
+//
+// The mock reproduces the API the way the adapter consumes it:
+//   - POST /api/v1/graphql2 with the x-api-key header and a {"query": "..."}
+//     JSON body (the adapter inlines accountIDs/marker into the query string;
+//     it does not use GraphQL variables).
+//   - A gzip-compressed response body. The adapter sets Accept-Encoding
+//     itself and gunzips the body unconditionally, exactly like the real API
+//     behaves for it.
+//   - The {"data":{"eventsFeed":{marker,fetchedCount,accounts:[{id,records:
+//     [{time,fieldsMap}]}]}}} envelope, with an opaque marker cursor that
+//     resumes the feed where the previous call left off.
+//   - GraphQL errors as {"errors":[{"message":...}]} (bad API key, bad
+//     account, rate limiting), which is how Cato reports failures.
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAPIKey    = "test-cato-api-key-1111111111111111"
+	testAccountID = 11111111
+
+	// mockMarkerPrefix prefixes the opaque cursor the mock hands out. The
+	// suffix encodes the feed offset so the mock can resume.
+	mockMarkerPrefix = "mock-marker-"
+)
+
+// --- in-memory USP sink -------------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Cato GraphQL API ----------------------------------------------------
+
+// catoRecord is one event of the mock's in-memory feed, mirroring an
+// eventsFeed EventRecord: an ISO-8601 time plus the fieldsMap of event fields.
+type catoRecord struct {
+	Time      string
+	FieldsMap map[string]interface{}
+}
+
+// mockCato is an in-memory stand-in for the Cato eventsFeed API.
+type mockCato struct {
+	t         *testing.T
+	apiKey    string
+	accountID string
+
+	mu           sync.Mutex
+	events       []catoRecord
+	batchSize    int    // max records per response; 0 means everything pending
+	rateLimited  int    // number of upcoming requests answered with a rate-limit error
+	forcedError  string // when set, every request gets this GraphQL error
+	markersSeen  []string
+	requests     int
+	authFailures int
+}
+
+func newMockCato(t *testing.T) *mockCato {
+	return &mockCato{
+		t:         t,
+		apiKey:    testAPIKey,
+		accountID: strconv.Itoa(testAccountID),
+	}
+}
+
+func (m *mockCato) addEvent(rec catoRecord) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, rec)
+}
+
+func (m *mockCato) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+func (m *mockCato) authFailureCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.authFailures
+}
+
+func (m *mockCato) markers() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.markersSeen))
+	copy(out, m.markersSeen)
+	return out
+}
+
+var (
+	// The adapter inlines its parameters into the query text; these extract
+	// them the way a GraphQL server would after parsing.
+	accountIDsRe = regexp.MustCompile(`accountIDs:\["([^"]*)"\]`)
+	markerRe     = regexp.MustCompile(`marker:"([^"]*)"`)
+)
+
+func (m *mockCato) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.requests++
+		m.mu.Unlock()
+
+		// Request shape: POST to the graphql2 path with a JSON body. assert
+		// (not require) because this runs on an httptest goroutine.
+		if !assert.Equal(m.t, http.MethodPost, r.Method, "the adapter must POST") ||
+			!assert.Equal(m.t, "/api/v1/graphql2", r.URL.Path, "wrong API path") {
+			writeGzipJSON(m.t, w, errorsEnvelope("bad request"))
+			return
+		}
+		assert.Equal(m.t, "application/json", r.Header.Get("Content-Type"))
+
+		// Authentication: the x-api-key header. Cato reports a bad key as a
+		// GraphQL errors envelope, which the adapter detects via the "errors"
+		// key.
+		if r.Header.Get("x-api-key") != m.apiKey {
+			m.mu.Lock()
+			m.authFailures++
+			m.mu.Unlock()
+			writeGzipJSON(m.t, w, errorsEnvelope("Invalid authentication credentials"))
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if !assert.NoError(m.t, err) {
+			writeGzipJSON(m.t, w, errorsEnvelope("unreadable body"))
+			return
+		}
+		var req struct {
+			Query string `json:"query"`
+		}
+		if !assert.NoError(m.t, json.Unmarshal(body, &req), "body must be {\"query\": ...} JSON") ||
+			!assert.Contains(m.t, req.Query, "eventsFeed", "query must target eventsFeed") {
+			writeGzipJSON(m.t, w, errorsEnvelope("malformed query"))
+			return
+		}
+		// The adapter must ask for everything it later consumes.
+		for _, field := range []string{"marker", "fetchedCount", "accounts", "records", "time", "fieldsMap"} {
+			assert.Contains(m.t, req.Query, field, "query must select %q", field)
+		}
+
+		accountMatch := accountIDsRe.FindStringSubmatch(req.Query)
+		if !assert.NotNil(m.t, accountMatch, "query must carry accountIDs") {
+			writeGzipJSON(m.t, w, errorsEnvelope("missing accountIDs"))
+			return
+		}
+		if accountMatch[1] != m.accountID {
+			writeGzipJSON(m.t, w, errorsEnvelope(fmt.Sprintf("account %s not found", accountMatch[1])))
+			return
+		}
+		markerMatch := markerRe.FindStringSubmatch(req.Query)
+		if !assert.NotNil(m.t, markerMatch, "query must carry a marker") {
+			writeGzipJSON(m.t, w, errorsEnvelope("missing marker"))
+			return
+		}
+		marker := markerMatch[1]
+
+		m.mu.Lock()
+		m.markersSeen = append(m.markersSeen, marker)
+
+		if m.rateLimited > 0 {
+			m.rateLimited--
+			m.mu.Unlock()
+			// Must match the exact prefix the adapter sniffs for.
+			writeGzipRaw(m.t, w, []byte(`{"errors":[{"message":"rate limit for operation: eventsFeed. Try again in 5 seconds"}]}`))
+			return
+		}
+		if m.forcedError != "" {
+			msg := m.forcedError
+			m.mu.Unlock()
+			writeGzipJSON(m.t, w, errorsEnvelope(msg))
+			return
+		}
+
+		// Resolve the marker to a feed offset; an empty marker starts from the
+		// beginning of the retained feed, like a first call to the real API.
+		offset := 0
+		if marker != "" {
+			n, convErr := strconv.Atoi(strings.TrimPrefix(marker, mockMarkerPrefix))
+			if !assert.NoError(m.t, convErr, "unknown marker %q", marker) {
+				m.mu.Unlock()
+				writeGzipJSON(m.t, w, errorsEnvelope("invalid marker"))
+				return
+			}
+			offset = n
+		}
+		if offset > len(m.events) {
+			offset = len(m.events)
+		}
+		end := len(m.events)
+		if m.batchSize > 0 && offset+m.batchSize < end {
+			end = offset + m.batchSize
+		}
+		batch := m.events[offset:end]
+		records := make([]interface{}, 0, len(batch))
+		for _, e := range batch {
+			records = append(records, map[string]interface{}{
+				"time":      e.Time,
+				"fieldsMap": e.FieldsMap,
+			})
+		}
+		newMarker := mockMarkerPrefix + strconv.Itoa(end)
+		m.mu.Unlock()
+
+		writeGzipJSON(m.t, w, map[string]interface{}{
+			"data": map[string]interface{}{
+				"eventsFeed": map[string]interface{}{
+					"marker":       newMarker,
+					"fetchedCount": len(batch),
+					"accounts": []interface{}{
+						map[string]interface{}{
+							"id":      m.accountID,
+							"records": records,
+						},
+					},
+				},
+			},
+		})
+	}
+}
+
+func errorsEnvelope(msg string) map[string]interface{} {
+	return map[string]interface{}{
+		"errors": []interface{}{
+			map[string]interface{}{"message": msg},
+		},
+	}
+}
+
+// writeGzipJSON writes v as a gzip-compressed JSON body. The adapter requests
+// "Accept-Encoding: gzip" itself and always gunzips the raw body, so the mock
+// must compress every response just like the real API does.
+func writeGzipJSON(t *testing.T, w http.ResponseWriter, v interface{}) {
+	b, err := json.Marshal(v)
+	assert.NoError(t, err)
+	writeGzipRaw(t, w, b)
+}
+
+func writeGzipRaw(t *testing.T, w http.ResponseWriter, b []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Encoding", "gzip")
+	gz := gzip.NewWriter(w)
+	_, err := gz.Write(b)
+	assert.NoError(t, err)
+	assert.NoError(t, gz.Close())
+}
+
+// --- realistic event fixtures ---------------------------------------------------
+
+// securityEvent returns a record shaped like a real Cato eventsFeed Security /
+// Internet Firewall event: the documented fieldsMap field names with clearly
+// fake values (example.com users, RFC 5737 addresses, all-1s account id).
+func securityEvent(i int, ts string) catoRecord {
+	return catoRecord{
+		Time: ts,
+		FieldsMap: map[string]interface{}{
+			"event_type":          "Security",
+			"event_sub_type":      "Internet Firewall",
+			"action":              "Block",
+			"rule":                "Block Malicious Categories",
+			"rule_name":           "Block Malicious Categories",
+			"src_ip":              fmt.Sprintf("10.0.0.%d", 10+i),
+			"src_site":            "branch-example-1",
+			"src_is_site_or_vpn":  "Site",
+			"dest_ip":             "203.0.113.55",
+			"dest_port":           "443",
+			"dest_country":        "United States",
+			"dest_is_site_or_vpn": "Internet",
+			"application":         "HTTPS",
+			"os_type":             "OS_WINDOWS",
+			"pop_name":            "Example-POP-1",
+			"user_name":           "alice@example.com",
+			"ISP_name":            "Example ISP Inc",
+			"traffic_direction":   "OUTBOUND",
+			"account_id":          strconv.Itoa(testAccountID),
+			"internalId":          fmt.Sprintf("ZmFrZS1ldmVudC0x-%d", i),
+			"time_str":            ts,
+		},
+	}
+}
+
+// connectivityEvent returns a record shaped like a Cato Connectivity event.
+func connectivityEvent(i int, ts string) catoRecord {
+	return catoRecord{
+		Time: ts,
+		FieldsMap: map[string]interface{}{
+			"event_type":     "Connectivity",
+			"event_sub_type": "Connected",
+			"src_site":       fmt.Sprintf("branch-example-%d", i),
+			"link_type":      "Cato",
+			"pop_name":       "Example-POP-2",
+			"ISP_name":       "Example ISP Inc",
+			"account_id":     strconv.Itoa(testAccountID),
+			"internalId":     fmt.Sprintf("ZmFrZS1jb25uLTE-%d", i),
+			"time_str":       ts,
+		},
+	}
+}
+
+// expectedPayload is what the adapter ships for a record: the fieldsMap plus
+// the record's time injected as "event_timestamp".
+func expectedPayload(rec catoRecord) map[string]interface{} {
+	out := make(map[string]interface{}, len(rec.FieldsMap)+1)
+	for k, v := range rec.FieldsMap {
+		out[k] = v
+	}
+	out["event_timestamp"] = rec.Time
+	return out
+}
+
+// --- test harness ---------------------------------------------------------------
+
+// resetAdapterGlobals resets the package-level state the adapter keeps between
+// runs (the marker cursor, its on-disk persistence path) and shortens the poll
+// interval so tests iterate quickly. It must only be called when no adapter
+// goroutine is running.
+func resetAdapterGlobals(t *testing.T) {
+	t.Helper()
+	marker = ""
+	configFile = filepath.Join(t.TempDir(), "cato-marker.txt")
+	pollInterval = 25 * time.Millisecond
+}
+
+// newMockServer starts an httptest server for the mock, closed at test end
+// (after the adapter is stopped -- cleanups run LIFO).
+func newMockServer(t *testing.T, mock *mockCato) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(mock.handler())
+	t.Cleanup(server.Close)
+	return server
+}
+
+// startTestAdapter resets package globals, optionally pre-seeds the persisted
+// marker file, and starts the adapter against the mock with an in-memory sink.
+// The adapter is stopped (and waited for) at test end.
+func startTestAdapter(t *testing.T, mock *mockCato, server *httptest.Server, preMarker string) *captureSink {
+	t.Helper()
+	resetAdapterGlobals(t)
+	if preMarker != "" {
+		require.NoError(t, os.WriteFile(configFile, []byte(preMarker+"\n"), 0o644))
+	}
+
+	sink := &captureSink{}
+	conf := CatoConfig{
+		ClientOptions: testClientOptions(t),
+		ApiKey:        mock.apiKey,
+		AccountId:     testAccountID,
+		Url:           server.URL + "/api/v1/graphql2",
+	}
+	require.NoError(t, conf.Validate())
+
+	adapter, chStopped, err := newCatoAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	t.Cleanup(func() { stopAdapter(t, adapter, chStopped) })
+	return sink
+}
+
+// stopAdapter asks the polling goroutine to exit and waits until it has. The
+// adapter's Close() is not usable as a stop mechanism (it calls Done() on a
+// WaitGroup that was never Add()ed, which panics), so tests flip the
+// isRunning flag the feed loop checks.
+func stopAdapter(t *testing.T, a *CatoAdapter, chStopped chan struct{}) {
+	t.Helper()
+	a.mRunning.Lock()
+	a.isRunning = 0
+	a.mRunning.Unlock()
+	select {
+	case <-chStopped:
+	case <-time.After(10 * time.Second):
+		t.Fatal("adapter goroutine did not stop")
+	}
+}
+
+func readPersistedMarker(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(configFile)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// --- end-to-end tests -------------------------------------------------------------
+
+// TestCatoEventsFeedEndToEnd drives the adapter against the mock API and
+// asserts the exact events shipped: each record's fieldsMap is forwarded
+// verbatim with the record time injected as event_timestamp, the message is
+// stamped with the ship time (this adapter does not parse the event time into
+// TimestampMs and does not set an EventType), and the first request starts
+// from an empty marker.
+func TestCatoEventsFeedEndToEnd(t *testing.T) {
+	mock := newMockCato(t)
+	events := []catoRecord{
+		securityEvent(1, "2026-06-11T10:00:00Z"),
+		securityEvent(2, "2026-06-11T10:00:05Z"),
+		connectivityEvent(3, "2026-06-11T10:00:09Z"),
+	}
+	for _, e := range events {
+		mock.addEvent(e)
+	}
+	server := newMockServer(t, mock)
+
+	startMs := uint64(time.Now().UnixMilli())
+	sink := startTestAdapter(t, mock, server, "")
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond, "expected all 3 events to ship")
+
+	msgs := sink.snapshot()
+	require.Len(t, msgs, 3)
+	for i, msg := range msgs {
+		// Payload: the fieldsMap verbatim + event_timestamp from the record time.
+		assert.JSONEq(t, mustJSON(t, expectedPayload(events[i])), mustJSON(t, msg.JsonPayload),
+			"event %d payload must be the record's fieldsMap plus event_timestamp", i)
+		// This adapter stamps messages with the ship time, not the event time.
+		assert.GreaterOrEqual(t, msg.TimestampMs, startMs, "event %d TimestampMs", i)
+		assert.LessOrEqual(t, msg.TimestampMs, uint64(time.Now().UnixMilli()), "event %d TimestampMs", i)
+		// And it ships untyped JSON (the platform comes from ClientOptions).
+		assert.Empty(t, msg.EventType, "event %d should have no per-event type", i)
+	}
+
+	markers := mock.markers()
+	require.NotEmpty(t, markers)
+	assert.Equal(t, "", markers[0], "the first poll must start from an empty marker")
+	assert.Zero(t, mock.authFailureCount())
+}
+
+// TestCatoRepollDoesNotReship verifies the marker advances after the first
+// batch and later polls carry it, so nothing is shipped twice.
+func TestCatoRepollDoesNotReship(t *testing.T) {
+	mock := newMockCato(t)
+	for i := 1; i <= 3; i++ {
+		mock.addEvent(securityEvent(i, fmt.Sprintf("2026-06-11T10:00:0%dZ", i)))
+	}
+	server := newMockServer(t, mock)
+	sink := startTestAdapter(t, mock, server, "")
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond)
+
+	// Let at least three more polls complete.
+	base := mock.requestCount()
+	require.Eventually(t, func() bool { return mock.requestCount() >= base+3 },
+		5*time.Second, 10*time.Millisecond, "the adapter should keep polling")
+
+	assert.Equal(t, 3, sink.count(), "re-polling must not re-ship events")
+
+	markers := mock.markers()
+	require.GreaterOrEqual(t, len(markers), 4)
+	assert.Equal(t, "", markers[0])
+	for i, mk := range markers[1:] {
+		assert.Equal(t, mockMarkerPrefix+"3", mk, "poll %d must resume from the advanced marker", i+1)
+	}
+
+	// The advanced marker is also persisted to disk between polls.
+	assert.Equal(t, mockMarkerPrefix+"3", readPersistedMarker(t))
+}
+
+// TestCatoMidRunEventShipsExactlyOnce verifies an event appearing while the
+// adapter is running is picked up by a later poll and shipped exactly once.
+func TestCatoMidRunEventShipsExactlyOnce(t *testing.T) {
+	mock := newMockCato(t)
+	mock.addEvent(securityEvent(1, "2026-06-11T10:00:00Z"))
+	mock.addEvent(securityEvent(2, "2026-06-11T10:00:01Z"))
+	server := newMockServer(t, mock)
+	sink := startTestAdapter(t, mock, server, "")
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 10*time.Millisecond)
+
+	// A new event arrives mid-run.
+	late := connectivityEvent(9, "2026-06-11T10:05:00Z")
+	mock.addEvent(late)
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond, "the mid-run event should ship")
+
+	// Let more polls happen, then confirm nothing was duplicated.
+	base := mock.requestCount()
+	require.Eventually(t, func() bool { return mock.requestCount() >= base+2 },
+		5*time.Second, 10*time.Millisecond)
+	assert.Equal(t, 3, sink.count(), "no event may ship more than once")
+
+	perID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		id, _ := msg.JsonPayload["internalId"].(string)
+		require.NotEmpty(t, id)
+		perID[id]++
+	}
+	assert.Equal(t, map[string]int{
+		"ZmFrZS1ldmVudC0x-1": 1,
+		"ZmFrZS1ldmVudC0x-2": 1,
+		"ZmFrZS1jb25uLTE-9":  1,
+	}, perID, "every event must ship exactly once")
+}
+
+// TestCatoMultiBatchFeedFullyConsumed verifies a backlog larger than one
+// eventsFeed batch is drained across successive polls via the marker cursor,
+// in order and without gaps or duplicates.
+func TestCatoMultiBatchFeedFullyConsumed(t *testing.T) {
+	mock := newMockCato(t)
+	mock.batchSize = 2
+	events := make([]catoRecord, 0, 5)
+	for i := 1; i <= 5; i++ {
+		e := securityEvent(i, fmt.Sprintf("2026-06-11T10:00:0%dZ", i))
+		events = append(events, e)
+		mock.addEvent(e)
+	}
+	server := newMockServer(t, mock)
+	sink := startTestAdapter(t, mock, server, "")
+
+	require.Eventually(t, func() bool { return sink.count() == 5 },
+		5*time.Second, 10*time.Millisecond, "all batches should be consumed")
+
+	msgs := sink.snapshot()
+	require.Len(t, msgs, 5)
+	for i, msg := range msgs {
+		assert.JSONEq(t, mustJSON(t, expectedPayload(events[i])), mustJSON(t, msg.JsonPayload),
+			"event %d must ship in feed order", i)
+	}
+
+	// The batches were walked through the marker cursor: "" -> 2 -> 4 -> 5.
+	markers := mock.markers()
+	require.GreaterOrEqual(t, len(markers), 3)
+	assert.Equal(t, []string{"", mockMarkerPrefix + "2", mockMarkerPrefix + "4"}, markers[:3])
+
+	// And the feed stays drained.
+	base := mock.requestCount()
+	require.Eventually(t, func() bool { return mock.requestCount() >= base+2 },
+		5*time.Second, 10*time.Millisecond)
+	assert.Equal(t, 5, sink.count())
+}
+
+// TestCatoMarkerPersistenceResume verifies the adapter resumes from the marker
+// persisted on disk by a previous run: events before the marker are not
+// re-shipped, and the file is updated as the feed advances.
+func TestCatoMarkerPersistenceResume(t *testing.T) {
+	mock := newMockCato(t)
+	events := make([]catoRecord, 0, 4)
+	for i := 1; i <= 4; i++ {
+		e := securityEvent(i, fmt.Sprintf("2026-06-11T10:00:0%dZ", i))
+		events = append(events, e)
+		mock.addEvent(e)
+	}
+	server := newMockServer(t, mock)
+
+	// A previous run consumed the first two events.
+	sink := startTestAdapter(t, mock, server, mockMarkerPrefix+"2")
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 10*time.Millisecond, "only the events after the marker should ship")
+
+	markers := mock.markers()
+	require.NotEmpty(t, markers)
+	assert.Equal(t, mockMarkerPrefix+"2", markers[0],
+		"the first request must resume from the persisted marker")
+
+	msgs := sink.snapshot()
+	require.Len(t, msgs, 2)
+	assert.JSONEq(t, mustJSON(t, expectedPayload(events[2])), mustJSON(t, msgs[0].JsonPayload))
+	assert.JSONEq(t, mustJSON(t, expectedPayload(events[3])), mustJSON(t, msgs[1].JsonPayload))
+
+	require.Eventually(t, func() bool { return readPersistedMarker(t) == mockMarkerPrefix+"4" },
+		5*time.Second, 10*time.Millisecond, "the advanced marker must be persisted")
+	assert.Equal(t, 2, sink.count(), "nothing may be re-shipped after resuming")
+}
+
+// --- send() behavior tests ----------------------------------------------------------
+//
+// Failure handling lives in the adapter's send(): a response carrying a
+// GraphQL "errors" key is reported as a failure to the caller; a rate-limit
+// error is retried in place. These are exercised directly (on an adapter
+// struct that has no polling goroutine) because the feed loop's own failure
+// path retries with multi-second sleeps and then crashes the process, which
+// cannot be hosted in a unit test.
+
+// bareAdapter builds a CatoAdapter without starting the polling goroutine, for
+// driving send() directly.
+func bareAdapter(t *testing.T, server *httptest.Server, apiKey string) *CatoAdapter {
+	t.Helper()
+	return &CatoAdapter{
+		conf: CatoConfig{
+			ClientOptions: testClientOptions(t),
+			ApiKey:        apiKey,
+			AccountId:     testAccountID,
+			Url:           server.URL + "/api/v1/graphql2",
+		},
+	}
+}
+
+// eventsFeedQuery mirrors the query string the feed loop builds.
+func eventsFeedQuery(accountID, marker string) string {
+	return fmt.Sprintf(`{
+  eventsFeed(accountIDs:[%q]
+    marker:%q
+    filters:[,])
+  {
+    marker
+    fetchedCount
+    accounts {
+      id
+      records {
+        time
+        fieldsMap
+      }
+    }
+  }
+}`, accountID, marker)
+}
+
+// TestCatoSendBadAPIKey verifies a rejected API key surfaces as a failed
+// send() carrying the GraphQL errors envelope, with nothing retried.
+func TestCatoSendBadAPIKey(t *testing.T) {
+	mock := newMockCato(t)
+	mock.addEvent(securityEvent(1, "2026-06-11T10:00:00Z"))
+	server := newMockServer(t, mock)
+
+	a := bareAdapter(t, server, "wrong-api-key")
+	ok, resp := a.send(eventsFeedQuery(mock.accountID, ""), mock.accountID, "wrong-api-key")
+
+	assert.False(t, ok, "a bad API key must fail the call")
+	require.Contains(t, resp, "errors")
+	assert.Equal(t, 1, mock.authFailureCount())
+	assert.Equal(t, 1, mock.requestCount(), "a credential rejection must not be retried")
+}
+
+// TestCatoSendGraphQLError verifies any GraphQL errors envelope (e.g. an
+// unknown account) is reported as a failure with the error details preserved.
+func TestCatoSendGraphQLError(t *testing.T) {
+	mock := newMockCato(t)
+	mock.forcedError = "Validation error: account 22222222 not found"
+	server := newMockServer(t, mock)
+
+	a := bareAdapter(t, server, mock.apiKey)
+	ok, resp := a.send(eventsFeedQuery(mock.accountID, ""), mock.accountID, mock.apiKey)
+
+	assert.False(t, ok)
+	errs, isList := resp["errors"].([]interface{})
+	require.True(t, isList, "errors must be the GraphQL error list, got %T", resp["errors"])
+	require.Len(t, errs, 1)
+	assert.Equal(t, mock.forcedError, errs[0].(map[string]interface{})["message"])
+	assert.Equal(t, 1, mock.requestCount(), "a GraphQL error must not be retried by send()")
+}
+
+// TestCatoSendRateLimitRetried verifies a Cato rate-limit error is retried in
+// place (after the adapter's fixed 5s pause) rather than reported as a failure.
+func TestCatoSendRateLimitRetried(t *testing.T) {
+	mock := newMockCato(t)
+	mock.rateLimited = 1
+	mock.addEvent(securityEvent(1, "2026-06-11T10:00:00Z"))
+	server := newMockServer(t, mock)
+
+	a := bareAdapter(t, server, mock.apiKey)
+	ok, resp := a.send(eventsFeedQuery(mock.accountID, ""), mock.accountID, mock.apiKey)
+
+	assert.True(t, ok, "the call must succeed after the rate limit clears")
+	assert.Equal(t, 2, mock.requestCount(), "rate-limited request then the successful retry")
+
+	feed := resp["data"].(map[string]interface{})["eventsFeed"].(map[string]interface{})
+	assert.Equal(t, float64(1), feed["fetchedCount"])
+	assert.Equal(t, mockMarkerPrefix+"1", feed["marker"])
+}

--- a/cylance/client.go
+++ b/cylance/client.go
@@ -36,11 +36,25 @@ type CylanceConfig struct {
 	AppID          string                  `json:"app_id" yaml:"app_id"`
 	AppSecret      string                  `json:"app_secret" yaml:"app_secret"`
 	LoggingBaseURL string                  `json:"logging_base_url" yaml:"logging_base_url"`
+
+	// PollInterval overrides the fixed wait between polls of the Cylance APIs.
+	// It is not settable through a config file; it exists as a seam for tests
+	// (the production interval stays the historical 60 seconds).
+	PollInterval time.Duration `json:"-" yaml:"-"`
+}
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
 }
 
 type CylanceAdapter struct {
 	conf       CylanceConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
 	chStopped  chan struct{}
 
@@ -58,6 +72,13 @@ type CylanceAdapter struct {
 }
 
 func NewCylanceAdapter(ctx context.Context, conf CylanceConfig) (*CylanceAdapter, chan struct{}, error) {
+	return newCylanceAdapter(ctx, conf, nil)
+}
+
+// newCylanceAdapter is the implementation behind NewCylanceAdapter. When sink
+// is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newCylanceAdapter(ctx context.Context, conf CylanceConfig, sink uspSink) (*CylanceAdapter, chan struct{}, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, nil, err
 	}
@@ -73,10 +94,14 @@ func NewCylanceAdapter(ctx context.Context, conf CylanceConfig) (*CylanceAdapter
 	a.ctx = rootCtx
 	a.cancel = cancel
 
-	var err error
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -113,6 +138,9 @@ func (c *CylanceConfig) Validate() error {
 	}
 	if c.LoggingBaseURL == "" {
 		c.LoggingBaseURL = defaultLoggingBaseURL
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = queryInterval * time.Second
 	}
 	return nil
 }
@@ -182,7 +210,7 @@ func (a *CylanceAdapter) fetchEvents() {
 		},
 	}
 
-	ticker := time.NewTicker(queryInterval * time.Second)
+	ticker := time.NewTicker(a.conf.PollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/cylance/client_test.go
+++ b/cylance/client_test.go
@@ -1,0 +1,181 @@
+package usp_cylance
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testLog collects adapter errors for assertions and forwards logs to the test
+// log. The adapter's Close() does not wait for its polling goroutine to exit,
+// so the goroutine can outlive the test function; testLog goes quiet once the
+// test is done instead of calling t.Logf after the test has completed.
+type testLog struct {
+	t    *testing.T
+	mu   sync.Mutex
+	done bool
+	errs []string
+}
+
+func newTestLog(t *testing.T) *testLog {
+	l := &testLog{t: t}
+	t.Cleanup(func() {
+		l.mu.Lock()
+		l.done = true
+		l.mu.Unlock()
+	})
+	return l
+}
+
+func (l *testLog) logf(format string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.done {
+		return
+	}
+	l.t.Logf(format, args...)
+}
+
+func (l *testLog) onError(err error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.done {
+		return
+	}
+	l.errs = append(l.errs, err.Error())
+	l.t.Logf("ERR: %v", err)
+}
+
+func (l *testLog) hasErrorContaining(substr string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, e := range l.errs {
+		if strings.Contains(e, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// testClientOptions returns ClientOptions wired for a sink (no real
+// LimaCharlie connection) with logging routed through a goroutine-safe
+// testLog, which is also returned for error assertions.
+func testClientOptions(t *testing.T) (uspclient.ClientOptions, *testLog) {
+	t.Helper()
+	l := newTestLog(t)
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { l.logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { l.logf("WRN: %s", msg) },
+		OnError:      l.onError,
+	}, l
+}
+
+// --- unit tests ---------------------------------------------------------------
+
+func TestValidate(t *testing.T) {
+	opts, _ := testClientOptions(t)
+
+	t.Run("requires tenant id", func(t *testing.T) {
+		c := CylanceConfig{ClientOptions: opts, AppID: "a", AppSecret: "s"}
+		assert.ErrorContains(t, c.Validate(), "tenant")
+	})
+
+	t.Run("requires app id", func(t *testing.T) {
+		c := CylanceConfig{ClientOptions: opts, TenantID: "t", AppSecret: "s"}
+		assert.ErrorContains(t, c.Validate(), "app id")
+	})
+
+	t.Run("requires app secret", func(t *testing.T) {
+		c := CylanceConfig{ClientOptions: opts, TenantID: "t", AppID: "a"}
+		assert.ErrorContains(t, c.Validate(), "app secret")
+	})
+
+	t.Run("applies defaults", func(t *testing.T) {
+		c := CylanceConfig{ClientOptions: opts, TenantID: "t", AppID: "a", AppSecret: "s"}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, defaultLoggingBaseURL, c.LoggingBaseURL)
+		assert.Equal(t, queryInterval*time.Second, c.PollInterval,
+			"production poll interval must stay the historical 60 seconds")
+	})
+
+	t.Run("keeps an explicit base url override", func(t *testing.T) {
+		c := CylanceConfig{
+			ClientOptions: opts, TenantID: "t", AppID: "a", AppSecret: "s",
+			LoggingBaseURL: "https://protect.example.com",
+		}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, "https://protect.example.com", c.LoggingBaseURL)
+	})
+}
+
+func TestGetJWTExpiration(t *testing.T) {
+	t.Run("reads exp from a token", func(t *testing.T) {
+		exp := time.Now().Add(42 * time.Minute).Truncate(time.Second).UTC()
+		tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"exp": exp.Unix()})
+		signed, err := tok.SignedString([]byte("not-a-real-secret"))
+		require.NoError(t, err)
+
+		got, err := getJWTExpiration(signed)
+		require.NoError(t, err)
+		assert.Equal(t, exp, got)
+	})
+
+	t.Run("rejects a malformed token", func(t *testing.T) {
+		_, err := getJWTExpiration("not.a.jwt")
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects a token without exp", func(t *testing.T) {
+		tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "x"})
+		signed, err := tok.SignedString([]byte("not-a-real-secret"))
+		require.NoError(t, err)
+
+		_, err = getJWTExpiration(signed)
+		assert.ErrorContains(t, err, "exp claim")
+	})
+}
+
+func TestEventsResponsePagination(t *testing.T) {
+	assert.True(t, CylanceEventsResponse{PageNumber: 1, TotalPages: 3}.HasNextPage())
+	assert.True(t, CylanceEventsResponse{PageNumber: 2, TotalPages: 3}.HasNextPage())
+	assert.False(t, CylanceEventsResponse{PageNumber: 3, TotalPages: 3}.HasNextPage())
+	// An empty result set (total_pages 0 on page 1) has no next page.
+	assert.False(t, CylanceEventsResponse{PageNumber: 1, TotalPages: 0}.HasNextPage())
+	// Detail responses are single objects and never paginate.
+	assert.False(t, CylanceEventResponse{}.HasNextPage())
+}
+
+func TestSetMeta(t *testing.T) {
+	t.Run("events response tags items but keeps existing meta", func(t *testing.T) {
+		r := &CylanceEventsResponse{PageItems: []utils.Dict{
+			{"Id": "a"},
+			{"Id": "b", "ObjectSource": "Custom", "ObjectType": "Existing"},
+		}}
+		r.SetMeta("Cylance", "Detection")
+
+		assert.Equal(t, "Cylance", r.PageItems[0]["ObjectSource"])
+		assert.Equal(t, "Detection", r.PageItems[0]["ObjectType"])
+		assert.Equal(t, "Custom", r.PageItems[1]["ObjectSource"], "existing meta must not be overwritten")
+		assert.Equal(t, "Existing", r.PageItems[1]["ObjectType"])
+	})
+
+	t.Run("event response tags the single document", func(t *testing.T) {
+		r := &CylanceEventResponse{Event: []utils.Dict{{"Id": "a", "ObjectType": nil}}}
+		r.SetMeta("Cylance", "Threat")
+		assert.Equal(t, "Cylance", r.Event[0]["ObjectSource"])
+		assert.Equal(t, "Threat", r.Event[0]["ObjectType"], "a nil ObjectType counts as absent")
+	})
+}

--- a/cylance/mock_test.go
+++ b/cylance/mock_test.go
@@ -1,0 +1,790 @@
+package usp_cylance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock of the Cylance
+// (BlackBerry Protect) API, capturing the exact messages it ships so their
+// content -- payload, ObjectSource/ObjectType tagging and timestamp -- can be
+// asserted without live credentials.
+//
+// The mock reproduces the API surface the adapter uses:
+//
+//   - POST /auth/v2/token        -- exchanges an HS256 application JWT (signed
+//     with the app secret, sub=app id, tid=tenant id) for an access token.
+//   - GET  /detections/v2        -- paginated list, ?page&page_size&start,
+//     RFC3339 "ReceivedTime", envelope {page_items, page_number, total_pages,
+//     page_size, total_number_of_items}.
+//   - GET  /detections/v2/{id}/details -- single-object detail.
+//   - GET  /threats/v2 and /threats/v2/{sha256} -- same envelope, but
+//     "last_found" uses the zone-less "2006-01-02T15:04:05" format.
+//   - GET  /memoryprotection/v2 and /memoryprotection/v2/{id} -- as threats,
+//     keyed by "device_image_file_event_id" / "created".
+//
+// Time-filter fidelity: the real detections API documents the ?start query
+// parameter, so the mock honors it there. The real threats and memory
+// protection list APIs only document ?page and ?page_size -- the ?start_time
+// parameter the adapter sends is an unknown parameter the real server ignores,
+// so the mock ignores it too (the adapter filters by time client-side).
+//
+// All list/detail endpoints require "Authorization: Bearer <issued token>".
+
+// legacyTimeFormat is the zone-less timestamp format Cylance uses on the
+// threats and memory protection APIs.
+const legacyTimeFormat = "2006-01-02T15:04:05"
+
+// Clearly-fake identifiers for fixtures (public repo: no real values).
+const (
+	testTenantID  = "11111111-1111-1111-1111-111111111111"
+	testAppID     = "22222222-2222-2222-2222-222222222222"
+	testAppSecret = "33333333-3333-3333-3333-333333333333"
+)
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Cylance API ---------------------------------------------------------
+
+type mockCylance struct {
+	t *testing.T
+
+	appID     string
+	tenantID  string
+	appSecret string
+
+	mu          sync.Mutex
+	validTokens map[string]bool
+	authCount   int
+	dataCount   int
+	listPages   map[string]map[int]bool // list path -> page numbers requested
+
+	detections       []utils.Dict
+	detectionDetails map[string]utils.Dict
+	threats          []utils.Dict
+	threatDetails    map[string]utils.Dict
+	memProtects      []utils.Dict
+	memProtectInfo   map[string]utils.Dict
+}
+
+func newMockCylance(t *testing.T) *mockCylance {
+	return &mockCylance{
+		t:                t,
+		appID:            testAppID,
+		tenantID:         testTenantID,
+		appSecret:        testAppSecret,
+		validTokens:      map[string]bool{},
+		listPages:        map[string]map[int]bool{},
+		detectionDetails: map[string]utils.Dict{},
+		threatDetails:    map[string]utils.Dict{},
+		memProtectInfo:   map[string]utils.Dict{},
+	}
+}
+
+// addDetection registers a detection list item and its detail document.
+func (m *mockCylance) addDetection(id string, received time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.detections = append(m.detections, fixtureDetection(id, received))
+	m.detectionDetails[id] = fixtureDetectionDetail(id, received)
+}
+
+// addDetectionWithoutDetail registers a detection whose detail lookup 404s.
+func (m *mockCylance) addDetectionWithoutDetail(id string, received time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.detections = append(m.detections, fixtureDetection(id, received))
+}
+
+func (m *mockCylance) addThreat(sha256 string, lastFound time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.threats = append(m.threats, fixtureThreat(sha256, lastFound))
+	m.threatDetails[sha256] = fixtureThreatDetail(sha256, lastFound)
+}
+
+func (m *mockCylance) addMemProtect(id string, created time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.memProtects = append(m.memProtects, fixtureMemProtect(id, created))
+	m.memProtectInfo[id] = fixtureMemProtectDetail(id, created)
+}
+
+// revokeTokens invalidates every access token issued so far, as the real API
+// does when a token expires: the next data call gets a 401.
+func (m *mockCylance) revokeTokens() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.validTokens = map[string]bool{}
+}
+
+func (m *mockCylance) authCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.authCount
+}
+
+func (m *mockCylance) dataCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.dataCount
+}
+
+func (m *mockCylance) pageRequested(listPath string, page int) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.listPages[listPath][page]
+}
+
+func (m *mockCylance) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		if path == authEndpoint {
+			if r.Method != http.MethodPost {
+				http.Error(w, `{"message":"method not allowed"}`, http.StatusMethodNotAllowed)
+				return
+			}
+			m.handleAuth(w, r)
+			return
+		}
+
+		// Every other endpoint requires a previously issued bearer token.
+		if !m.checkBearer(w, r) {
+			return
+		}
+		m.mu.Lock()
+		m.dataCount++
+		m.mu.Unlock()
+
+		if r.Method != http.MethodGet {
+			http.Error(w, `{"message":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+
+		switch {
+		case path == detectionsEndpoint:
+			m.serveList(w, r, m.snapshotList(&m.detections), "ReceivedTime", time.RFC3339, "start")
+		case strings.HasPrefix(path, detectionsEndpoint+"/") && strings.HasSuffix(path, "/details"):
+			id := strings.TrimSuffix(strings.TrimPrefix(path, detectionsEndpoint+"/"), "/details")
+			m.serveDetail(w, m.detectionDetails, id)
+		case path == threatsEndpoint:
+			// The real threats API has no time filter; start_time is ignored.
+			m.serveList(w, r, m.snapshotList(&m.threats), "last_found", legacyTimeFormat, "")
+		case strings.HasPrefix(path, threatsEndpoint+"/"):
+			m.serveDetail(w, m.threatDetails, strings.TrimPrefix(path, threatsEndpoint+"/"))
+		case path == memoryProtectionEndpoint:
+			// Same: the real memory protection API has no time filter.
+			m.serveList(w, r, m.snapshotList(&m.memProtects), "created", legacyTimeFormat, "")
+		case strings.HasPrefix(path, memoryProtectionEndpoint+"/"):
+			m.serveDetail(w, m.memProtectInfo, strings.TrimPrefix(path, memoryProtectionEndpoint+"/"))
+		default:
+			http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		}
+	}
+}
+
+// handleAuth implements POST /auth/v2/token: it validates the caller's signed
+// application JWT exactly as the real service does (HS256 signature with the
+// app secret, sub == application id, tid == tenant id, iss == cylance.com) and
+// returns {"access_token": <JWT with a 30 minute exp>}.
+func (m *mockCylance) handleAuth(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.authCount++
+	m.mu.Unlock()
+
+	var body struct {
+		AuthToken string `json:"auth_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.AuthToken == "" {
+		http.Error(w, `{"message":"malformed request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	token, err := jwt.Parse(body.AuthToken, func(tok *jwt.Token) (interface{}, error) {
+		if _, ok := tok.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method %v", tok.Header["alg"])
+		}
+		return []byte(m.appSecret), nil
+	})
+	if err != nil || !token.Valid {
+		http.Error(w, `{"message":"invalid application token"}`, http.StatusUnauthorized)
+		return
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok ||
+		claims["sub"] != m.appID ||
+		claims["tid"] != m.tenantID ||
+		claims["iss"] != "http://cylance.com" {
+		http.Error(w, `{"message":"application not found"}`, http.StatusUnauthorized)
+		return
+	}
+
+	access := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"exp": time.Now().UTC().Add(30 * time.Minute).Unix(),
+		"iat": time.Now().UTC().Unix(),
+		"iss": "http://cylance.com",
+		"sub": m.appID,
+		"tid": m.tenantID,
+		"jti": uuid.New().String(),
+	})
+	signed, err := access.SignedString([]byte(m.appSecret))
+	if !assert.NoError(m.t, err) {
+		http.Error(w, `{"message":"internal error"}`, http.StatusInternalServerError)
+		return
+	}
+
+	m.mu.Lock()
+	m.validTokens[signed] = true
+	m.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"access_token": signed})
+}
+
+func (m *mockCylance) checkBearer(w http.ResponseWriter, r *http.Request) bool {
+	auth := r.Header.Get("Authorization")
+	tok := strings.TrimPrefix(auth, "Bearer ")
+	m.mu.Lock()
+	valid := tok != auth && m.validTokens[tok]
+	m.mu.Unlock()
+	if !valid {
+		http.Error(w, `{"message":"Unauthorized"}`, http.StatusUnauthorized)
+		return false
+	}
+	return true
+}
+
+func (m *mockCylance) snapshotList(list *[]utils.Dict) []utils.Dict {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]utils.Dict, len(*list))
+	copy(out, *list)
+	return out
+}
+
+// serveList implements the paginated list endpoints: it filters records by the
+// caller's start-time query parameter (when the real endpoint supports one --
+// startParam is empty for endpoints that don't), slices the requested page and
+// wraps it in the Cylance page envelope.
+func (m *mockCylance) serveList(w http.ResponseWriter, r *http.Request, records []utils.Dict, timeField, timeFormat, startParam string) {
+	q := r.URL.Query()
+	page := intParam(q.Get("page"), 1)
+	pageSize := intParam(q.Get("page_size"), 10)
+
+	m.mu.Lock()
+	if m.listPages[r.URL.Path] == nil {
+		m.listPages[r.URL.Path] = map[int]bool{}
+	}
+	m.listPages[r.URL.Path][page] = true
+	m.mu.Unlock()
+
+	filtered := records
+	if startStr := q.Get(startParam); startParam != "" && startStr != "" {
+		start, err := time.Parse(timeFormat, startStr)
+		if !assert.NoError(m.t, err, "adapter sent an unparseable %s", startParam) {
+			http.Error(w, `{"message":"invalid time filter"}`, http.StatusBadRequest)
+			return
+		}
+		filtered = nil
+		for _, rec := range records {
+			ts, err := time.Parse(timeFormat, rec[timeField].(string))
+			if !assert.NoError(m.t, err) {
+				continue
+			}
+			if !ts.Before(start) {
+				filtered = append(filtered, rec)
+			}
+		}
+	}
+
+	totalPages := (len(filtered) + pageSize - 1) / pageSize
+	var pageItems []utils.Dict
+	if start := (page - 1) * pageSize; start < len(filtered) {
+		end := start + pageSize
+		if end > len(filtered) {
+			end = len(filtered)
+		}
+		pageItems = filtered[start:end]
+	}
+	if pageItems == nil {
+		pageItems = []utils.Dict{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"page_items":            pageItems,
+		"page_number":           page,
+		"page_size":             pageSize,
+		"total_pages":           totalPages,
+		"total_number_of_items": len(filtered),
+	})
+}
+
+func (m *mockCylance) serveDetail(w http.ResponseWriter, details map[string]utils.Dict, id string) {
+	m.mu.Lock()
+	detail, ok := details[id]
+	m.mu.Unlock()
+	if !ok {
+		http.Error(w, `{"message":"resource not found"}`, http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(detail)
+}
+
+func intParam(s string, def int) int {
+	v, err := strconv.Atoi(s)
+	if err != nil || v < 1 {
+		return def
+	}
+	return v
+}
+
+// --- realistic fixtures -------------------------------------------------------
+
+// fixtureDetection is shaped like a CylanceOPTICS detection list item
+// (GET /detections/v2 page_items).
+func fixtureDetection(id string, received time.Time) utils.Dict {
+	return utils.Dict{
+		"Id":                   id,
+		"TenantId":             testTenantID,
+		"DetectionDescription": "Powershell Download And Execute",
+		"OccurrenceTime":       received.Add(-3 * time.Second).UTC().Format(time.RFC3339),
+		"ReceivedTime":         received.UTC().Format(time.RFC3339),
+		"Severity":             "High",
+		"Status":               "New",
+		"PhoneticId":           "AlphaBravoCharlie",
+		"Device": utils.Dict{
+			"CylanceId": "44444444-4444-4444-4444-444444444444",
+			"Name":      "WIN-EXAMPLE-01",
+		},
+	}
+}
+
+// fixtureDetectionDetail is the full document returned by
+// GET /detections/v2/{id}/details.
+func fixtureDetectionDetail(id string, received time.Time) utils.Dict {
+	d := fixtureDetection(id, received)
+	d["ActivationTime"] = received.Add(-5 * time.Second).UTC().Format(time.RFC3339)
+	d["DetectionRule"] = utils.Dict{
+		"Id":       "55555555-5555-5555-5555-555555555555",
+		"Name":     "Powershell Download And Execute",
+		"Category": "Execution",
+	}
+	d["AssociatedIocs"] = []interface{}{
+		utils.Dict{
+			"Type":  "File",
+			"Value": `C:\Users\jdoe\AppData\Local\Temp\dropper.ps1`,
+		},
+	}
+	d["Tactics"] = []interface{}{"Execution", "Defense Evasion"}
+	d["Comments"] = []interface{}{}
+	return d
+}
+
+// fixtureThreat is shaped like a real GET /threats/v2 page item (field names
+// from the BlackBerry Protect API docs).
+func fixtureThreat(sha256 string, lastFound time.Time) utils.Dict {
+	return utils.Dict{
+		"name":               "bad_installer.exe",
+		"sha256":             sha256,
+		"md5":                "11111111111111111111111111111111",
+		"cylance_score":      -0.92,
+		"av_industry":        nil,
+		"classification":     "Malware",
+		"sub_classification": "Trojan",
+		"global_quarantined": false,
+		"safelisted":         false,
+		"file_size":          38912,
+		"unique_to_cylance":  false,
+		"last_found":         lastFound.UTC().Format(legacyTimeFormat),
+	}
+}
+
+// fixtureThreatDetail is the document returned by GET /threats/v2/{sha256}.
+func fixtureThreatDetail(sha256 string, lastFound time.Time) utils.Dict {
+	d := fixtureThreat(sha256, lastFound)
+	d["cert_publisher"] = ""
+	d["cert_issuer"] = ""
+	d["cert_timestamp"] = "0001-01-01T00:00:00"
+	d["signed"] = false
+	d["auto_run"] = false
+	d["running"] = false
+	d["detected_by"] = "FileWatcher"
+	return d
+}
+
+// fixtureMemProtect is shaped like a GET /memoryprotection/v2 page item.
+func fixtureMemProtect(id string, created time.Time) utils.Dict {
+	return utils.Dict{
+		"device_image_file_event_id": id,
+		"tenant_id":                  testTenantID,
+		"device_id":                  "66666666-6666-6666-6666-666666666666",
+		"image_path":                 `C:\Users\jdoe\AppData\Local\Temp\injector.exe`,
+		"action":                     "Terminate",
+		"violation_type":             "LsassRead",
+		"process_id":                 4242,
+		"user_name":                  `EXAMPLE\jdoe`,
+		"created":                    created.UTC().Format(legacyTimeFormat),
+	}
+}
+
+// fixtureMemProtectDetail is the document returned by
+// GET /memoryprotection/v2/{id}.
+func fixtureMemProtectDetail(id string, created time.Time) utils.Dict {
+	d := fixtureMemProtect(id, created)
+	d["device_name"] = "WIN-EXAMPLE-02"
+	return d
+}
+
+// expectedShipped is what the adapter ships for a detail document: the payload
+// verbatim plus the ObjectSource/ObjectType meta fields it injects.
+func expectedShipped(detail utils.Dict, objectType string) utils.Dict {
+	out := utils.Dict{}
+	for k, v := range detail {
+		out[k] = v
+	}
+	out["ObjectSource"] = "Cylance"
+	out["ObjectType"] = objectType
+	return out
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// startMockAdapter spins up the adapter against a mock server with a capture
+// sink and a fast poll interval.
+func startMockAdapter(t *testing.T, mock *mockCylance, conf CylanceConfig) (*CylanceAdapter, chan struct{}, *captureSink, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(mock.handler())
+
+	if conf.TenantID == "" {
+		conf.TenantID = testTenantID
+	}
+	if conf.AppID == "" {
+		conf.AppID = testAppID
+	}
+	if conf.AppSecret == "" {
+		conf.AppSecret = testAppSecret
+	}
+	conf.LoggingBaseURL = server.URL
+	if conf.PollInterval == 0 {
+		conf.PollInterval = 50 * time.Millisecond
+	}
+
+	sink := &captureSink{}
+	adapter, chStopped, err := newCylanceAdapter(context.Background(), conf, sink)
+	if err != nil {
+		server.Close()
+		t.Fatalf("newCylanceAdapter: %v", err)
+	}
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { _ = adapter.Close() })
+	return adapter, chStopped, sink, server
+}
+
+// --- tests --------------------------------------------------------------------
+
+// TestMockDetectionsEndToEnd drives the adapter against the mock API and
+// asserts the exact events shipped: the detection *detail* document verbatim,
+// tagged ObjectSource=Cylance / ObjectType=Detection, with the adapter's
+// ship-time TimestampMs and no EventType (the adapter relies on the platform
+// default). It then verifies re-polling does not re-ship.
+func TestMockDetectionsEndToEnd(t *testing.T) {
+	mock := newMockCylance(t)
+	// Timestamps must fall inside the adapter's initial 60-minute lookback.
+	base := time.Now().UTC().Truncate(time.Second).Add(-10 * time.Minute)
+	ids := []string{
+		"77777777-7777-7777-7777-777777777701",
+		"77777777-7777-7777-7777-777777777702",
+		"77777777-7777-7777-7777-777777777703",
+	}
+	for i, id := range ids {
+		mock.addDetection(id, base.Add(time.Duration(i)*time.Minute))
+	}
+
+	testStart := time.Now()
+	opts, _ := testClientOptions(t)
+	_, _, sink, _ := startMockAdapter(t, mock, CylanceConfig{ClientOptions: opts})
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 detections to ship")
+
+	// Re-polling must not re-ship: the count stays at 3 across several polls.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		400*time.Millisecond, 30*time.Millisecond, "detections were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		require.NotNil(t, msg.JsonPayload)
+		assert.Empty(t, msg.EventType, "the adapter does not set EventType")
+		assert.GreaterOrEqual(t, msg.TimestampMs, uint64(testStart.UnixMilli()),
+			"TimestampMs is the ship time")
+		assert.LessOrEqual(t, msg.TimestampMs, uint64(time.Now().UnixMilli()))
+		id, _ := msg.JsonPayload["Id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3, "each detection ships exactly once")
+
+	for i, id := range ids {
+		msg := byID[id]
+		require.NotNil(t, msg, "detection %s was not shipped", id)
+		want := expectedShipped(fixtureDetectionDetail(id, base.Add(time.Duration(i)*time.Minute)), "Detection")
+		assert.JSONEq(t, mustJSON(t, want), mustJSON(t, msg.JsonPayload),
+			"shipped payload must be the detail document verbatim plus ObjectSource/ObjectType")
+	}
+}
+
+// TestMockAllThreeAPIs verifies the adapter polls all three Cylance APIs
+// (detections, threats, memory protection), ships each detail document once,
+// and tags each with the correct ObjectType. Threat and memory protection
+// payloads are also checked verbatim, including their zone-less timestamps.
+func TestMockAllThreeAPIs(t *testing.T) {
+	mock := newMockCylance(t)
+	base := time.Now().UTC().Truncate(time.Second).Add(-10 * time.Minute)
+
+	detID := "77777777-7777-7777-7777-777777777711"
+	sha := "1111111111111111111111111111111111111111111111111111111111111111"
+	memID := "88888888-8888-8888-8888-888888888801"
+	mock.addDetection(detID, base)
+	mock.addThreat(sha, base.Add(1*time.Minute))
+	mock.addMemProtect(memID, base.Add(2*time.Minute))
+
+	opts, _ := testClientOptions(t)
+	_, _, sink, _ := startMockAdapter(t, mock, CylanceConfig{ClientOptions: opts})
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected one event from each API")
+	require.Never(t, func() bool { return sink.count() != 3 },
+		400*time.Millisecond, 30*time.Millisecond, "events were re-shipped on a later poll")
+
+	byType := map[string]utils.Dict{}
+	for _, msg := range sink.snapshot() {
+		objType, _ := msg.JsonPayload["ObjectType"].(string)
+		require.NotEmpty(t, objType)
+		assert.Equal(t, "Cylance", msg.JsonPayload["ObjectSource"])
+		byType[objType] = msg.JsonPayload
+	}
+	require.Len(t, byType, 3)
+
+	assert.JSONEq(t,
+		mustJSON(t, expectedShipped(fixtureDetectionDetail(detID, base), "Detection")),
+		mustJSON(t, byType["Detection"]))
+	assert.JSONEq(t,
+		mustJSON(t, expectedShipped(fixtureThreatDetail(sha, base.Add(1*time.Minute)), "Threat")),
+		mustJSON(t, byType["Threat"]))
+	assert.JSONEq(t,
+		mustJSON(t, expectedShipped(fixtureMemProtectDetail(memID, base.Add(2*time.Minute)), "Memory Protection")),
+		mustJSON(t, byType["Memory Protection"]))
+}
+
+// TestMockNewDetectionMidRunShipsOnce verifies an event that appears while the
+// adapter is running is picked up on a later poll and shipped exactly once,
+// without re-shipping earlier events.
+func TestMockNewDetectionMidRunShipsOnce(t *testing.T) {
+	mock := newMockCylance(t)
+	base := time.Now().UTC().Truncate(time.Second).Add(-10 * time.Minute)
+	idA := "77777777-7777-7777-7777-777777777721"
+	idB := "77777777-7777-7777-7777-777777777722"
+	idC := "77777777-7777-7777-7777-777777777723"
+	mock.addDetection(idA, base)
+	mock.addDetection(idB, base.Add(1*time.Minute))
+
+	opts, _ := testClientOptions(t)
+	_, _, sink, _ := startMockAdapter(t, mock, CylanceConfig{ClientOptions: opts})
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new detection arrives mid-run, strictly newer than everything shipped.
+	mock.addDetection(idC, time.Now().UTC().Truncate(time.Second).Add(-1*time.Minute))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new detection should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		400*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["Id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{idA: 1, idB: 1, idC: 1}, shippedPerID,
+		"every detection must ship exactly once")
+}
+
+// TestMockPaginationFullDataset verifies a dataset larger than one page
+// (page_size is a fixed 100) is walked to the last page and every record's
+// detail document is shipped exactly once. It uses the threats API: its real
+// server has no time filter, so the multi-page walk sees a stable dataset.
+//
+// (The detections API cannot fully consume a multi-page poll: the adapter
+// advances the start filter to the newest record seen while also incrementing
+// the page number, so against a server that honors ?start -- as the real
+// detections API does -- later pages of the shrunken result set skip records.
+// That is existing adapter behavior, faithfully reproduced by this mock, not a
+// mock artifact.)
+func TestMockPaginationFullDataset(t *testing.T) {
+	const total = 250 // 3 pages at the adapter's fixed page_size of 100
+
+	mock := newMockCylance(t)
+	base := time.Now().UTC().Truncate(time.Second).Add(-30 * time.Minute)
+	for i := 0; i < total; i++ {
+		mock.addThreat(fmt.Sprintf("%064d", i), base.Add(time.Duration(i)*time.Second))
+	}
+
+	opts, _ := testClientOptions(t)
+	_, _, sink, _ := startMockAdapter(t, mock, CylanceConfig{ClientOptions: opts})
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 25*time.Millisecond, "all paginated threats should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		400*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		assert.Equal(t, "Threat", msg.JsonPayload["ObjectType"])
+		ids[msg.JsonPayload["sha256"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct threat should ship exactly once")
+
+	// The walk must have covered every page and stopped at total_pages.
+	for page := 1; page <= 3; page++ {
+		assert.True(t, mock.pageRequested(threatsEndpoint, page), "page %d should be requested", page)
+	}
+	assert.False(t, mock.pageRequested(threatsEndpoint, 4), "pagination must stop at total_pages")
+}
+
+// TestMockBadCredentialsShipNothing verifies that when the token endpoint
+// rejects the application JWT (wrong app secret), the adapter ships nothing
+// and never reaches a data endpoint, and that it surfaces the auth failure.
+//
+// The adapter's full shutdown on bad credentials only happens after
+// consecutiveAuthFailsLimit failed refreshes with 60s sleeps between them
+// (~10+ minutes by design), so this test asserts the observable fast part:
+// the auth error is reported and no data ships.
+func TestMockBadCredentialsShipNothing(t *testing.T) {
+	mock := newMockCylance(t)
+	base := time.Now().UTC().Truncate(time.Second).Add(-10 * time.Minute)
+	mock.addDetection("77777777-7777-7777-7777-777777777731", base)
+
+	opts, log := testClientOptions(t)
+	_, _, sink, _ := startMockAdapter(t, mock, CylanceConfig{
+		ClientOptions: opts,
+		AppSecret:     "99999999-9999-9999-9999-999999999999", // wrong secret
+	})
+
+	require.Eventually(t, func() bool {
+		return mock.authCalls() >= 1 && log.hasErrorContaining("cylance auth api non-200")
+	}, 5*time.Second, 20*time.Millisecond, "the auth failure should be attempted and reported")
+
+	// Nothing ships and no data endpoint is ever reached.
+	require.Never(t, func() bool { return sink.count() != 0 || mock.dataCalls() != 0 },
+		400*time.Millisecond, 30*time.Millisecond, "nothing must ship with bad credentials")
+}
+
+// TestMockTokenRevokedReauthenticates verifies the adapter transparently
+// re-authenticates when a data endpoint answers 401 (revoked/expired token)
+// and then resumes shipping new events.
+func TestMockTokenRevokedReauthenticates(t *testing.T) {
+	mock := newMockCylance(t)
+	base := time.Now().UTC().Truncate(time.Second).Add(-10 * time.Minute)
+	idA := "77777777-7777-7777-7777-777777777741"
+	idB := "77777777-7777-7777-7777-777777777742"
+	mock.addDetection(idA, base)
+
+	opts, _ := testClientOptions(t)
+	_, _, sink, _ := startMockAdapter(t, mock, CylanceConfig{ClientOptions: opts})
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond)
+	authedOnce := mock.authCalls()
+	require.GreaterOrEqual(t, authedOnce, 1)
+
+	// The token dies server-side; a newer detection appears.
+	mock.revokeTokens()
+	mock.addDetection(idB, time.Now().UTC().Truncate(time.Second).Add(-1*time.Minute))
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "the adapter should re-authenticate and ship the new detection")
+	assert.Greater(t, mock.authCalls(), authedOnce, "a second token exchange must have happened")
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["Id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{idA: 1, idB: 1}, shippedPerID)
+}
+
+// TestMockMissingDetailDoesNotBlockOthers verifies that a list item whose
+// detail lookup fails (404) is reported and skipped without blocking other
+// events from shipping.
+func TestMockMissingDetailDoesNotBlockOthers(t *testing.T) {
+	mock := newMockCylance(t)
+	base := time.Now().UTC().Truncate(time.Second).Add(-10 * time.Minute)
+	idOK := "77777777-7777-7777-7777-777777777751"
+	idGone := "77777777-7777-7777-7777-777777777752"
+	mock.addDetection(idOK, base)
+	mock.addDetectionWithoutDetail(idGone, base.Add(1*time.Minute))
+
+	opts, log := testClientOptions(t)
+	_, _, sink, _ := startMockAdapter(t, mock, CylanceConfig{ClientOptions: opts})
+
+	require.Eventually(t, func() bool {
+		return sink.count() == 1 && log.hasErrorContaining("details fetch failed")
+	}, 5*time.Second, 20*time.Millisecond, "the healthy detection ships, the broken one is reported")
+	require.Never(t, func() bool { return sink.count() > 1 },
+		400*time.Millisecond, 30*time.Millisecond)
+
+	assert.Equal(t, idOK, sink.snapshot()[0].JsonPayload["Id"])
+}

--- a/cylance/mock_test.go
+++ b/cylance/mock_test.go
@@ -38,11 +38,13 @@ import (
 //   - GET  /memoryprotection/v2 and /memoryprotection/v2/{id} -- as threats,
 //     keyed by "device_image_file_event_id" / "created".
 //
-// Time-filter fidelity: the real detections API documents the ?start query
-// parameter, so the mock honors it there. The real threats and memory
-// protection list APIs only document ?page and ?page_size -- the ?start_time
-// parameter the adapter sends is an unknown parameter the real server ignores,
-// so the mock ignores it too (the adapter filters by time client-side).
+// Time-filter fidelity: all three list APIs document a server-side start
+// filter -- ?start (ISO 8601) on detections, ?start_time/?end_time
+// ("YYYY-MM-DDThh:mm:ss.SSSZ") on threats and memory protection -- so the mock
+// honors it on all of them. The adapter sends threats/memory protection
+// timestamps in the zone-less "2006-01-02T15:04:05" variant; the mock accepts
+// that and interprets it as UTC, matching the zone-less timestamps those APIs
+// return.
 //
 // All list/detail endpoints require "Authorization: Bearer <issued token>".
 
@@ -214,13 +216,11 @@ func (m *mockCylance) handler() http.HandlerFunc {
 			id := strings.TrimSuffix(strings.TrimPrefix(path, detectionsEndpoint+"/"), "/details")
 			m.serveDetail(w, m.detectionDetails, id)
 		case path == threatsEndpoint:
-			// The real threats API has no time filter; start_time is ignored.
-			m.serveList(w, r, m.snapshotList(&m.threats), "last_found", legacyTimeFormat, "")
+			m.serveList(w, r, m.snapshotList(&m.threats), "last_found", legacyTimeFormat, "start_time")
 		case strings.HasPrefix(path, threatsEndpoint+"/"):
 			m.serveDetail(w, m.threatDetails, strings.TrimPrefix(path, threatsEndpoint+"/"))
 		case path == memoryProtectionEndpoint:
-			// Same: the real memory protection API has no time filter.
-			m.serveList(w, r, m.snapshotList(&m.memProtects), "created", legacyTimeFormat, "")
+			m.serveList(w, r, m.snapshotList(&m.memProtects), "created", legacyTimeFormat, "start_time")
 		case strings.HasPrefix(path, memoryProtectionEndpoint+"/"):
 			m.serveDetail(w, m.memProtectInfo, strings.TrimPrefix(path, memoryProtectionEndpoint+"/"))
 		default:
@@ -309,9 +309,9 @@ func (m *mockCylance) snapshotList(list *[]utils.Dict) []utils.Dict {
 }
 
 // serveList implements the paginated list endpoints: it filters records by the
-// caller's start-time query parameter (when the real endpoint supports one --
-// startParam is empty for endpoints that don't), slices the requested page and
-// wraps it in the Cylance page envelope.
+// caller's start-time query parameter (named startParam -- "start" on
+// detections, "start_time" on threats and memory protection), slices the
+// requested page and wraps it in the Cylance page envelope.
 func (m *mockCylance) serveList(w http.ResponseWriter, r *http.Request, records []utils.Dict, timeField, timeFormat, startParam string) {
 	q := r.URL.Query()
 	page := intParam(q.Get("page"), 1)
@@ -417,14 +417,18 @@ func fixtureDetectionDetail(id string, received time.Time) utils.Dict {
 		"Name":     "Powershell Download And Execute",
 		"Category": "Execution",
 	}
-	d["AssociatedIocs"] = []interface{}{
+	d["DetectionRule"].(utils.Dict)["Version"] = "1.2"
+	d["AssociatedArtifacts"] = []interface{}{
 		utils.Dict{
-			"Type":  "File",
-			"Value": `C:\Users\jdoe\AppData\Local\Temp\dropper.ps1`,
+			"Type": "File",
+			"Uid":  "99999999-9999-9999-9999-999999999901",
+			"File": utils.Dict{
+				"Path": `C:\Users\jdoe\AppData\Local\Temp\dropper.ps1`,
+			},
 		},
 	}
-	d["Tactics"] = []interface{}{"Execution", "Defense Evasion"}
-	d["Comments"] = []interface{}{}
+	d["Comment"] = ""
+	d["ZoneIds"] = []interface{}{}
 	return d
 }
 
@@ -460,17 +464,18 @@ func fixtureThreatDetail(sha256 string, lastFound time.Time) utils.Dict {
 	return d
 }
 
-// fixtureMemProtect is shaped like a GET /memoryprotection/v2 page item.
+// fixtureMemProtect is shaped like a GET /memoryprotection/v2 page item
+// (field names and types from the official Memory Protection API docs:
+// action and violation_type are numeric -- 3 is Terminate, 12 is LSASS read).
 func fixtureMemProtect(id string, created time.Time) utils.Dict {
 	return utils.Dict{
 		"device_image_file_event_id": id,
-		"tenant_id":                  testTenantID,
 		"device_id":                  "66666666-6666-6666-6666-666666666666",
-		"image_path":                 `C:\Users\jdoe\AppData\Local\Temp\injector.exe`,
-		"action":                     "Terminate",
-		"violation_type":             "LsassRead",
+		"image_name":                 `C:\Users\jdoe\AppData\Local\Temp\injector.exe`,
+		"action":                     3,
+		"violation_type":             12,
 		"process_id":                 4242,
-		"user_name":                  `EXAMPLE\jdoe`,
+		"username":                   `EXAMPLE\jdoe`,
 		"created":                    created.UTC().Format(legacyTimeFormat),
 	}
 }
@@ -479,7 +484,12 @@ func fixtureMemProtect(id string, created time.Time) utils.Dict {
 // GET /memoryprotection/v2/{id}.
 func fixtureMemProtectDetail(id string, created time.Time) utils.Dict {
 	d := fixtureMemProtect(id, created)
-	d["device_name"] = "WIN-EXAMPLE-02"
+	d["agent_event_id"] = "99999999-9999-9999-9999-999999999902"
+	d["file_hash_id"] = "2222222222222222222222222222222222222222222222222222222222222222"
+	d["dll_version"] = "3.1.1000.123"
+	d["file_version"] = "1.0.0.0"
+	d["groups"] = []interface{}{"Users"}
+	d["sid"] = "S-1-5-21-1111111111-2222222222-3333333333-1001"
 	return d
 }
 
@@ -665,22 +675,24 @@ func TestMockNewDetectionMidRunShipsOnce(t *testing.T) {
 
 // TestMockPaginationFullDataset verifies a dataset larger than one page
 // (page_size is a fixed 100) is walked to the last page and every record's
-// detail document is shipped exactly once. It uses the threats API: its real
-// server has no time filter, so the multi-page walk sees a stable dataset.
+// detail document is shipped exactly once.
 //
-// (The detections API cannot fully consume a multi-page poll: the adapter
-// advances the start filter to the newest record seen while also incrementing
-// the page number, so against a server that honors ?start -- as the real
-// detections API does -- later pages of the shrunken result set skip records.
-// That is existing adapter behavior, faithfully reproduced by this mock, not a
-// mock artifact.)
+// All records share one timestamp. That keeps the server-side result set
+// stable across the walk: the adapter advances its start filter to the newest
+// record seen *while also* incrementing the page number, so against the
+// documented server-side start filters (?start on detections,
+// ?start_time on threats and memory protection -- all honored by this mock),
+// a multi-page poll over records with distinct timestamps skips every record
+// that lands between the new filter position and the next page boundary.
+// That data loss is existing adapter behavior, not a mock artifact; this test
+// pins down the one shape of multi-page poll the adapter does fully consume.
 func TestMockPaginationFullDataset(t *testing.T) {
 	const total = 250 // 3 pages at the adapter's fixed page_size of 100
 
 	mock := newMockCylance(t)
 	base := time.Now().UTC().Truncate(time.Second).Add(-30 * time.Minute)
 	for i := 0; i < total; i++ {
-		mock.addThreat(fmt.Sprintf("%064d", i), base.Add(time.Duration(i)*time.Second))
+		mock.addThreat(fmt.Sprintf("%064d", i), base)
 	}
 
 	opts, _ := testClientOptions(t)

--- a/defender/client.go
+++ b/defender/client.go
@@ -72,8 +72,10 @@ type DefenderConfig struct {
 	AlertsURL string `json:"alerts_url" yaml:"alerts_url"`
 
 	// PollInterval overrides how long the adapter waits between polls of the
-	// alerts endpoint (default: 30s).
-	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+	// alerts endpoint (default: 30s). Not exposed in json/yaml configs
+	// (time.Duration does not deserialize meaningfully); it is a seam for
+	// tests, like in the other polling adapters.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 // tokenURL returns the token endpoint to use: the configured override, or the

--- a/defender/client.go
+++ b/defender/client.go
@@ -23,12 +23,32 @@ var URL = map[string]string{
 	"get_alerts": "https://graph.microsoft.com/v1.0/security/alerts_v2",
 }
 
+const (
+	// defaultTokenURLTemplate is the Microsoft identity platform token endpoint,
+	// parameterized by tenant id.
+	defaultTokenURLTemplate = "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
+
+	// defaultPollInterval is how long the adapter waits between polls of the
+	// alerts endpoint.
+	defaultPollInterval = 30 * time.Second
+)
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type DefenderAdapter struct {
 	conf       DefenderConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
 
-	endpoint string
+	endpoint     string
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -42,6 +62,36 @@ type DefenderConfig struct {
 	TenantID      string                  `json:"tenant_id" yaml:"tenant_id"`
 	ClientID      string                  `json:"client_id" yaml:"client_id"`
 	ClientSecret  string                  `json:"client_secret" yaml:"client_secret"`
+
+	// TokenURL overrides the Microsoft identity platform token endpoint
+	// (default: https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/token).
+	TokenURL string `json:"token_url" yaml:"token_url"`
+
+	// AlertsURL overrides the MS Graph security alerts endpoint
+	// (default: https://graph.microsoft.com/v1.0/security/alerts_v2).
+	AlertsURL string `json:"alerts_url" yaml:"alerts_url"`
+
+	// PollInterval overrides how long the adapter waits between polls of the
+	// alerts endpoint (default: 30s).
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+}
+
+// tokenURL returns the token endpoint to use: the configured override, or the
+// default Microsoft identity platform endpoint for the configured tenant.
+func (c *DefenderConfig) tokenURL() string {
+	if c.TokenURL != "" {
+		return c.TokenURL
+	}
+	return fmt.Sprintf(defaultTokenURLTemplate, c.TenantID)
+}
+
+// alertsURL returns the alerts endpoint to use: the configured override, or
+// the default MS Graph security alerts endpoint.
+func (c *DefenderConfig) alertsURL() string {
+	if c.AlertsURL != "" {
+		return c.AlertsURL
+	}
+	return URL["get_alerts"]
 }
 
 func (c *DefenderConfig) Validate() error {
@@ -61,16 +111,31 @@ func (c *DefenderConfig) Validate() error {
 }
 
 func NewDefenderAdapter(ctx context.Context, conf DefenderConfig) (*DefenderAdapter, chan struct{}, error) {
+	return newDefenderAdapter(ctx, conf, nil)
+}
+
+// newDefenderAdapter is the implementation behind NewDefenderAdapter. When
+// sink is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newDefenderAdapter(ctx context.Context, conf DefenderConfig, sink uspSink) (*DefenderAdapter, chan struct{}, error) {
 	var err error
 	a := &DefenderAdapter{
-		conf:   conf,
-		ctx:    context.Background(),
-		doStop: utils.NewEvent(),
+		conf:         conf,
+		ctx:          context.Background(),
+		doStop:       utils.NewEvent(),
+		pollInterval: conf.PollInterval,
+	}
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	a.httpClient = &http.Client{
@@ -87,7 +152,7 @@ func NewDefenderAdapter(ctx context.Context, conf DefenderConfig) (*DefenderAdap
 	a.conf.ClientOptions.DebugLog(fmt.Sprintf("starting to fetch alerts"))
 
 	a.wgSenders.Add(1)
-	go a.fetchEvents(URL["get_alerts"])
+	go a.fetchEvents(a.conf.alertsURL())
 
 	go func() {
 		a.wgSenders.Wait()
@@ -114,7 +179,7 @@ func (a *DefenderAdapter) Close() error {
 
 func (a *DefenderAdapter) fetchToken() (string, error) {
 
-	url := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", a.conf.TenantID)
+	url := a.conf.tokenURL()
 	payload := fmt.Sprintf("client_id=%s&scope=%s&grant_type=%s&client_secret=%s", a.conf.ClientID, scope, "client_credentials", a.conf.ClientSecret)
 
 	req, err := http.NewRequest("POST", url, bytes.NewBufferString(payload))
@@ -158,7 +223,7 @@ func (a *DefenderAdapter) fetchEvents(url string) {
 	// since := time.Date(2022, time.June, 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02T15:04:05.000000Z")
 	since := time.Now().Format("2006-01-02T15:04:05.000000Z")
 
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// The makeOneRequest function handles error
 		// handling and fatal error handling.
 		items, newSince, eventId, _ := a.makeOneListRequest(url, since, lastEventId)

--- a/defender/client_test.go
+++ b/defender/client_test.go
@@ -1,0 +1,106 @@
+package usp_defender
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real
+// LimaCharlie connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func TestValidate(t *testing.T) {
+	valid := func() DefenderConfig {
+		return DefenderConfig{
+			ClientOptions: testClientOptions(t),
+			TenantID:      "11111111-1111-1111-1111-111111111111",
+			ClientID:      "22222222-2222-2222-2222-222222222222",
+			ClientSecret:  "fake-secret",
+		}
+	}
+
+	t.Run("valid config passes", func(t *testing.T) {
+		c := valid()
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("requires tenant_id", func(t *testing.T) {
+		c := valid()
+		c.TenantID = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires client_id", func(t *testing.T) {
+		c := valid()
+		c.ClientID = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires client_secret", func(t *testing.T) {
+		c := valid()
+		c.ClientSecret = ""
+		assert.Error(t, c.Validate())
+	})
+}
+
+func TestEndpointDefaults(t *testing.T) {
+	t.Run("token endpoint defaults to the Microsoft identity platform", func(t *testing.T) {
+		c := DefenderConfig{TenantID: "11111111-1111-1111-1111-111111111111"}
+		assert.Equal(t,
+			"https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/oauth2/v2.0/token",
+			c.tokenURL())
+	})
+
+	t.Run("token endpoint override wins", func(t *testing.T) {
+		c := DefenderConfig{
+			TenantID: "11111111-1111-1111-1111-111111111111",
+			TokenURL: "https://mock.example.com/token",
+		}
+		assert.Equal(t, "https://mock.example.com/token", c.tokenURL())
+	})
+
+	t.Run("alerts endpoint defaults to MS Graph alerts_v2", func(t *testing.T) {
+		c := DefenderConfig{}
+		assert.Equal(t, "https://graph.microsoft.com/v1.0/security/alerts_v2", c.alertsURL())
+	})
+
+	t.Run("alerts endpoint override wins", func(t *testing.T) {
+		c := DefenderConfig{AlertsURL: "https://mock.example.com/v1.0/security/alerts_v2"}
+		assert.Equal(t, "https://mock.example.com/v1.0/security/alerts_v2", c.alertsURL())
+	})
+}
+
+// TestPollIntervalDefault verifies an unset poll_interval falls back to the
+// historical 30s default.
+func TestPollIntervalDefault(t *testing.T) {
+	sink := &captureSink{}
+	conf := DefenderConfig{
+		ClientOptions: testClientOptions(t),
+		TenantID:      "11111111-1111-1111-1111-111111111111",
+		ClientID:      "22222222-2222-2222-2222-222222222222",
+		ClientSecret:  "fake-secret",
+	}
+	adapter, _, err := newDefenderAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	// Close() before the first 30s poll tick fires, so no network call is made.
+	defer adapter.Close()
+	assert.Equal(t, 30*time.Second, adapter.pollInterval)
+}

--- a/defender/mock_test.go
+++ b/defender/mock_test.go
@@ -82,9 +82,17 @@ func (s *captureSink) snapshot() []*protocol.DataMessage {
 //   - GET /v1.0/security/alerts_v2 -- the MS Graph security alerts endpoint.
 //     It validates the bearer token, honors the adapter's
 //     `$filter=createdDateTime ge <ts>` query parameter against an in-memory
-//     dataset (kept in ascending createdDateTime order, the order the adapter
-//     relies on), and returns the Graph envelope ({"@odata.context", "value",
+//     dataset, and returns the Graph envelope ({"@odata.context", "value",
 //     and "@odata.nextLink" when the page is truncated}).
+//
+// Ordering caveat: the mock serves alerts in ascending createdDateTime order
+// because the adapter's watermark logic (take the createdDateTime of the last
+// item processed as the next `since`) only makes forward progress under that
+// ordering. The official docs do NOT promise it: the List alerts_v2 page says
+// "The most recent alerts are displayed at the top of the list" (newest
+// first) and $orderby is not among the supported query parameters ($count,
+// $filter, $skip, $top). These tests pin the adapter's behavior, not a Graph
+// ordering guarantee.
 type mockMicrosoft struct {
 	mu sync.Mutex
 
@@ -104,8 +112,9 @@ func newMockMicrosoft() *mockMicrosoft {
 	return &mockMicrosoft{}
 }
 
-// appendAlert appends an alert at the end of the dataset (newest last), as a
-// createdDateTime-ascending Graph result would surface a new alert.
+// appendAlert appends an alert at the end of the dataset (newest last),
+// keeping the dataset in the ascending createdDateTime order the adapter's
+// watermark logic depends on (see the ordering caveat on mockMicrosoft).
 func (m *mockMicrosoft) appendAlert(alert map[string]interface{}) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -185,25 +194,39 @@ func (m *mockMicrosoft) handleToken(t *testing.T, w http.ResponseWriter, r *http
 
 	w.Header().Set("Content-Type", "application/json")
 
+	// Documented AAD error responses carry error/error_description/error_codes
+	// plus timestamp, trace_id, correlation_id and (when available) error_uri.
+	// All ids here are clearly fake; the adapter only cares that no
+	// access_token is present.
 	if form.Get("grant_type") != "client_credentials" ||
 		form.Get("scope") != "https://graph.microsoft.com/.default" ||
 		form.Get("client_id") != mockClientID {
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error":             "invalid_request",
-			"error_description": "AADSTS900144: The request body must contain the following parameter: 'client_id'.",
+			"error_description": "AADSTS900144: The request body must contain the following parameter: 'client_id'.\r\nTrace ID: 00000000-0000-0000-0000-000000000001\r\nCorrelation ID: 00000000-0000-0000-0000-000000000002\r\nTimestamp: 2024-01-01 00:00:00Z",
 			"error_codes":       []int{900144},
+			"timestamp":         "2024-01-01 00:00:00Z",
+			"trace_id":          "00000000-0000-0000-0000-000000000001",
+			"correlation_id":    "00000000-0000-0000-0000-000000000002",
+			"error_uri":         "https://login.microsoftonline.com/error?code=900144",
 		})
 		return
 	}
 	if form.Get("client_secret") != mockClientSecret {
-		// What AAD returns for a bad secret; the adapter only cares that no
-		// access_token is present.
+		// What AAD returns for a bad secret: error "invalid_client" with
+		// AADSTS7000215 ("Invalid client secret is provided" per the AADSTS
+		// error code reference). AAD serves invalid_client over HTTP 401,
+		// which RFC 6749 section 5.2 permits.
 		w.WriteHeader(http.StatusUnauthorized)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error":             "invalid_client",
-			"error_description": "AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID.",
+			"error_description": "AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID, for a secret added to app '" + mockClientID + "'.\r\nTrace ID: 00000000-0000-0000-0000-000000000001\r\nCorrelation ID: 00000000-0000-0000-0000-000000000002\r\nTimestamp: 2024-01-01 00:00:00Z",
 			"error_codes":       []int{7000215},
+			"timestamp":         "2024-01-01 00:00:00Z",
+			"trace_id":          "00000000-0000-0000-0000-000000000001",
+			"correlation_id":    "00000000-0000-0000-0000-000000000002",
+			"error_uri":         "https://login.microsoftonline.com/error?code=7000215",
 		})
 		return
 	}
@@ -304,8 +327,8 @@ func (m *mockMicrosoft) handleAlerts(t *testing.T, w http.ResponseWriter, r *htt
 // realisticAlert returns an alert shaped like a real MS Graph security
 // alerts_v2 record (microsoft.graph.security.alert): the documented top-level
 // fields plus an evidence array mixing deviceEvidence / fileEvidence /
-// processEvidence, nulls, ints, bools and nested objects. All identifiers are
-// clearly fake.
+// processEvidence, nulls, ints, arrays and nested objects. All identifiers
+// are clearly fake.
 func realisticAlert(id string, createdDateTime time.Time) map[string]interface{} {
 	created := createdDateTime.Format(graphTimestampLayout)
 	return map[string]interface{}{

--- a/defender/mock_test.go
+++ b/defender/mock_test.go
@@ -1,0 +1,705 @@
+package usp_defender
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock of the two
+// Microsoft endpoints it talks to -- the identity platform token endpoint and
+// the MS Graph security alerts_v2 endpoint -- capturing the exact messages it
+// ships so their content can be asserted.
+
+// graphTimestampLayout matches how MS Graph renders alerts_v2 timestamps
+// (seven fractional digits, Z suffix). The trailing Z is a literal in this
+// layout, mirroring how the adapter itself renders its `since` watermark.
+const graphTimestampLayout = "2006-01-02T15:04:05.0000000Z"
+
+const (
+	mockTenantID     = "11111111-1111-1111-1111-111111111111"
+	mockClientID     = "22222222-2222-2222-2222-222222222222"
+	mockClientSecret = "fake-client-secret-for-tests-only"
+	mockAccessToken  = "fake-access-token-0000000000000001"
+
+	tokenPath  = "/" + mockTenantID + "/oauth2/v2.0/token"
+	alertsPath = "/v1.0/security/alerts_v2"
+)
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Microsoft endpoints -------------------------------------------------
+
+// mockMicrosoft is an in-memory stand-in for the two Microsoft endpoints the
+// adapter uses:
+//
+//   - POST /<tenant>/oauth2/v2.0/token -- the identity platform
+//     client_credentials flow. It validates client_id/client_secret/
+//     grant_type/scope exactly as the adapter sends them and returns an
+//     access_token.
+//   - GET /v1.0/security/alerts_v2 -- the MS Graph security alerts endpoint.
+//     It validates the bearer token, honors the adapter's
+//     `$filter=createdDateTime ge <ts>` query parameter against an in-memory
+//     dataset (kept in ascending createdDateTime order, the order the adapter
+//     relies on), and returns the Graph envelope ({"@odata.context", "value",
+//     and "@odata.nextLink" when the page is truncated}).
+type mockMicrosoft struct {
+	mu sync.Mutex
+
+	alerts   []map[string]interface{} // ascending createdDateTime
+	pageSize int                      // 0 = no truncation
+
+	tokenRequests int
+	alertRequests int
+	nextLinks     int
+
+	lastTokenForm  url.Values
+	lastAuthHeader string
+	lastFilter     string
+}
+
+func newMockMicrosoft() *mockMicrosoft {
+	return &mockMicrosoft{}
+}
+
+// appendAlert appends an alert at the end of the dataset (newest last), as a
+// createdDateTime-ascending Graph result would surface a new alert.
+func (m *mockMicrosoft) appendAlert(alert map[string]interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.alerts = append(m.alerts, alert)
+}
+
+func (m *mockMicrosoft) tokenRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests
+}
+
+func (m *mockMicrosoft) alertRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.alertRequests
+}
+
+func (m *mockMicrosoft) nextLinkCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.nextLinks
+}
+
+func (m *mockMicrosoft) lastSeenTokenForm() url.Values {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastTokenForm
+}
+
+func (m *mockMicrosoft) lastSeenAuthHeader() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastAuthHeader
+}
+
+func (m *mockMicrosoft) lastSeenFilter() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastFilter
+}
+
+func (m *mockMicrosoft) handler(t *testing.T) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenPath, func(w http.ResponseWriter, r *http.Request) { m.handleToken(t, w, r) })
+	mux.HandleFunc(alertsPath, func(w http.ResponseWriter, r *http.Request) { m.handleAlerts(t, w, r) })
+	return mux
+}
+
+// handleToken implements the client_credentials token grant. Note: handlers
+// run on httptest goroutines, so they use assert (never require).
+func (m *mockMicrosoft) handleToken(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.tokenRequests++
+	m.mu.Unlock()
+
+	if !assert.Equal(t, http.MethodPost, r.Method, "token endpoint expects POST") {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(r.Body)
+	if !assert.NoError(t, err) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	form, err := url.ParseQuery(string(body))
+	if !assert.NoError(t, err, "token request body must be form-encoded") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	m.mu.Lock()
+	m.lastTokenForm = form
+	m.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if form.Get("grant_type") != "client_credentials" ||
+		form.Get("scope") != "https://graph.microsoft.com/.default" ||
+		form.Get("client_id") != mockClientID {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "invalid_request",
+			"error_description": "AADSTS900144: The request body must contain the following parameter: 'client_id'.",
+			"error_codes":       []int{900144},
+		})
+		return
+	}
+	if form.Get("client_secret") != mockClientSecret {
+		// What AAD returns for a bad secret; the adapter only cares that no
+		// access_token is present.
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "invalid_client",
+			"error_description": "AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID.",
+			"error_codes":       []int{7000215},
+		})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"token_type":     "Bearer",
+		"expires_in":     3599,
+		"ext_expires_in": 3599,
+		"access_token":   mockAccessToken,
+	})
+}
+
+// handleAlerts implements GET /v1.0/security/alerts_v2 with the
+// `$filter=createdDateTime ge <ts>` filter the adapter sends.
+func (m *mockMicrosoft) handleAlerts(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.alertRequests++
+	m.lastAuthHeader = r.Header.Get("Authorization")
+	m.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if !assert.Equal(t, http.MethodGet, r.Method, "alerts endpoint expects GET") {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if r.Header.Get("Authorization") != "Bearer "+mockAccessToken {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{
+				"code":    "InvalidAuthenticationToken",
+				"message": "Access token is empty or invalid.",
+			},
+		})
+		return
+	}
+
+	filter := r.URL.Query().Get("$filter")
+	m.mu.Lock()
+	m.lastFilter = filter
+	m.mu.Unlock()
+
+	const prefix = "createdDateTime ge "
+	if !assert.True(t, strings.HasPrefix(filter, prefix), "unexpected $filter: %q", filter) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{"code": "BadRequest", "message": "Invalid filter clause."},
+		})
+		return
+	}
+	since, err := time.Parse(time.RFC3339Nano, strings.TrimPrefix(filter, prefix))
+	if !assert.NoError(t, err, "unparseable $filter timestamp in %q", filter) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{"code": "BadRequest", "message": "Invalid filter clause."},
+		})
+		return
+	}
+
+	m.mu.Lock()
+	var matching []map[string]interface{}
+	for _, alert := range m.alerts {
+		created, perr := time.Parse(time.RFC3339Nano, alert["createdDateTime"].(string))
+		if !assert.NoError(t, perr) {
+			continue
+		}
+		if !created.Before(since) {
+			matching = append(matching, alert)
+		}
+	}
+	pageSize := m.pageSize
+	m.mu.Unlock()
+
+	envelope := map[string]interface{}{
+		"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#security/alerts_v2",
+	}
+	if pageSize > 0 && len(matching) > pageSize {
+		matching = matching[:pageSize]
+		envelope["@odata.nextLink"] = fmt.Sprintf(
+			"https://graph.microsoft.com/v1.0/security/alerts_v2?$filter=%s&$skiptoken=fakeSkipToken%d",
+			url.QueryEscape(filter), pageSize)
+		m.mu.Lock()
+		m.nextLinks++
+		m.mu.Unlock()
+	}
+	if matching == nil {
+		matching = []map[string]interface{}{}
+	}
+	envelope["value"] = matching
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(envelope)
+}
+
+// --- realistic alert fixtures -------------------------------------------------
+
+// realisticAlert returns an alert shaped like a real MS Graph security
+// alerts_v2 record (microsoft.graph.security.alert): the documented top-level
+// fields plus an evidence array mixing deviceEvidence / fileEvidence /
+// processEvidence, nulls, ints, bools and nested objects. All identifiers are
+// clearly fake.
+func realisticAlert(id string, createdDateTime time.Time) map[string]interface{} {
+	created := createdDateTime.Format(graphTimestampLayout)
+	return map[string]interface{}{
+		"@odata.type":        "#microsoft.graph.security.alert",
+		"id":                 id,
+		"providerAlertId":    strings.TrimPrefix(id, "da"),
+		"incidentId":         "10001",
+		"status":             "new",
+		"severity":           "medium",
+		"classification":     nil,
+		"determination":      nil,
+		"serviceSource":      "microsoftDefenderForEndpoint",
+		"detectionSource":    "antivirus",
+		"detectorId":         "33333333-3333-3333-3333-333333333333",
+		"tenantId":           mockTenantID,
+		"title":              "Suspicious execution of hidden file",
+		"description":        "A hidden file has been launched. This activity could indicate a malicious attempt to evade detection.",
+		"recommendedActions": "Collect artifacts and determine scope. Review the machine timeline for suspicious activities.",
+		"category":           "DefenseEvasion",
+		"assignedTo":         nil,
+		"alertWebUrl":        "https://security.microsoft.com/alerts/" + id + "?tid=" + mockTenantID,
+		"incidentWebUrl":     "https://security.microsoft.com/incidents/10001?tid=" + mockTenantID,
+		"actorDisplayName":   nil,
+		"threatDisplayName":  nil,
+		"threatFamilyName":   nil,
+		"mitreTechniques":    []interface{}{"T1564.001"},
+		"createdDateTime":    created,
+		"lastUpdateDateTime": created,
+		"resolvedDateTime":   nil,
+		"firstActivityDateTime": createdDateTime.Add(-2 * time.Minute).
+			Format(graphTimestampLayout),
+		"lastActivityDateTime": created,
+		"comments":             []interface{}{},
+		"systemTags":           []interface{}{},
+		"alertPolicyId":        nil,
+		"evidence": []interface{}{
+			map[string]interface{}{
+				"@odata.type":       "#microsoft.graph.security.deviceEvidence",
+				"createdDateTime":   created,
+				"verdict":           "suspicious",
+				"remediationStatus": "none",
+				"roles":             []interface{}{},
+				"tags":              []interface{}{"Test Machine"},
+				"firstSeenDateTime": "2024-01-01T08:00:00.0000000Z",
+				"mdeDeviceId":       "1111111111111111111111111111111111111111",
+				"azureAdDeviceId":   nil,
+				"deviceDnsName":     "test-host-1.example.com",
+				"hostName":          "test-host-1",
+				"osPlatform":        "Windows11",
+				"osBuild":           22631,
+				"version":           "23H2",
+				"healthStatus":      "active",
+				"riskScore":         "medium",
+				"onboardingStatus":  "onboarded",
+				"defenderAvStatus":  "updated",
+				"loggedOnUsers": []interface{}{
+					map[string]interface{}{
+						"accountName": "jdoe",
+						"domainName":  "EXAMPLE",
+					},
+				},
+			},
+			map[string]interface{}{
+				"@odata.type":       "#microsoft.graph.security.fileEvidence",
+				"createdDateTime":   created,
+				"verdict":           "suspicious",
+				"remediationStatus": "none",
+				"roles":             []interface{}{},
+				"tags":              []interface{}{},
+				"detectionStatus":   "detected",
+				"mdeDeviceId":       "1111111111111111111111111111111111111111",
+				"fileDetails": map[string]interface{}{
+					"sha1":          "1111111111111111111111111111111111111111",
+					"sha256":        "1111111111111111111111111111111111111111111111111111111111111111",
+					"fileName":      "hidden_payload.exe",
+					"filePath":      `C:\Users\jdoe\AppData\Local\Temp`,
+					"fileSize":      433152,
+					"filePublisher": "Example Software Inc.",
+					"signer":        nil,
+					"issuer":        nil,
+				},
+			},
+			map[string]interface{}{
+				"@odata.type":             "#microsoft.graph.security.processEvidence",
+				"createdDateTime":         created,
+				"verdict":                 "suspicious",
+				"remediationStatus":       "none",
+				"roles":                   []interface{}{},
+				"tags":                    []interface{}{},
+				"processId":               4780,
+				"parentProcessId":         668,
+				"processCommandLine":      `"hidden_payload.exe" -enc SQBFAFgA`,
+				"detectionStatus":         "detected",
+				"mdeDeviceId":             "1111111111111111111111111111111111111111",
+				"processCreationDateTime": created,
+				"parentProcessCreationDateTime": createdDateTime.Add(-10 * time.Minute).
+					Format(graphTimestampLayout),
+				"imageFile": map[string]interface{}{
+					"fileName": "hidden_payload.exe",
+					"filePath": `C:\Users\jdoe\AppData\Local\Temp`,
+					"fileSize": 433152,
+				},
+				"userAccount": map[string]interface{}{
+					"accountName":       "jdoe",
+					"domainName":        "EXAMPLE",
+					"userSid":           "S-1-5-21-1111111111-1111111111-1111111111-1001",
+					"azureAdUserId":     nil,
+					"userPrincipalName": "jdoe@example.com",
+				},
+			},
+		},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// startMockAdapter spins up the adapter wired to the mock server and the
+// capture sink, with a short poll interval so tests run fast.
+func startMockAdapter(t *testing.T, serverURL string, sink uspSink, clientSecret string) (*DefenderAdapter, chan struct{}) {
+	t.Helper()
+	conf := DefenderConfig{
+		ClientOptions: testClientOptions(t),
+		TenantID:      mockTenantID,
+		ClientID:      mockClientID,
+		ClientSecret:  clientSecret,
+		TokenURL:      serverURL + tokenPath,
+		AlertsURL:     serverURL + alertsPath,
+		PollInterval:  30 * time.Millisecond,
+	}
+	require.NoError(t, conf.Validate())
+	adapter, chStopped, err := newDefenderAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	return adapter, chStopped
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestMockAlertsEndToEnd drives the adapter against the mock Microsoft
+// endpoints and asserts the exact events shipped: every alert ships exactly
+// once with its payload verbatim (nested evidence included), an
+// ingestion-time TimestampMs and no EventType (the adapter sets none); the
+// mock observed a valid client_credentials token request and a bearer-token'd
+// Graph call carrying the createdDateTime $filter.
+func TestMockAlertsEndToEnd(t *testing.T) {
+	testStart := time.Now()
+
+	// The adapter only collects alerts created after it starts (its watermark
+	// is initialized to "now"), so fixtures carry future createdDateTimes.
+	base := time.Now().Add(1 * time.Hour)
+	want := []map[string]interface{}{
+		realisticAlert("da637551227677560813_-1111111111", base),
+		realisticAlert("da637551227677560814_-1111111112", base.Add(1*time.Second)),
+		realisticAlert("da637551227677560815_-1111111113", base.Add(2*time.Second)),
+	}
+
+	mock := newMockMicrosoft()
+	for _, alert := range want {
+		mock.appendAlert(alert)
+	}
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, sink, mockClientSecret)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond, "expected all 3 alerts to ship")
+
+	// Re-polling must not re-ship: the count stays at 3.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 20*time.Millisecond, "alerts were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		// The adapter ships alerts without an EventType.
+		assert.Equal(t, "", msg.EventType)
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+
+		// TimestampMs is ingestion time: between test start and now.
+		assert.GreaterOrEqual(t, msg.TimestampMs, uint64(testStart.UnixMilli()))
+		assert.LessOrEqual(t, msg.TimestampMs, uint64(time.Now().UnixMilli()))
+	}
+	require.Len(t, byID, 3, "each alert must ship exactly once")
+
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "alert %s was not shipped", id)
+		// The payload is shipped verbatim -- nested evidence objects, arrays,
+		// nulls and ints included.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Graph alert")
+	}
+
+	// The mock saw the credential flow and the Graph query the adapter sends.
+	form := mock.lastSeenTokenForm()
+	require.NotNil(t, form)
+	assert.Equal(t, mockClientID, form.Get("client_id"))
+	assert.Equal(t, mockClientSecret, form.Get("client_secret"))
+	assert.Equal(t, "client_credentials", form.Get("grant_type"))
+	assert.Equal(t, "https://graph.microsoft.com/.default", form.Get("scope"))
+	assert.Equal(t, "Bearer "+mockAccessToken, mock.lastSeenAuthHeader())
+	assert.True(t, strings.HasPrefix(mock.lastSeenFilter(), "createdDateTime ge "),
+		"Graph call must filter on createdDateTime, got %q", mock.lastSeenFilter())
+	// A token is fetched for every poll of the alerts endpoint.
+	assert.GreaterOrEqual(t, mock.tokenRequestCount(), 1)
+	assert.GreaterOrEqual(t, mock.alertRequestCount(), 1)
+}
+
+// TestMockNewAlertMidRunShipsOnce verifies an alert appearing while the
+// adapter is running is picked up by a later poll and shipped exactly once,
+// without re-shipping the alerts that came before it.
+func TestMockNewAlertMidRunShipsOnce(t *testing.T) {
+	base := time.Now().Add(1 * time.Hour)
+
+	mock := newMockMicrosoft()
+	mock.appendAlert(realisticAlert("da637551227677560813_-2222222221", base))
+	mock.appendAlert(realisticAlert("da637551227677560814_-2222222222", base.Add(1*time.Second)))
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, sink, mockClientSecret)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 10*time.Millisecond)
+
+	// A new alert is created while the adapter is running.
+	mock.appendAlert(realisticAlert("da637551227677560815_-2222222223", base.Add(2*time.Second)))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond, "the new alert should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 20*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{
+		"da637551227677560813_-2222222221": 1,
+		"da637551227677560814_-2222222222": 1,
+		"da637551227677560815_-2222222223": 1,
+	}, shippedPerID, "every alert must ship exactly once")
+}
+
+// TestMockPaginatedDatasetFullyConsumed verifies a result set larger than one
+// Graph page is fully collected. The adapter does not follow @odata.nextLink;
+// it makes progress because each poll advances the createdDateTime watermark
+// to the last alert it saw, so successive polls drain the remainder. The mock
+// truncates to a page size and emits @odata.nextLink exactly like Graph does;
+// every alert must still ship exactly once.
+func TestMockPaginatedDatasetFullyConsumed(t *testing.T) {
+	const total = 12
+	base := time.Now().Add(1 * time.Hour)
+
+	mock := newMockMicrosoft()
+	mock.pageSize = 5
+	wantIDs := make([]string, 0, total)
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("da637551227677560813_-33333333%02d", i)
+		wantIDs = append(wantIDs, id)
+		mock.appendAlert(realisticAlert(id, base.Add(time.Duration(i)*time.Second)))
+	}
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, sink, mockClientSecret)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 10*time.Millisecond, "the full paginated dataset should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 20*time.Millisecond, "no alert may ship twice")
+
+	shipped := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shipped[msg.JsonPayload["id"].(string)]++
+	}
+	for _, id := range wantIDs {
+		assert.Equal(t, 1, shipped[id], "alert %s must ship exactly once", id)
+	}
+	assert.GreaterOrEqual(t, mock.nextLinkCount(), 1,
+		"the mock must actually have truncated (served @odata.nextLink) for this test to be meaningful")
+	assert.GreaterOrEqual(t, mock.alertRequestCount(), 3,
+		"consuming 12 alerts at page size 5 requires at least 3 polls")
+}
+
+// TestMockBadCredentialsShipNothing verifies the adapter's error handling for
+// rejected credentials: the token endpoint rejects the client secret, the
+// adapter retries the token fetch 3 times then reports an error for the poll,
+// nothing is ever shipped, the Graph endpoint is never called, and -- per the
+// adapter's design -- it keeps running (it does not stop itself on auth
+// failure; it retries on the next poll).
+func TestMockBadCredentialsShipNothing(t *testing.T) {
+	mock := newMockMicrosoft()
+	mock.appendAlert(realisticAlert("da637551227677560813_-4444444441", time.Now().Add(1*time.Hour)))
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	var errMu sync.Mutex
+	var errs []string
+
+	sink := &captureSink{}
+	conf := DefenderConfig{
+		ClientOptions: testClientOptions(t),
+		TenantID:      mockTenantID,
+		ClientID:      mockClientID,
+		ClientSecret:  "wrong-secret",
+		TokenURL:      server.URL + tokenPath,
+		AlertsURL:     server.URL + alertsPath,
+		PollInterval:  30 * time.Millisecond,
+	}
+	conf.ClientOptions.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		errMu.Lock()
+		errs = append(errs, err.Error())
+		errMu.Unlock()
+	}
+	adapter, chStopped, err := newDefenderAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The token fetch retries 3 times (with 1s+2s backoff) before reporting
+	// the poll as failed.
+	require.Eventually(t, func() bool {
+		errMu.Lock()
+		defer errMu.Unlock()
+		for _, e := range errs {
+			if strings.Contains(e, "error fetching token after 3 attempts") {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 50*time.Millisecond, "the failed token fetch must be reported")
+
+	assert.Equal(t, 0, sink.count(), "nothing may ship when credentials are rejected")
+	assert.Equal(t, 0, mock.alertRequestCount(), "the Graph endpoint must not be called without a token")
+	assert.GreaterOrEqual(t, mock.tokenRequestCount(), 3, "the token fetch is retried 3 times")
+
+	// The adapter does not stop itself on bad credentials -- it keeps polling.
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped on bad credentials; it is designed to keep retrying")
+	default:
+	}
+}
+
+// TestMockNoAlertsShipsNothing verifies that an empty alerts_v2 result set
+// polls cleanly: requests are made, nothing ships, and no errors are raised.
+func TestMockNoAlertsShipsNothing(t *testing.T) {
+	mock := newMockMicrosoft()
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	var errMu sync.Mutex
+	var errs []string
+
+	sink := &captureSink{}
+	conf := DefenderConfig{
+		ClientOptions: testClientOptions(t),
+		TenantID:      mockTenantID,
+		ClientID:      mockClientID,
+		ClientSecret:  mockClientSecret,
+		TokenURL:      server.URL + tokenPath,
+		AlertsURL:     server.URL + alertsPath,
+		PollInterval:  30 * time.Millisecond,
+	}
+	conf.ClientOptions.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		errMu.Lock()
+		errs = append(errs, err.Error())
+		errMu.Unlock()
+	}
+	adapter, _, err := newDefenderAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return mock.alertRequestCount() >= 2 },
+		5*time.Second, 10*time.Millisecond, "the adapter should keep polling")
+
+	assert.Equal(t, 0, sink.count(), "an empty result set ships nothing")
+	errMu.Lock()
+	defer errMu.Unlock()
+	assert.Empty(t, errs, "an empty result set is not an error")
+}

--- a/entraid/client.go
+++ b/entraid/client.go
@@ -23,12 +23,28 @@ var URL = map[string]string{
 	"get_alerts": "https://graph.microsoft.com/v1.0/identityProtection/riskDetections",
 }
 
+const (
+	defaultLoginEndpoint = "https://login.microsoftonline.com"
+	defaultGraphEndpoint = "https://graph.microsoft.com"
+	defaultPollInterval  = 30 * time.Second
+)
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type EntraIDAdapter struct {
 	conf       EntraIDConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
 
-	endpoint string
+	endpoint     string
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -42,6 +58,49 @@ type EntraIDConfig struct {
 	TenantID      string                  `json:"tenant_id" yaml:"tenant_id"`
 	ClientID      string                  `json:"client_id" yaml:"client_id"`
 	ClientSecret  string                  `json:"client_secret" yaml:"client_secret"`
+
+	// LoginEndpoint overrides the base URL of the Microsoft identity platform
+	// used for the OAuth2 client_credentials token exchange. Defaults to
+	// https://login.microsoftonline.com when empty.
+	LoginEndpoint string `json:"login_endpoint,omitempty" yaml:"login_endpoint,omitempty"`
+
+	// GraphEndpoint overrides the base URL of the Microsoft Graph API the risk
+	// detections are fetched from. Defaults to https://graph.microsoft.com
+	// when empty.
+	GraphEndpoint string `json:"graph_endpoint,omitempty" yaml:"graph_endpoint,omitempty"`
+
+	// PollInterval overrides the wait between polls of the riskDetections
+	// endpoint (default 30s). It is not settable through a config file; it
+	// exists as a seam for tests.
+	PollInterval time.Duration `json:"-" yaml:"-"`
+}
+
+// loginEndpoint returns the Microsoft identity platform base URL to use,
+// defaulting to the public endpoint when no override is configured.
+func (c EntraIDConfig) loginEndpoint() string {
+	if c.LoginEndpoint != "" {
+		return strings.TrimRight(c.LoginEndpoint, "/")
+	}
+	return defaultLoginEndpoint
+}
+
+// graphEndpoint returns the Microsoft Graph base URL to use, defaulting to the
+// public endpoint when no override is configured.
+func (c EntraIDConfig) graphEndpoint() string {
+	if c.GraphEndpoint != "" {
+		return strings.TrimRight(c.GraphEndpoint, "/")
+	}
+	return defaultGraphEndpoint
+}
+
+// tokenURL is the OAuth2 client_credentials token endpoint for the tenant.
+func (c EntraIDConfig) tokenURL() string {
+	return fmt.Sprintf("%s/%s/oauth2/v2.0/token", c.loginEndpoint(), c.TenantID)
+}
+
+// riskDetectionsURL is the Identity Protection risk detections endpoint.
+func (c EntraIDConfig) riskDetectionsURL() string {
+	return c.graphEndpoint() + "/v1.0/identityProtection/riskDetections"
 }
 
 func (c *EntraIDConfig) Validate() error {
@@ -61,16 +120,31 @@ func (c *EntraIDConfig) Validate() error {
 }
 
 func NewEntraIDAdapter(ctx context.Context, conf EntraIDConfig) (*EntraIDAdapter, chan struct{}, error) {
-	var err error
+	return newEntraIDAdapter(ctx, conf, nil)
+}
+
+// newEntraIDAdapter is the implementation behind NewEntraIDAdapter. When sink
+// is non-nil it is used in place of a real LimaCharlie client -- the seam tests
+// use to capture shipped events.
+func newEntraIDAdapter(ctx context.Context, conf EntraIDConfig, sink uspSink) (*EntraIDAdapter, chan struct{}, error) {
 	a := &EntraIDAdapter{
-		conf:   conf,
-		ctx:    context.Background(),
-		doStop: utils.NewEvent(),
+		conf:         conf,
+		ctx:          context.Background(),
+		doStop:       utils.NewEvent(),
+		pollInterval: conf.PollInterval,
+	}
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -87,7 +161,7 @@ func NewEntraIDAdapter(ctx context.Context, conf EntraIDConfig) (*EntraIDAdapter
 	a.conf.ClientOptions.DebugLog(fmt.Sprintf("starting to fetch alerts"))
 
 	a.wgSenders.Add(1)
-	go a.fetchEvents(URL["get_alerts"])
+	go a.fetchEvents(a.conf.riskDetectionsURL())
 
 	go func() {
 		a.wgSenders.Wait()
@@ -114,7 +188,7 @@ func (a *EntraIDAdapter) Close() error {
 
 func (a *EntraIDAdapter) fetchToken() (string, error) {
 
-	url := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", a.conf.TenantID)
+	url := a.conf.tokenURL()
 	payload := fmt.Sprintf("client_id=%s&scope=%s&grant_type=%s&client_secret=%s", a.conf.ClientID, scope, "client_credentials", a.conf.ClientSecret)
 
 	req, err := http.NewRequest("POST", url, bytes.NewBufferString(payload))
@@ -157,7 +231,7 @@ func (a *EntraIDAdapter) fetchEvents(url string) {
 	lastEventId := ""
 	since := time.Now().Format("2006-01-02T15:04:05.000000Z")
 
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// The makeOneRequest function handles error
 		// handling and fatal error handling.
 		items, newSince, eventId, _ := a.makeOneListRequest(url, since, lastEventId)

--- a/entraid/client_test.go
+++ b/entraid/client_test.go
@@ -1,0 +1,71 @@
+package usp_entraid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	valid := func(t *testing.T) EntraIDConfig {
+		return EntraIDConfig{
+			ClientOptions: testClientOptions(t),
+			TenantID:      testTenantID,
+			ClientID:      testClientID,
+			ClientSecret:  testClientSecret,
+		}
+	}
+
+	t.Run("valid config passes", func(t *testing.T) {
+		c := valid(t)
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("requires tenant_id", func(t *testing.T) {
+		c := valid(t)
+		c.TenantID = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires client_id", func(t *testing.T) {
+		c := valid(t)
+		c.ClientID = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires client_secret", func(t *testing.T) {
+		c := valid(t)
+		c.ClientSecret = ""
+		assert.Error(t, c.Validate())
+	})
+}
+
+func TestEndpointResolution(t *testing.T) {
+	t.Run("defaults match the public Microsoft endpoints", func(t *testing.T) {
+		c := EntraIDConfig{TenantID: testTenantID}
+		assert.Equal(t,
+			"https://login.microsoftonline.com/"+testTenantID+"/oauth2/v2.0/token",
+			c.tokenURL())
+		assert.Equal(t,
+			"https://graph.microsoft.com/v1.0/identityProtection/riskDetections",
+			c.riskDetectionsURL())
+		// The default Graph URL must stay in sync with the historical
+		// hardcoded value.
+		assert.Equal(t, URL["get_alerts"], c.riskDetectionsURL())
+	})
+
+	t.Run("overrides are honored and trailing slashes trimmed", func(t *testing.T) {
+		c := EntraIDConfig{
+			TenantID:      testTenantID,
+			LoginEndpoint: "http://127.0.0.1:8080/",
+			GraphEndpoint: "http://127.0.0.1:9090/",
+		}
+		assert.Equal(t,
+			"http://127.0.0.1:8080/"+testTenantID+"/oauth2/v2.0/token",
+			c.tokenURL())
+		assert.Equal(t,
+			"http://127.0.0.1:9090/v1.0/identityProtection/riskDetections",
+			c.riskDetectionsURL())
+	})
+}

--- a/entraid/mock_test.go
+++ b/entraid/mock_test.go
@@ -1,0 +1,685 @@
+package usp_entraid
+
+// This file exercises the adapter end-to-end against a mock of the two
+// Microsoft endpoints it talks to:
+//
+//   - the Microsoft identity platform token endpoint
+//     (POST /<tenant>/oauth2/v2.0/token, OAuth2 client_credentials), and
+//   - the Microsoft Graph Identity Protection risk detections endpoint
+//     (GET /v1.0/identityProtection/riskDetections?$filter=activityDateTime ge <ts>).
+//
+// The mock validates the credential exchange and the bearer token, honours the
+// adapter's $filter on activityDateTime (inclusive "ge", as OData defines it),
+// orders results by activityDateTime ascending and can truncate responses to a
+// page size, advertising the Graph "@odata.nextLink" continuation the real API
+// returns. Note the adapter does not follow @odata.nextLink: it drains large
+// result sets across successive polls by advancing its $filter to the last
+// detection's activityDateTime, which is what the pagination test exercises.
+//
+// All fixture data is fake: example.com principals, all-1s UUIDs,
+// documentation-range IPs (203.0.113.0/24) and made-up tokens.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testTenantID     = "11111111-1111-1111-1111-111111111111"
+	testClientID     = "11111111-1111-1111-1111-222222222222"
+	testClientSecret = "fake-client-secret-for-tests"
+	testAccessToken  = "fake-access-token-issued-by-mock"
+
+	// graphTimeLayout matches the shape of Microsoft Graph datetime fields
+	// (UTC, fractional seconds, Z suffix). It is also the layout the adapter
+	// uses for its initial "since" value.
+	graphTimeLayout = "2006-01-02T15:04:05.000000Z"
+
+	// testPollInterval keeps the e2e tests fast; production default is 30s.
+	testPollInterval = 50 * time.Millisecond
+)
+
+// --- in-memory USP sink -------------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- test client options ------------------------------------------------------
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// errorRecorder collects OnError messages so tests can assert on the adapter's
+// error reporting. Safe for use from the adapter's goroutines.
+type errorRecorder struct {
+	mu     sync.Mutex
+	errors []string
+}
+
+func (e *errorRecorder) record(err error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.errors = append(e.errors, err.Error())
+}
+
+func (e *errorRecorder) anyContains(substr string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, s := range e.errors {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- mock Microsoft (login.microsoftonline.com + graph.microsoft.com) ---------
+
+// mockMicrosoft serves both the identity platform token endpoint and the Graph
+// riskDetections endpoint from a single httptest server; tests point both of
+// the adapter's endpoint overrides at it.
+type mockMicrosoft struct {
+	mu sync.Mutex
+
+	tenantID     string
+	clientID     string
+	clientSecret string
+	accessToken  string
+
+	// detections is the in-memory Graph dataset.
+	detections []map[string]interface{}
+
+	// pageSize, when > 0, caps how many detections a single response carries;
+	// truncated responses include an @odata.nextLink, like the real Graph API.
+	pageSize int
+
+	// revokeGraphAccess makes the Graph endpoint reject every bearer token
+	// (e.g. the app registration lost its IdentityRiskEvent.Read.All grant).
+	revokeGraphAccess bool
+
+	tokenRequests int
+	graphRequests int
+
+	// lastTokenForm is the most recent decoded body of a token request, kept
+	// so tests can assert the exact client_credentials exchange.
+	lastTokenForm url.Values
+
+	serverURL string
+}
+
+func newMockMicrosoft() *mockMicrosoft {
+	return &mockMicrosoft{
+		tenantID:     testTenantID,
+		clientID:     testClientID,
+		clientSecret: testClientSecret,
+		accessToken:  testAccessToken,
+	}
+}
+
+func (m *mockMicrosoft) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(m.handler(t))
+	t.Cleanup(server.Close)
+	m.mu.Lock()
+	m.serverURL = server.URL
+	m.mu.Unlock()
+	return server
+}
+
+func (m *mockMicrosoft) addDetection(d map[string]interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.detections = append(m.detections, d)
+}
+
+func (m *mockMicrosoft) tokenRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests
+}
+
+func (m *mockMicrosoft) graphRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.graphRequests
+}
+
+func (m *mockMicrosoft) lastTokenRequest() url.Values {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastTokenForm
+}
+
+func (m *mockMicrosoft) handler(t *testing.T) http.HandlerFunc {
+	tokenPath := "/" + testTenantID + "/oauth2/v2.0/token"
+	graphPath := "/v1.0/identityProtection/riskDetections"
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case tokenPath:
+			m.handleToken(w, r)
+		case graphPath:
+			m.handleRiskDetections(w, r)
+		default:
+			writeGraphError(w, http.StatusNotFound, "ResourceNotFound",
+				fmt.Sprintf("Resource not found for the segment %q.", r.URL.Path))
+		}
+	}
+}
+
+// handleToken implements the OAuth2 client_credentials exchange of the
+// Microsoft identity platform v2.0 endpoint.
+func (m *mockMicrosoft) handleToken(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.tokenRequests++
+	m.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "invalid_request",
+			"error_description": "AADSTS900561: The endpoint only accepts POST requests.",
+		})
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "invalid_request",
+			"error_description": "AADSTS900144: The request body must be form-urlencoded.",
+		})
+		return
+	}
+
+	m.mu.Lock()
+	m.lastTokenForm = r.PostForm
+	clientID, clientSecret := m.clientID, m.clientSecret
+	token := m.accessToken
+	m.mu.Unlock()
+
+	if r.PostForm.Get("grant_type") != "client_credentials" {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "unsupported_grant_type",
+			"error_description": "AADSTS70003: The app requested an unsupported grant type.",
+		})
+		return
+	}
+	if r.PostForm.Get("client_id") != clientID || r.PostForm.Get("client_secret") != clientSecret {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "invalid_client",
+			"error_description": "AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID.",
+			"error_codes":       []int{7000215},
+			"timestamp":         time.Now().UTC().Format("2006-01-02 15:04:05Z"),
+			"trace_id":          "11111111-1111-1111-1111-111111111111",
+			"correlation_id":    "11111111-1111-1111-1111-111111111111",
+		})
+		return
+	}
+	if r.PostForm.Get("scope") != "https://graph.microsoft.com/.default" {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "invalid_scope",
+			"error_description": "AADSTS70011: The provided value for the input parameter 'scope' is not valid.",
+		})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"token_type":     "Bearer",
+		"expires_in":     3599,
+		"ext_expires_in": 3599,
+		"access_token":   token,
+	})
+}
+
+// handleRiskDetections implements GET /v1.0/identityProtection/riskDetections
+// with the $filter the adapter sends: "activityDateTime ge <timestamp>".
+func (m *mockMicrosoft) handleRiskDetections(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.graphRequests++
+	token := m.accessToken
+	revoked := m.revokeGraphAccess
+	pageSize := m.pageSize
+	detections := make([]map[string]interface{}, len(m.detections))
+	copy(detections, m.detections)
+	serverURL := m.serverURL
+	m.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodGet {
+		writeGraphError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "Method not allowed.")
+		return
+	}
+	if revoked || r.Header.Get("Authorization") != "Bearer "+token {
+		writeGraphError(w, http.StatusUnauthorized, "InvalidAuthenticationToken",
+			"Access token validation failure. Invalid audience.")
+		return
+	}
+
+	since, ok := parseActivityDateTimeFilter(r.URL.Query().Get("$filter"))
+	if !ok {
+		writeGraphError(w, http.StatusBadRequest, "BadRequest", "Invalid $filter clause.")
+		return
+	}
+
+	// "ge" is inclusive, and Graph returns risk detections ordered by
+	// activityDateTime ascending when filtered this way.
+	matched := make([]map[string]interface{}, 0, len(detections))
+	for _, d := range detections {
+		at, err := time.Parse(time.RFC3339, d["activityDateTime"].(string))
+		if err != nil {
+			continue
+		}
+		if !at.Before(since) {
+			matched = append(matched, d)
+		}
+	}
+	sort.SliceStable(matched, func(i, j int) bool {
+		ti, _ := time.Parse(time.RFC3339, matched[i]["activityDateTime"].(string))
+		tj, _ := time.Parse(time.RFC3339, matched[j]["activityDateTime"].(string))
+		return ti.Before(tj)
+	})
+
+	envelope := map[string]interface{}{
+		"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#riskDetections",
+	}
+	if pageSize > 0 && len(matched) > pageSize {
+		matched = matched[:pageSize]
+		envelope["@odata.nextLink"] = serverURL +
+			"/v1.0/identityProtection/riskDetections?$skiptoken=fake-skip-token-1111"
+	}
+	envelope["value"] = matched
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(envelope)
+}
+
+// parseActivityDateTimeFilter extracts the timestamp from a
+// "activityDateTime ge <ts>" OData filter. The adapter has a quirk where a
+// retried request re-appends "?$filter=..." to an URL that already carries one,
+// so anything from a stray "?" onward is ignored.
+func parseActivityDateTimeFilter(filter string) (time.Time, bool) {
+	if i := strings.Index(filter, "?"); i >= 0 {
+		filter = filter[:i]
+	}
+	const prefix = "activityDateTime ge "
+	if !strings.HasPrefix(filter, prefix) {
+		return time.Time{}, false
+	}
+	ts, err := time.Parse(time.RFC3339, strings.TrimSpace(strings.TrimPrefix(filter, prefix)))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return ts, true
+}
+
+// writeGraphError writes a Microsoft Graph error envelope.
+func writeGraphError(w http.ResponseWriter, status int, code, message string) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    code,
+			"message": message,
+			"innerError": map[string]interface{}{
+				"date":              time.Now().UTC().Format(time.RFC3339),
+				"request-id":        "11111111-1111-1111-1111-111111111111",
+				"client-request-id": "11111111-1111-1111-1111-111111111111",
+			},
+		},
+	})
+}
+
+// --- fixtures -------------------------------------------------------------------
+
+// fixtureBaseTime returns a base time for fixture activityDateTime values. The
+// adapter's initial "since" is the local wall-clock rendered with a Z suffix,
+// so fixtures sit a full day in the future to be on the late side of that
+// filter in any timezone.
+func fixtureBaseTime() time.Time {
+	return time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
+}
+
+// realisticRiskDetection builds a record shaped like a Microsoft Graph
+// identityProtection riskDetection resource. All identifying values are fake.
+func realisticRiskDetection(seq int, riskEventType, upn, activityDateTime string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":                  fmt.Sprintf("%060d%04d", 0, seq),
+		"requestId":           "11111111-1111-1111-1111-111111111111",
+		"correlationId":       "11111111-1111-1111-1111-111111111111",
+		"riskEventType":       riskEventType,
+		"riskState":           "atRisk",
+		"riskLevel":           "medium",
+		"riskDetail":          "none",
+		"source":              "IdentityProtection",
+		"detectionTimingType": "realtime",
+		"activity":            "signin",
+		"tokenIssuerType":     "AzureAD",
+		"ipAddress":           fmt.Sprintf("203.0.113.%d", seq%250+1),
+		"activityDateTime":    activityDateTime,
+		"detectedDateTime":    activityDateTime,
+		"lastUpdatedDateTime": activityDateTime,
+		"userId":              "11111111-1111-1111-1111-111111111111",
+		"userDisplayName":     "Jane Doe",
+		"userPrincipalName":   upn,
+		"additionalInfo":      `[{"Key":"riskReasons","Value":["Anonymous IP address"]}]`,
+		"location": map[string]interface{}{
+			"city":            "Springfield",
+			"state":           "Illinois",
+			"countryOrRegion": "US",
+			"geoCoordinates": map[string]interface{}{
+				"latitude":  39.78,
+				"longitude": -89.65,
+			},
+		},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// testConfig returns an adapter config pointed at the mock server.
+func testConfig(t *testing.T, serverURL string) EntraIDConfig {
+	t.Helper()
+	return EntraIDConfig{
+		ClientOptions: testClientOptions(t),
+		TenantID:      testTenantID,
+		ClientID:      testClientID,
+		ClientSecret:  testClientSecret,
+		LoginEndpoint: serverURL,
+		GraphEndpoint: serverURL,
+		PollInterval:  testPollInterval,
+	}
+}
+
+// --- tests ----------------------------------------------------------------------
+
+// TestRiskDetectionsEndToEnd drives the adapter against the mock Microsoft
+// endpoints and asserts the exact events shipped: every detection arrives with
+// its payload verbatim (nested location object included), no EventType (the
+// adapter does not tag one) and an ingestion-time TimestampMs. It then verifies
+// that subsequent polls do not re-ship anything.
+func TestRiskDetectionsEndToEnd(t *testing.T) {
+	mock := newMockMicrosoft()
+	base := fixtureBaseTime()
+	want := []map[string]interface{}{
+		realisticRiskDetection(1, "anonymizedIPAddress", "jdoe@example.com", base.Format(graphTimeLayout)),
+		realisticRiskDetection(2, "unfamiliarFeatures", "asmith@example.com", base.Add(1*time.Minute).Format(graphTimeLayout)),
+		realisticRiskDetection(3, "unlikelyTravel", "bjones@example.com", base.Add(2*time.Minute).Format(graphTimeLayout)),
+	}
+	for _, d := range want {
+		mock.addDetection(d)
+	}
+	server := mock.start(t)
+
+	sink := &captureSink{}
+	startMs := uint64(time.Now().UnixMilli())
+
+	adapter, chStopped, err := newEntraIDAdapter(context.Background(), testConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		10*time.Second, 20*time.Millisecond, "expected all 3 risk detections to ship")
+
+	// Re-polling must not re-ship: the count stays at 3 across further polls.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		400*time.Millisecond, 30*time.Millisecond, "detections were re-shipped on a later poll")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped unexpectedly")
+	default:
+	}
+
+	endMs := uint64(time.Now().UnixMilli())
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		// The adapter does not set an EventType for risk detections.
+		assert.Empty(t, msg.EventType)
+		// TimestampMs is the ingestion time, not the detection time.
+		assert.GreaterOrEqual(t, msg.TimestampMs, startMs)
+		assert.LessOrEqual(t, msg.TimestampMs, endMs)
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "detection %s was not shipped", id)
+		// The payload is shipped verbatim -- nested objects included.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Graph riskDetection")
+	}
+
+	// The mock validated the credential exchange and bearer token on every
+	// request; verify the exact client_credentials form the adapter sent.
+	form := mock.lastTokenRequest()
+	require.NotNil(t, form)
+	assert.Equal(t, "client_credentials", form.Get("grant_type"))
+	assert.Equal(t, testClientID, form.Get("client_id"))
+	assert.Equal(t, testClientSecret, form.Get("client_secret"))
+	assert.Equal(t, "https://graph.microsoft.com/.default", form.Get("scope"))
+}
+
+// TestMidRunDetectionShipsOnce verifies a detection appearing while the adapter
+// is running ships exactly once, and the already-shipped ones never re-ship.
+func TestMidRunDetectionShipsOnce(t *testing.T) {
+	mock := newMockMicrosoft()
+	base := fixtureBaseTime()
+	mock.addDetection(realisticRiskDetection(1, "anonymizedIPAddress", "jdoe@example.com", base.Format(graphTimeLayout)))
+	mock.addDetection(realisticRiskDetection(2, "passwordSpray", "asmith@example.com", base.Add(1*time.Minute).Format(graphTimeLayout)))
+	server := mock.start(t)
+
+	sink := &captureSink{}
+	adapter, _, err := newEntraIDAdapter(context.Background(), testConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		10*time.Second, 20*time.Millisecond)
+
+	// A new risk detection occurs mid-run, later than everything shipped so far.
+	mock.addDetection(realisticRiskDetection(3, "unlikelyTravel", "bjones@example.com", base.Add(5*time.Minute).Format(graphTimeLayout)))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		10*time.Second, 20*time.Millisecond, "the new detection should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		400*time.Millisecond, 30*time.Millisecond, "a detection was shipped more than once")
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["id"].(string)]++
+	}
+	require.Len(t, shippedPerID, 3)
+	for id, n := range shippedPerID {
+		assert.Equal(t, 1, n, "detection %q must ship exactly once", id)
+	}
+}
+
+// TestPaginatedResultSetFullyConsumed verifies a result set larger than one
+// Graph response is fully consumed. The mock truncates each response to a page
+// and advertises @odata.nextLink like the real API; the adapter does not follow
+// the link but drains the set across polls by advancing its activityDateTime
+// filter, and every detection must ship exactly once.
+func TestPaginatedResultSetFullyConsumed(t *testing.T) {
+	const total = 5
+
+	mock := newMockMicrosoft()
+	mock.pageSize = 2
+	base := fixtureBaseTime()
+	for i := 1; i <= total; i++ {
+		mock.addDetection(realisticRiskDetection(
+			i, "unfamiliarFeatures", fmt.Sprintf("user%d@example.com", i),
+			base.Add(time.Duration(i)*time.Minute).Format(graphTimeLayout)))
+	}
+	server := mock.start(t)
+
+	sink := &captureSink{}
+	adapter, _, err := newEntraIDAdapter(context.Background(), testConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 20*time.Millisecond, "all paginated detections should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		400*time.Millisecond, 30*time.Millisecond, "detections were re-shipped")
+
+	// Draining a truncated result set takes multiple Graph requests.
+	assert.GreaterOrEqual(t, mock.graphRequestCount(), 3,
+		"consuming the set should take several polls when responses are truncated")
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["id"].(string)]++
+	}
+	require.Len(t, shippedPerID, total)
+	for id, n := range shippedPerID {
+		assert.Equal(t, 1, n, "detection %q must ship exactly once", id)
+	}
+}
+
+// TestBadClientSecretShipsNothing verifies that when the token endpoint rejects
+// the credentials, nothing ships, the failure is reported through OnError, the
+// Graph endpoint is never reached, and -- per the adapter's error handling --
+// the adapter stays alive and keeps retrying on its poll interval.
+func TestBadClientSecretShipsNothing(t *testing.T) {
+	mock := newMockMicrosoft()
+	base := fixtureBaseTime()
+	mock.addDetection(realisticRiskDetection(1, "anonymizedIPAddress", "jdoe@example.com", base.Format(graphTimeLayout)))
+	server := mock.start(t)
+
+	rec := &errorRecorder{}
+	conf := testConfig(t, server.URL)
+	conf.ClientSecret = "wrong-secret"
+	baseOnError := conf.ClientOptions.OnError
+	conf.ClientOptions.OnError = func(err error) {
+		rec.record(err)
+		baseOnError(err)
+	}
+
+	sink := &captureSink{}
+	adapter, chStopped, err := newEntraIDAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The adapter keeps polling: it reports the token failure and tries again
+	// on the next interval rather than stopping.
+	require.Eventually(t, func() bool { return mock.tokenRequestCount() >= 2 },
+		10*time.Second, 20*time.Millisecond, "the adapter should retry the token exchange on later polls")
+	require.Eventually(t, func() bool { return rec.anyContains("error fetching token") },
+		10*time.Second, 20*time.Millisecond, "the token failure should be reported via OnError")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter should keep running after a failed token exchange")
+	default:
+	}
+	assert.Equal(t, 0, sink.count(), "nothing should ship when the credential exchange fails")
+	assert.Equal(t, 0, mock.graphRequestCount(), "the Graph API must not be called without a token")
+}
+
+// TestGraphRejectsTokenShipsNothing verifies that when Graph rejects the bearer
+// token (e.g. missing IdentityRiskEvent.Read.All), the adapter retries the call
+// up to 3 times per poll, reports the failure, ships nothing, and stays alive.
+func TestGraphRejectsTokenShipsNothing(t *testing.T) {
+	mock := newMockMicrosoft()
+	mock.revokeGraphAccess = true
+	base := fixtureBaseTime()
+	mock.addDetection(realisticRiskDetection(1, "anonymizedIPAddress", "jdoe@example.com", base.Format(graphTimeLayout)))
+	server := mock.start(t)
+
+	rec := &errorRecorder{}
+	conf := testConfig(t, server.URL)
+	baseOnError := conf.ClientOptions.OnError
+	conf.ClientOptions.OnError = func(err error) {
+		rec.record(err)
+		baseOnError(err)
+	}
+
+	sink := &captureSink{}
+	adapter, chStopped, err := newEntraIDAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// Each poll retries the Graph call up to 3 times before giving up.
+	require.Eventually(t, func() bool { return mock.graphRequestCount() >= 3 },
+		10*time.Second, 20*time.Millisecond, "the adapter should retry the Graph call within a poll")
+	require.Eventually(t, func() bool { return rec.anyContains("error response from Microsoft API") },
+		10*time.Second, 20*time.Millisecond, "the Graph rejection should be reported via OnError")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter should keep running after a Graph authorization failure")
+	default:
+	}
+	assert.Equal(t, 0, sink.count(), "nothing should ship when Graph rejects the token")
+}

--- a/entraid/mock_test.go
+++ b/entraid/mock_test.go
@@ -145,7 +145,9 @@ type mockMicrosoft struct {
 	detections []map[string]interface{}
 
 	// pageSize, when > 0, caps how many detections a single response carries;
-	// truncated responses include an @odata.nextLink, like the real Graph API.
+	// truncated responses include an @odata.nextLink, like the real Graph API
+	// (the documented default page size for this endpoint is 20 objects, and
+	// the maximum with $top is 500; tests use a tiny page to force paging).
 	pageSize int
 
 	// revokeGraphAccess makes the Graph endpoint reject every bearer token
@@ -323,8 +325,12 @@ func (m *mockMicrosoft) handleRiskDetections(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// "ge" is inclusive, and Graph returns risk detections ordered by
-	// activityDateTime ascending when filtered this way.
+	// "ge" is inclusive (greater than or equal, as OData defines it). The
+	// mock returns matches ordered by activityDateTime ascending: the
+	// official docs make no ordering guarantee for this endpoint, but the
+	// adapter's cursor -- it advances "since" to the activityDateTime of the
+	// last item in the response -- only makes progress when responses are
+	// ascending, so the mock keeps them deterministic.
 	matched := make([]map[string]interface{}, 0, len(detections))
 	for _, d := range detections {
 		at, err := time.Parse(time.RFC3339, d["activityDateTime"].(string))
@@ -346,8 +352,12 @@ func (m *mockMicrosoft) handleRiskDetections(w http.ResponseWriter, r *http.Requ
 	}
 	if pageSize > 0 && len(matched) > pageSize {
 		matched = matched[:pageSize]
+		// Like the real API, the nextLink carries the query parameters of the
+		// original request plus a $skiptoken (see
+		// https://learn.microsoft.com/en-us/graph/paging).
 		envelope["@odata.nextLink"] = serverURL +
-			"/v1.0/identityProtection/riskDetections?$skiptoken=fake-skip-token-1111"
+			"/v1.0/identityProtection/riskDetections?" + r.URL.RawQuery +
+			"&$skiptoken=fake-skip-token-1111"
 	}
 	envelope["value"] = matched
 
@@ -411,7 +421,7 @@ func realisticRiskDetection(seq int, riskEventType, upn, activityDateTime string
 		"riskState":           "atRisk",
 		"riskLevel":           "medium",
 		"riskDetail":          "none",
-		"source":              "IdentityProtection",
+		"source":              "activeDirectory",
 		"detectionTimingType": "realtime",
 		"activity":            "signin",
 		"tokenIssuerType":     "AzureAD",
@@ -422,7 +432,9 @@ func realisticRiskDetection(seq int, riskEventType, upn, activityDateTime string
 		"userId":              "11111111-1111-1111-1111-111111111111",
 		"userDisplayName":     "Jane Doe",
 		"userPrincipalName":   upn,
-		"additionalInfo":      `[{"Key":"riskReasons","Value":["Anonymous IP address"]}]`,
+		// additionalInfo is a JSON-formatted *string*, not a nested object;
+		// this is the example value from the official riskDetection docs.
+		"additionalInfo": `[{"Key":"userAgent","Value":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36"}]`,
 		"location": map[string]interface{}{
 			"city":            "Springfield",
 			"state":           "Illinois",

--- a/hubspot/client.go
+++ b/hubspot/client.go
@@ -17,9 +17,19 @@ import (
 )
 
 const (
-	logsURL       = "https://api.hubapi.com/account-info/v3/activity/audit-logs"
-	overlapPeriod = 30 * time.Minute
+	logsURL             = "https://api.hubapi.com/account-info/v3/activity/audit-logs"
+	overlapPeriod       = 30 * time.Minute
+	defaultPollInterval = 30 * time.Second
 )
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
 
 type opRequest struct {
 	Limit     int    `json:"page[size],omitempty"`
@@ -29,8 +39,11 @@ type opRequest struct {
 
 type HubSpotAdapter struct {
 	conf       HubSpotConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
+
+	apiURL       string
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -44,6 +57,16 @@ type HubSpotAdapter struct {
 type HubSpotConfig struct {
 	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 	AccessToken   string                  `json:"access_token" yaml:"access_token"`
+
+	// URL overrides the audit-logs endpoint queried. Empty means the standard
+	// HubSpot API endpoint
+	// (https://api.hubapi.com/account-info/v3/activity/audit-logs).
+	URL string `json:"url" yaml:"url"`
+
+	// PollInterval overrides the wait between polls of the audit-logs
+	// endpoint. It is not settable through a config file; it exists as a seam
+	// for tests. Zero means the default (30 seconds).
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *HubSpotConfig) Validate() error {
@@ -57,17 +80,36 @@ func (c *HubSpotConfig) Validate() error {
 }
 
 func NewHubSpotAdapter(ctx context.Context, conf HubSpotConfig) (*HubSpotAdapter, chan struct{}, error) {
-	var err error
+	return newHubSpotAdapter(ctx, conf, nil)
+}
+
+// newHubSpotAdapter is the implementation behind NewHubSpotAdapter. When sink
+// is non-nil it is used in place of a real LimaCharlie client -- the seam tests
+// use to capture shipped events.
+func newHubSpotAdapter(ctx context.Context, conf HubSpotConfig, sink uspSink) (*HubSpotAdapter, chan struct{}, error) {
 	a := &HubSpotAdapter{
-		conf:   conf,
-		ctx:    context.Background(),
-		doStop: utils.NewEvent(),
-		dedupe: make(map[string]int64),
+		conf:         conf,
+		ctx:          context.Background(),
+		doStop:       utils.NewEvent(),
+		dedupe:       make(map[string]int64),
+		apiURL:       conf.URL,
+		pollInterval: conf.PollInterval,
+	}
+	if a.apiURL == "" {
+		a.apiURL = logsURL
+	}
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -109,10 +151,10 @@ func (a *HubSpotAdapter) Close() error {
 
 func (a *HubSpotAdapter) fetchEvents() {
 	defer a.wgSenders.Done()
-	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching of %s events exiting", logsURL))
+	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching of %s events exiting", a.apiURL))
 
 	adapterStart := time.Now()
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// The makeOneRequest function handles error
 		// handling and fatal error handling.
 		items := a.makeOneRequest(adapterStart)
@@ -155,8 +197,8 @@ func (a *HubSpotAdapter) makeOneRequest(notBefore time.Time) []utils.Dict {
 
 	for {
 		// Prepare the request.
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s?occurredAfter=%s&occurredBefore=%s", logsURL, start, until), nil)
-		a.conf.ClientOptions.DebugLog(fmt.Sprintf("requesting from %s starting at %s until %s", logsURL, start, until))
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s?occurredAfter=%s&occurredBefore=%s", a.apiURL, start, until), nil)
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf("requesting from %s starting at %s until %s", a.apiURL, start, until))
 		if err != nil {
 			a.doStop.Set()
 			return nil

--- a/hubspot/client_test.go
+++ b/hubspot/client_test.go
@@ -1,0 +1,81 @@
+package usp_hubspot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Run("requires access_token", func(t *testing.T) {
+		c := HubSpotConfig{ClientOptions: testClientOptions(t)}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		c := HubSpotConfig{
+			ClientOptions: testClientOptions(t),
+			AccessToken:   "fake-hubspot-token-1111",
+		}
+		assert.NoError(t, c.Validate())
+	})
+}
+
+// TestDefaults verifies an empty URL/PollInterval resolve to the real HubSpot
+// endpoint and the production poll interval.
+func TestDefaults(t *testing.T) {
+	sink := &captureSink{}
+	conf := HubSpotConfig{
+		ClientOptions: testClientOptions(t),
+		AccessToken:   "fake-hubspot-token-1111",
+	}
+	adapter, chStopped, err := newHubSpotAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	require.NotNil(t, chStopped)
+
+	assert.Equal(t, logsURL, adapter.apiURL)
+	assert.Equal(t, defaultPollInterval, adapter.pollInterval)
+
+	// With the default 30s poll interval the fetch goroutine is still idling;
+	// nothing was requested or shipped, and Close unblocks it promptly.
+	require.NoError(t, adapter.Close())
+	assert.Equal(t, 0, sink.count())
+}
+
+// TestURLOverride verifies the config override replaces the endpoint queried.
+func TestURLOverride(t *testing.T) {
+	sink := &captureSink{}
+	conf := HubSpotConfig{
+		ClientOptions: testClientOptions(t),
+		AccessToken:   "fake-hubspot-token-1111",
+		URL:           "https://hubspot-proxy.example.com/audit-logs",
+		PollInterval:  time.Hour, // never polls during the test
+	}
+	adapter, _, err := newHubSpotAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://hubspot-proxy.example.com/audit-logs", adapter.apiURL)
+	assert.Equal(t, time.Hour, adapter.pollInterval)
+	require.NoError(t, adapter.Close())
+}

--- a/hubspot/mock_test.go
+++ b/hubspot/mock_test.go
@@ -141,7 +141,7 @@ func (m *mockHubSpot) handler() http.HandlerFunc {
 
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)
-			_, _ = w.Write([]byte(`{"status":"error","message":"Method not allowed","category":"VALIDATION_ERROR"}`))
+			_, _ = w.Write([]byte(`{"status":"error","message":"Method not allowed","category":"VALIDATION_ERROR","correlationId":"22222222-2222-2222-2222-222222222222"}`))
 			return
 		}
 		// HubSpot private-app auth: Authorization: Bearer <token>.
@@ -169,13 +169,13 @@ func (m *mockHubSpot) handler() http.HandlerFunc {
 		after, err := time.Parse(time.RFC3339, afterRaw)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"status":"error","message":"Invalid occurredAfter","category":"VALIDATION_ERROR"}`))
+			_, _ = w.Write([]byte(`{"status":"error","message":"Invalid occurredAfter","category":"VALIDATION_ERROR","correlationId":"33333333-3333-3333-3333-333333333333"}`))
 			return
 		}
 		before, err := time.Parse(time.RFC3339, beforeRaw)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"status":"error","message":"Invalid occurredBefore","category":"VALIDATION_ERROR"}`))
+			_, _ = w.Write([]byte(`{"status":"error","message":"Invalid occurredBefore","category":"VALIDATION_ERROR","correlationId":"44444444-4444-4444-4444-444444444444"}`))
 			return
 		}
 
@@ -243,12 +243,13 @@ func realisticAuditLog(id string, occurredAt time.Time) utils.Dict {
 	}
 }
 
-// realisticSecuritySettingsLog returns an audit-log entry of a different
-// category, to keep the dataset heterogeneous.
-func realisticSecuritySettingsLog(id string, occurredAt time.Time) utils.Dict {
+// realisticSecurityActivityLog returns an audit-log entry of a different
+// category ("Security Activity" in HubSpot's documented category list), to
+// keep the dataset heterogeneous.
+func realisticSecurityActivityLog(id string, occurredAt time.Time) utils.Dict {
 	return utils.Dict{
 		"id":             id,
-		"category":       "SECURITY_SETTINGS",
+		"category":       "SECURITY_ACTIVITY",
 		"subCategory":    "TWO_FACTOR_AUTHENTICATION",
 		"action":         "UPDATE",
 		"targetObjectId": "240375137",
@@ -301,7 +302,7 @@ func TestMockAuditLogsEndToEnd(t *testing.T) {
 	want := []utils.Dict{
 		realisticAuditLog("8392545957", now.Add(900*time.Millisecond)),
 		realisticAuditLog("8392545958", now.Add(950*time.Millisecond)),
-		realisticSecuritySettingsLog("8392545959", now.Add(1*time.Second)),
+		realisticSecurityActivityLog("8392545959", now.Add(1*time.Second)),
 	}
 	mock.setEvents(want)
 
@@ -382,7 +383,7 @@ func TestMockNewEventMidRunShipsOnce(t *testing.T) {
 		8*time.Second, 20*time.Millisecond)
 
 	// A new account activity occurs mid-run.
-	mock.addEvent(realisticSecuritySettingsLog("1000000003", time.Now().Add(700*time.Millisecond)))
+	mock.addEvent(realisticSecurityActivityLog("1000000003", time.Now().Add(700*time.Millisecond)))
 
 	require.Eventually(t, func() bool { return sink.count() == 3 },
 		8*time.Second, 20*time.Millisecond, "the new entry should ship")

--- a/hubspot/mock_test.go
+++ b/hubspot/mock_test.go
@@ -1,0 +1,484 @@
+package usp_hubspot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock HubSpot Account
+// Activity API (GET /account-info/v3/activity/audit-logs), capturing the exact
+// messages it ships so their content -- timestamp and verbatim payload -- can
+// be asserted.
+//
+// The mock reproduces the API as the adapter uses it: it authenticates the
+// Bearer token, filters the in-memory audit-log set by the
+// occurredAfter/occurredBefore window, and paginates with the documented
+// {"results": [...], "paging": {"next": {"after", "link"}}} envelope. One
+// deliberate deviation from the real service: the adapter feeds paging.next.
+// after back through the occurredAfter query parameter (not the documented
+// `after` parameter), so the mock accepts a cursor token there too.
+
+// testToken is a clearly fake HubSpot private-app access token.
+const testToken = "fake-hubspot-token-1111"
+
+// occurredAtLayout is the millisecond-precision UTC timestamp format HubSpot
+// uses for occurredAt (e.g. "2023-07-18T15:59:26.920Z").
+const occurredAtLayout = "2006-01-02T15:04:05.000Z"
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock HubSpot Account Activity API ----------------------------------------
+
+// mockHubSpot is an in-memory stand-in for the HubSpot account audit-logs
+// endpoint.
+type mockHubSpot struct {
+	mu       sync.Mutex
+	token    string
+	events   []utils.Dict // audit-log entries, each with an RFC3339 occurredAt
+	pageSize int          // 0 means "no pagination" (everything in one page)
+
+	cursorSeq int
+	cursors   map[string][]utils.Dict // outstanding paging.next.after token -> remaining records
+
+	requests     int
+	cursorHits   int // requests that presented a paging cursor
+	authFailures int
+	lastAfter    string // occurredAfter of the last non-cursor request
+	lastBefore   string // occurredBefore of the last non-cursor request
+	lastContent  string // Content-Type header of the last request
+}
+
+func newMockHubSpot(token string) *mockHubSpot {
+	return &mockHubSpot{token: token, cursors: map[string][]utils.Dict{}}
+}
+
+func (m *mockHubSpot) setEvents(events []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = events
+}
+
+// addEvent appends a new audit-log entry, as the real API would surface a new
+// account activity.
+func (m *mockHubSpot) addEvent(e utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, e)
+}
+
+func (m *mockHubSpot) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+func (m *mockHubSpot) cursorHitCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cursorHits
+}
+
+func (m *mockHubSpot) authFailureCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.authFailures
+}
+
+func (m *mockHubSpot) lastWindow() (string, string, string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastAfter, m.lastBefore, m.lastContent
+}
+
+func (m *mockHubSpot) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		m.requests++
+		m.lastContent = r.Header.Get("Content-Type")
+
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = w.Write([]byte(`{"status":"error","message":"Method not allowed","category":"VALIDATION_ERROR"}`))
+			return
+		}
+		// HubSpot private-app auth: Authorization: Bearer <token>.
+		if r.Header.Get("Authorization") != "Bearer "+m.token {
+			m.authFailures++
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"status":"error","message":"Authentication credentials not found.","category":"INVALID_AUTHENTICATION","correlationId":"11111111-1111-1111-1111-111111111111"}`))
+			return
+		}
+
+		q := r.URL.Query()
+		afterRaw := q.Get("occurredAfter")
+		beforeRaw := q.Get("occurredBefore")
+
+		// Continuation: the adapter echoes paging.next.after back through the
+		// occurredAfter parameter, so a cursor token shows up here.
+		if remaining, ok := m.cursors[afterRaw]; ok {
+			m.cursorHits++
+			delete(m.cursors, afterRaw)
+			m.writePage(w, r, remaining)
+			return
+		}
+
+		m.lastAfter, m.lastBefore = afterRaw, beforeRaw
+		after, err := time.Parse(time.RFC3339, afterRaw)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"status":"error","message":"Invalid occurredAfter","category":"VALIDATION_ERROR"}`))
+			return
+		}
+		before, err := time.Parse(time.RFC3339, beforeRaw)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"status":"error","message":"Invalid occurredBefore","category":"VALIDATION_ERROR"}`))
+			return
+		}
+
+		// Select the audit-log entries inside the requested window.
+		var window []utils.Dict
+		for _, e := range m.events {
+			occurredAt, _ := e["occurredAt"].(string)
+			ts, terr := time.Parse(time.RFC3339, occurredAt)
+			if terr != nil {
+				continue
+			}
+			if ts.After(after) && !ts.After(before) {
+				window = append(window, e)
+			}
+		}
+		m.writePage(w, r, window)
+	}
+}
+
+// writePage emits one page of `set` using the documented envelope. Must be
+// called with m.mu held.
+func (m *mockHubSpot) writePage(w http.ResponseWriter, r *http.Request, set []utils.Dict) {
+	resp := map[string]interface{}{}
+	page := set
+	if m.pageSize > 0 && len(set) > m.pageSize {
+		page = set[:m.pageSize]
+		m.cursorSeq++
+		// An opaque cursor, like the real API's base64-ish tokens.
+		token := fmt.Sprintf("VFZSWk5FOVVX%d", m.cursorSeq)
+		m.cursors[token] = set[m.pageSize:]
+		resp["paging"] = map[string]interface{}{
+			"next": map[string]interface{}{
+				"after": token,
+				"link":  fmt.Sprintf("http://%s%s?after=%s", r.Host, r.URL.Path, token),
+			},
+		}
+	}
+	if page == nil {
+		page = []utils.Dict{}
+	}
+	resp["results"] = page
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// --- realistic record fixtures ------------------------------------------------
+
+// realisticAuditLog returns a record shaped like a real HubSpot account
+// audit-log entry (developers.hubspot.com Account Activity API): id, category/
+// subCategory/action, targetObjectId, millisecond-precision occurredAt, and the
+// nested actingUser object.
+func realisticAuditLog(id string, occurredAt time.Time) utils.Dict {
+	return utils.Dict{
+		"id":             id,
+		"category":       "LOGIN",
+		"subCategory":    "LOGIN_SUCCEEDED",
+		"action":         "PERFORM",
+		"targetObjectId": "240375137",
+		"occurredAt":     occurredAt.UTC().Format(occurredAtLayout),
+		"actingUser": utils.Dict{
+			"userId":    int64(1234567),
+			"userEmail": "jane.doe@example.com",
+		},
+	}
+}
+
+// realisticSecuritySettingsLog returns an audit-log entry of a different
+// category, to keep the dataset heterogeneous.
+func realisticSecuritySettingsLog(id string, occurredAt time.Time) utils.Dict {
+	return utils.Dict{
+		"id":             id,
+		"category":       "SECURITY_SETTINGS",
+		"subCategory":    "TWO_FACTOR_AUTHENTICATION",
+		"action":         "UPDATE",
+		"targetObjectId": "240375137",
+		"occurredAt":     occurredAt.UTC().Format(occurredAtLayout),
+		"actingUser": utils.Dict{
+			"userId":    int64(7654321),
+			"userEmail": "admin@example.com",
+		},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// startMockAdapter wires an adapter to the mock server with a fast poll
+// interval and an injected capture sink.
+func startMockAdapter(t *testing.T, serverURL string, token string, sink uspSink) (*HubSpotAdapter, chan struct{}) {
+	t.Helper()
+	conf := HubSpotConfig{
+		ClientOptions: testClientOptions(t),
+		AccessToken:   token,
+		URL:           serverURL,
+		PollInterval:  25 * time.Millisecond,
+	}
+	adapter, chStopped, err := newHubSpotAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	return adapter, chStopped
+}
+
+// --- tests ----------------------------------------------------------------------
+
+// Note on fixture timestamps: on its first ~30 minutes of life the adapter
+// queries occurredAfter = its own start time, so only events that occur after
+// the adapter starts are in scope. Fixtures are therefore stamped slightly in
+// the future (~1s); they enter the rolling occurredBefore=now window within a
+// second or two of wall-clock time, which the fast poll interval picks up.
+
+// TestMockAuditLogsEndToEnd drives the adapter against the mock API and asserts
+// the exact events shipped: payload preserved verbatim (nested actingUser
+// included), ingestion-time TimestampMs, no EventType tagging, the
+// occurredAfter/occurredBefore request contract, and that re-polling the same
+// window does not re-ship.
+func TestMockAuditLogsEndToEnd(t *testing.T) {
+	mock := newMockHubSpot(testToken)
+	now := time.Now()
+	want := []utils.Dict{
+		realisticAuditLog("8392545957", now.Add(900*time.Millisecond)),
+		realisticAuditLog("8392545958", now.Add(950*time.Millisecond)),
+		realisticSecuritySettingsLog("8392545959", now.Add(1*time.Second)),
+	}
+	mock.setEvents(want)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	testStartMs := uint64(time.Now().UnixMilli())
+	adapter, _ := startMockAdapter(t, server.URL, testToken, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		8*time.Second, 20*time.Millisecond, "expected all 3 audit-log entries to ship")
+
+	// Re-polling the same window must not re-ship: the count stays at 3.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "records were re-shipped on a later poll")
+
+	doneMs := uint64(time.Now().UnixMilli())
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		// The adapter does not tag an EventType (platform-level parsing applies).
+		assert.Empty(t, msg.EventType)
+		// The adapter stamps ingestion time, not the record's occurredAt.
+		assert.GreaterOrEqual(t, msg.TimestampMs, testStartMs)
+		assert.LessOrEqual(t, msg.TimestampMs, doneMs)
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	// The payload is shipped verbatim -- nested actingUser object included.
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "record %s was not shipped", id)
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original HubSpot record")
+	}
+
+	// Request contract: a JSON GET carrying an RFC3339 occurredAfter (around the
+	// adapter's start) and occurredBefore (around now).
+	afterRaw, beforeRaw, contentType := mock.lastWindow()
+	assert.Equal(t, "application/json", contentType)
+	after, err := time.Parse(time.RFC3339, afterRaw)
+	require.NoError(t, err, "occurredAfter must be RFC3339")
+	before, err := time.Parse(time.RFC3339, beforeRaw)
+	require.NoError(t, err, "occurredBefore must be RFC3339")
+	assert.False(t, before.Before(after), "occurredBefore must not precede occurredAfter")
+	assert.WithinDuration(t, now, after, 5*time.Second,
+		"on a fresh adapter, occurredAfter should be the adapter's start time")
+	assert.WithinDuration(t, time.Now(), before, 5*time.Second,
+		"occurredBefore should be the poll time")
+}
+
+// TestMockNewEventMidRunShipsOnce verifies an audit-log entry appearing while
+// the adapter is running is shipped exactly once, and already-shipped entries
+// are never re-sent.
+func TestMockNewEventMidRunShipsOnce(t *testing.T) {
+	mock := newMockHubSpot(testToken)
+	now := time.Now()
+	mock.setEvents([]utils.Dict{
+		realisticAuditLog("1000000001", now.Add(800*time.Millisecond)),
+		realisticAuditLog("1000000002", now.Add(850*time.Millisecond)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, testToken, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		8*time.Second, 20*time.Millisecond)
+
+	// A new account activity occurs mid-run.
+	mock.addEvent(realisticSecuritySettingsLog("1000000003", time.Now().Add(700*time.Millisecond)))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		8*time.Second, 20*time.Millisecond, "the new entry should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{"1000000001": 1, "1000000002": 1, "1000000003": 1},
+		shippedPerID, "every entry must ship exactly once")
+}
+
+// TestMockPaginationFullDataset verifies a window larger than one page is
+// walked completely by following paging.next cursors, and every record ships
+// exactly once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const total = 25
+
+	mock := newMockHubSpot(testToken)
+	mock.pageSize = 10 // 25 records => pages of 10, 10, 5
+	now := time.Now()
+	events := make([]utils.Dict, total)
+	for i := 0; i < total; i++ {
+		events[i] = realisticAuditLog(
+			fmt.Sprintf("90000000%02d", i),
+			now.Add(1*time.Second+time.Duration(i)*time.Millisecond))
+	}
+	mock.setEvents(events)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, testToken, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		8*time.Second, 20*time.Millisecond, "all paginated records should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["id"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct record should be shipped once")
+
+	assert.GreaterOrEqual(t, mock.cursorHitCount(), 2,
+		"the adapter must have followed paging.next cursors to fetch pages 2 and 3")
+}
+
+// TestMockRejectsBadTokenShipsNothing verifies a rejected token ships nothing.
+// The adapter's behavior on a 401 is to report the error and keep polling (it
+// does not stop), so the test also pins that: repeated requests, no shutdown.
+func TestMockRejectsBadTokenShipsNothing(t *testing.T) {
+	mock := newMockHubSpot(testToken)
+	mock.setEvents([]utils.Dict{
+		realisticAuditLog("4040404040", time.Now().Add(500*time.Millisecond)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	var apiErrors atomic.Int32
+	opts := testClientOptions(t)
+	prevOnError := opts.OnError
+	opts.OnError = func(err error) {
+		apiErrors.Add(1)
+		prevOnError(err)
+	}
+
+	sink := &captureSink{}
+	conf := HubSpotConfig{
+		ClientOptions: opts,
+		AccessToken:   "fake-hubspot-token-0000", // wrong token
+		URL:           server.URL,
+		PollInterval:  25 * time.Millisecond,
+	}
+	adapter, chStopped, err := newHubSpotAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The adapter keeps polling (and keeps being rejected) rather than stopping.
+	require.Eventually(t, func() bool { return mock.authFailureCount() >= 2 },
+		5*time.Second, 20*time.Millisecond, "the adapter should keep retrying on 401")
+	require.Eventually(t, func() bool { return apiErrors.Load() >= 1 },
+		5*time.Second, 20*time.Millisecond, "the 401 must be surfaced via OnError")
+
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter stopped on a 401; its documented behavior is to keep polling")
+	default:
+	}
+
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	assert.GreaterOrEqual(t, mock.requestCount(), 2)
+}

--- a/itglue/client.go
+++ b/itglue/client.go
@@ -19,6 +19,8 @@ import (
 const (
 	logsURL = "/logs"
 	URL     = "https://api.itglue.com"
+
+	defaultPollInterval = 30 * time.Second
 )
 
 type opRequest struct {
@@ -27,10 +29,22 @@ type opRequest struct {
 	Sort      string `json:"sort,omitempty"`
 }
 
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type ITGlueAdapter struct {
 	conf       ITGlueConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
+
+	baseURL      string
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -42,6 +56,15 @@ type ITGlueAdapter struct {
 type ITGlueConfig struct {
 	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 	Token         string                  `json:"token" yaml:"token"`
+
+	// BaseURL overrides the IT Glue API root. Empty means the public API:
+	// https://api.itglue.com
+	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// PollInterval overrides the wait between polls of the logs endpoint
+	// (default 30s). It is not settable through a config file; it exists as a
+	// seam for tests.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *ITGlueConfig) Validate() error {
@@ -55,16 +78,36 @@ func (c *ITGlueConfig) Validate() error {
 }
 
 func NewITGlueAdapter(ctx context.Context, conf ITGlueConfig) (*ITGlueAdapter, chan struct{}, error) {
-	var err error
+	return newITGlueAdapter(ctx, conf, nil)
+}
+
+// newITGlueAdapter is the implementation behind NewITGlueAdapter. When sink is
+// non-nil it is used in place of a real LimaCharlie client -- the seam tests
+// use to capture shipped events.
+func newITGlueAdapter(ctx context.Context, conf ITGlueConfig, sink uspSink) (*ITGlueAdapter, chan struct{}, error) {
 	a := &ITGlueAdapter{
 		conf:   conf,
 		ctx:    context.Background(),
 		doStop: utils.NewEvent(),
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	a.baseURL = conf.BaseURL
+	if a.baseURL == "" {
+		a.baseURL = URL
+	}
+	a.pollInterval = conf.PollInterval
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -109,7 +152,7 @@ func (a *ITGlueAdapter) fetchEvents(url string) {
 	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching of %s events exiting", url))
 
 	lastCursor := ""
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// The makeOneRequest function handles error
 		// handling and fatal error handling.
 		items, newCursor := a.makeOneRequest(url, lastCursor)
@@ -156,7 +199,7 @@ func (a *ITGlueAdapter) makeOneRequest(url string, lastCursor string) ([]utils.D
 	formattedTime := thirtySecondsAgo.Format(timeFormat)
 
 	// Prepare the request.
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s%s?filter[created_at]=%s&sort=created_at&page[size]=1000", URL, url, formattedTime), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s%s?filter[created_at]=%s&sort=created_at&page[size]=1000", a.baseURL, url, formattedTime), nil)
 	//debugTimestamp := formattedTime
 	if lastCursor != "" {
 		req, err = http.NewRequest("GET", fmt.Sprintf("%s", lastCursor), nil)

--- a/itglue/client_test.go
+++ b/itglue/client_test.go
@@ -1,0 +1,79 @@
+package usp_itglue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("requires token", func(t *testing.T) {
+		c := ITGlueConfig{ClientOptions: testClientOptions(t)}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires valid client options", func(t *testing.T) {
+		c := ITGlueConfig{Token: "itg.fake-api-key-1111"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("valid config passes", func(t *testing.T) {
+		c := ITGlueConfig{ClientOptions: testClientOptions(t), Token: "itg.fake-api-key-1111"}
+		assert.NoError(t, c.Validate())
+	})
+}
+
+// TestConstructorDefaults verifies the adapter falls back to the public IT Glue
+// API root and the production 30s poll interval when neither is overridden, and
+// honours overrides when they are set.
+func TestConstructorDefaults(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		sink := &captureSink{}
+		conf := ITGlueConfig{ClientOptions: testClientOptions(t), Token: "itg.fake-api-key-1111"}
+		adapter, _, err := newITGlueAdapter(context.Background(), conf, sink)
+		require.NoError(t, err)
+		defer adapter.Close()
+
+		assert.Equal(t, URL, adapter.baseURL)
+		assert.Equal(t, defaultPollInterval, adapter.pollInterval)
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		sink := &captureSink{}
+		conf := ITGlueConfig{
+			ClientOptions: testClientOptions(t),
+			Token:         "itg.fake-api-key-1111",
+			BaseURL:       "https://itglue.example.com",
+			// A long interval so the poller never fires a request at the fake
+			// host during the test; only the stored value is asserted.
+			PollInterval: time.Hour,
+		}
+		adapter, _, err := newITGlueAdapter(context.Background(), conf, sink)
+		require.NoError(t, err)
+		defer adapter.Close()
+
+		assert.Equal(t, "https://itglue.example.com", adapter.baseURL)
+		assert.Equal(t, time.Hour, adapter.pollInterval)
+	})
+}

--- a/itglue/mock_test.go
+++ b/itglue/mock_test.go
@@ -1,0 +1,637 @@
+package usp_itglue
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock IT Glue API,
+// capturing the exact messages it ships so their content can be asserted.
+//
+// The mock reproduces the IT Glue logs API as the adapter uses it: a GET on
+// /logs authenticated with the x-api-key header, taking filter[created_at]
+// (treated as "created at or after this RFC3339 time", the semantics the
+// adapter's 30s-lookback watermark relies on), sort=created_at and
+// page[size]/page[number] query parameters, and returning the JSON:API
+// envelope: {"data": [...], "links": {...}, "meta": {...}} with pagination
+// URLs nested under "links" per the JSON API spec.
+
+// itglueTimeLayout matches the timestamp format the adapter sends in
+// filter[created_at] and that IT Glue uses in created-at attributes.
+const itglueTimeLayout = "2006-01-02T15:04:05.000000Z07:00"
+
+// --- in-memory USP sink -------------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// idsShipped returns the distinct log ids shipped so far.
+func (s *captureSink) idsShipped() map[string]int {
+	ids := map[string]int{}
+	for _, m := range s.snapshot() {
+		if id, ok := m.JsonPayload["id"].(string); ok {
+			ids[id]++
+		}
+	}
+	return ids
+}
+
+// --- mock IT Glue API ---------------------------------------------------------
+
+// recordedRequest captures the request properties the tests assert on.
+type recordedRequest struct {
+	method      string
+	path        string
+	apiKey      string
+	contentType string
+	sortParam   string
+	pageSize    string
+	pageNumber  int
+	filter      string
+	receivedAt  time.Time
+}
+
+// mockITGlue is an in-memory stand-in for the IT Glue logs API.
+type mockITGlue struct {
+	mu     sync.Mutex
+	apiKey string
+	logs   []utils.Dict // JSON:API "logs" resources, each with attributes/created-at
+
+	// serverPageSize, when > 0, caps the effective page size below what the
+	// client requested -- the lever used to make the dataset span multiple
+	// pages without 1000+ fixtures.
+	serverPageSize int
+
+	requests []recordedRequest
+	pageHits map[int]int // page[number] -> request count
+}
+
+func newMockITGlue(apiKey string) *mockITGlue {
+	return &mockITGlue{apiKey: apiKey, pageHits: map[int]int{}}
+}
+
+func (m *mockITGlue) setLogs(logs []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = logs
+}
+
+func (m *mockITGlue) addLog(record utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, record)
+}
+
+func (m *mockITGlue) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.requests)
+}
+
+func (m *mockITGlue) lastRequest() recordedRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.requests) == 0 {
+		return recordedRequest{}
+	}
+	return m.requests[len(m.requests)-1]
+}
+
+func (m *mockITGlue) hitsForPage(n int) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pageHits[n]
+}
+
+func createdAtOf(record utils.Dict) time.Time {
+	attrs, _ := record.GetDict("attributes")
+	s, _ := attrs.GetString("created-at")
+	ts, _ := time.Parse(time.RFC3339Nano, s)
+	return ts
+}
+
+func (m *mockITGlue) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		pageNumber := 1
+		if v, err := strconv.Atoi(q.Get("page[number]")); err == nil && v >= 1 {
+			pageNumber = v
+		}
+		rec := recordedRequest{
+			method:      r.Method,
+			path:        r.URL.Path,
+			apiKey:      r.Header.Get("x-api-key"),
+			contentType: r.Header.Get("Content-Type"),
+			sortParam:   q.Get("sort"),
+			pageSize:    q.Get("page[size]"),
+			pageNumber:  pageNumber,
+			filter:      q.Get("filter[created_at]"),
+			receivedAt:  time.Now(),
+		}
+
+		m.mu.Lock()
+		m.requests = append(m.requests, rec)
+		m.pageHits[pageNumber]++
+		logs := make([]utils.Dict, len(m.logs))
+		copy(logs, m.logs)
+		serverPageSize := m.serverPageSize
+		m.mu.Unlock()
+
+		if r.Method != http.MethodGet || r.URL.Path != logsURL {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"404","title":"Not Found"}]}`))
+			return
+		}
+		// IT Glue authenticates with the key in the x-api-key header.
+		if rec.apiKey != m.apiKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"401","title":"Unauthorized","detail":"invalid or missing api key"}]}`))
+			return
+		}
+
+		// filter[created_at]: keep logs created at or after the watermark.
+		var since time.Time
+		if rec.filter != "" {
+			ts, err := time.Parse(time.RFC3339Nano, rec.filter)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"errors":[{"status":"400","title":"Bad Request","detail":"invalid filter[created_at]"}]}`))
+				return
+			}
+			since = ts
+		}
+		matched := make([]utils.Dict, 0, len(logs))
+		for _, record := range logs {
+			if !createdAtOf(record).Before(since) {
+				matched = append(matched, record)
+			}
+		}
+		// sort=created_at: ascending by creation time.
+		sort.Slice(matched, func(i, j int) bool {
+			return createdAtOf(matched[i]).Before(createdAtOf(matched[j]))
+		})
+
+		// Paginate. The effective page size is the client's page[size] capped
+		// by the server (the real API caps at 1000).
+		pageSize := 1000
+		if v, err := strconv.Atoi(rec.pageSize); err == nil && v >= 1 && v < pageSize {
+			pageSize = v
+		}
+		if serverPageSize > 0 && serverPageSize < pageSize {
+			pageSize = serverPageSize
+		}
+		totalPages := (len(matched) + pageSize - 1) / pageSize
+		if totalPages == 0 {
+			totalPages = 1
+		}
+		page := []utils.Dict{}
+		if start := (pageNumber - 1) * pageSize; start < len(matched) {
+			end := start + pageSize
+			if end > len(matched) {
+				end = len(matched)
+			}
+			page = matched[start:end]
+		}
+
+		// JSON:API envelope: pagination URLs live under top-level "links", and
+		// page counters under "meta" -- not at the top level.
+		pageURL := func(n int) string {
+			v := url.Values{}
+			v.Set("filter[created_at]", rec.filter)
+			v.Set("sort", "created_at")
+			v.Set("page[number]", strconv.Itoa(n))
+			v.Set("page[size]", strconv.Itoa(pageSize))
+			return "http://" + r.Host + logsURL + "?" + v.Encode()
+		}
+		links := map[string]interface{}{"self": pageURL(pageNumber)}
+		meta := map[string]interface{}{
+			"current-page": pageNumber,
+			"prev-page":    nil,
+			"next-page":    nil,
+			"total-pages":  totalPages,
+			"total-count":  len(matched),
+			"filters":      map[string]interface{}{"created_at": rec.filter},
+		}
+		if pageNumber > 1 {
+			links["prev"] = pageURL(pageNumber - 1)
+			meta["prev-page"] = pageNumber - 1
+		}
+		if pageNumber < totalPages {
+			links["next"] = pageURL(pageNumber + 1)
+			links["last"] = pageURL(totalPages)
+			meta["next-page"] = pageNumber + 1
+		}
+
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":  page,
+			"links": links,
+			"meta":  meta,
+		})
+	}
+}
+
+// --- realistic fixtures -------------------------------------------------------
+
+// realisticLogRecord returns a JSON:API resource shaped like an IT Glue
+// activity log: a string id, type "logs", and kebab-case attributes mirroring
+// what the activity log surfaces (who did what to which resource, when, from
+// where). All identifying values are clearly fake (RFC 5737 test addresses,
+// example.com-style names).
+func realisticLogRecord(id string, createdAt time.Time) utils.Dict {
+	return utils.Dict{
+		"id":   id,
+		"type": "logs",
+		"attributes": utils.Dict{
+			"created-at":        createdAt.UTC().Format(itglueTimeLayout),
+			"action":            "viewed",
+			"resource-id":       1111111,
+			"resource-type":     "Password",
+			"resource-name":     "Example Firewall Admin",
+			"organization-id":   2222222,
+			"organization-name": "Example Org Inc.",
+			"member-id":         3333333,
+			"member-name":       "Jane Doe",
+			"ip-address":        "203.0.113.10",
+		},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// startAdapter spins up the adapter against the mock server with a fast poll
+// interval and returns the sink it ships into.
+func startAdapter(t *testing.T, serverURL, token string) (*ITGlueAdapter, chan struct{}, *captureSink) {
+	t.Helper()
+	sink := &captureSink{}
+	conf := ITGlueConfig{
+		ClientOptions: testClientOptions(t),
+		Token:         token,
+		BaseURL:       serverURL,
+		PollInterval:  40 * time.Millisecond,
+	}
+	adapter, chStopped, err := newITGlueAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	return adapter, chStopped, sink
+}
+
+// --- tests --------------------------------------------------------------------
+
+// TestMockLogsEndToEnd drives the adapter against the mock API and asserts the
+// exact events shipped: the payload is the verbatim JSON:API log resource, the
+// timestamp is the ingestion time (the adapter stamps time.Now, it does not
+// parse created-at), no EventType is set, and the request the adapter makes
+// carries the documented auth header, content type, sort, page size and a
+// created_at watermark 30 seconds in the past.
+func TestMockLogsEndToEnd(t *testing.T) {
+	const token = "itg.fake-api-key-1111"
+
+	now := time.Now()
+	want := []utils.Dict{
+		realisticLogRecord("9000001", now.Add(-5*time.Second)),
+		realisticLogRecord("9000002", now.Add(-3*time.Second)),
+		realisticLogRecord("9000003", now.Add(-1*time.Second)),
+	}
+	mock := newMockITGlue(token)
+	mock.setLogs(want)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	testStart := time.Now()
+	adapter, _, sink := startAdapter(t, server.URL, token)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() >= 3 },
+		5*time.Second, 10*time.Millisecond, "expected all 3 logs to ship")
+
+	// The first three messages are the first poll's page, in created_at order.
+	first := sink.snapshot()[:3]
+	for i, msg := range first {
+		assert.Empty(t, msg.EventType, "the adapter does not tag an event type")
+		require.NotNil(t, msg.JsonPayload)
+
+		// Payload is shipped verbatim: the whole JSON:API resource, id, type
+		// and nested attributes included.
+		assert.JSONEq(t, mustJSON(t, want[i]), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original IT Glue log resource")
+
+		// The adapter stamps ingestion time, not the log's created-at.
+		assert.GreaterOrEqual(t, msg.TimestampMs, uint64(testStart.UnixMilli()))
+		assert.LessOrEqual(t, msg.TimestampMs, uint64(time.Now().UnixMilli()))
+	}
+
+	// The request the adapter built matches the IT Glue logs API contract.
+	req := mock.lastRequest()
+	assert.Equal(t, http.MethodGet, req.method)
+	assert.Equal(t, "/logs", req.path)
+	assert.Equal(t, token, req.apiKey)
+	assert.Equal(t, "application/vnd.api+json", req.contentType)
+	assert.Equal(t, "created_at", req.sortParam)
+	assert.Equal(t, "1000", req.pageSize)
+	filterTime, err := time.Parse(time.RFC3339Nano, req.filter)
+	require.NoError(t, err, "filter[created_at] must be a valid RFC3339 time")
+	lookback := req.receivedAt.Sub(filterTime)
+	assert.Greater(t, lookback, 29*time.Second, "watermark should be ~30s in the past")
+	assert.Less(t, lookback, 35*time.Second, "watermark should be ~30s in the past")
+}
+
+// TestMockRepollReshipsEventsStillInWindow pins the adapter's actual re-poll
+// behavior: it has no deduplication, and every poll re-requests everything
+// created in the last 30 seconds. A log still inside that lookback window is
+// therefore shipped again on each poll. (In production the poll interval
+// equals the lookback, so a log ships once or twice; here the fast test poll
+// makes the duplication obvious.)
+func TestMockRepollReshipsEventsStillInWindow(t *testing.T) {
+	const token = "itg.fake-api-key-1111"
+
+	now := time.Now()
+	mock := newMockITGlue(token)
+	mock.setLogs([]utils.Dict{
+		realisticLogRecord("9000001", now.Add(-2*time.Second)),
+		realisticLogRecord("9000002", now.Add(-1*time.Second)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	adapter, _, sink := startAdapter(t, server.URL, token)
+	defer adapter.Close()
+
+	// At least three polls' worth of shipments: both logs re-ship every poll.
+	require.Eventually(t, func() bool { return sink.count() >= 6 },
+		5*time.Second, 10*time.Millisecond,
+		"in-window logs are re-shipped on every poll (the adapter does not dedupe)")
+
+	ids := sink.idsShipped()
+	assert.GreaterOrEqual(t, ids["9000001"], 2, "log 9000001 re-ships while in the lookback window")
+	assert.GreaterOrEqual(t, ids["9000002"], 2, "log 9000002 re-ships while in the lookback window")
+	assert.Len(t, ids, 2, "no other ids ship")
+}
+
+// TestMockOldEventsNeverShip verifies the created_at watermark works end to
+// end: logs older than the 30s lookback are filtered out by the API and never
+// ship, poll after poll.
+func TestMockOldEventsNeverShip(t *testing.T) {
+	const token = "itg.fake-api-key-1111"
+
+	mock := newMockITGlue(token)
+	mock.setLogs([]utils.Dict{
+		realisticLogRecord("9000001", time.Now().Add(-5*time.Minute)),
+		realisticLogRecord("9000002", time.Now().Add(-10*time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	adapter, _, sink := startAdapter(t, server.URL, token)
+	defer adapter.Close()
+
+	// Let several polls complete before concluding nothing shipped.
+	require.Eventually(t, func() bool { return mock.requestCount() >= 3 },
+		5*time.Second, 10*time.Millisecond, "the adapter should keep polling")
+	assert.Equal(t, 0, sink.count(), "logs older than the lookback window must not ship")
+}
+
+// TestMockMidRunEventShips verifies a log that appears while the adapter is
+// running is picked up by a subsequent poll and shipped. (It ships at least
+// once; this adapter re-ships while a log remains inside the 30s lookback, as
+// pinned by TestMockRepollReshipsEventsStillInWindow.)
+func TestMockMidRunEventShips(t *testing.T) {
+	const token = "itg.fake-api-key-1111"
+
+	mock := newMockITGlue(token)
+	mock.setLogs([]utils.Dict{
+		realisticLogRecord("9000001", time.Now().Add(-1*time.Second)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	adapter, _, sink := startAdapter(t, server.URL, token)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.idsShipped()["9000001"] >= 1 },
+		5*time.Second, 10*time.Millisecond, "the initial log should ship")
+
+	// A new activity log is written mid-run.
+	mock.addLog(realisticLogRecord("9000099", time.Now()))
+
+	require.Eventually(t, func() bool { return sink.idsShipped()["9000099"] >= 1 },
+		5*time.Second, 10*time.Millisecond, "the mid-run log should ship on a later poll")
+}
+
+// TestMockPaginationOnlyFirstPageConsumed pins the adapter's actual pagination
+// behavior against the real IT Glue envelope -- a known limitation. IT Glue,
+// per the JSON API spec, returns the next-page URL nested under top-level
+// "links" ({"links": {"next": ...}}), but the adapter looks the cursor up with
+// FindOneString("next"), which only matches a *top-level* "next" key. The
+// cursor is therefore never found: only page[number]=1 is ever requested, and
+// records beyond the first page are never shipped. If the adapter is ever
+// fixed to read "links/next", this test must be updated to assert full
+// multi-page consumption.
+func TestMockPaginationOnlyFirstPageConsumed(t *testing.T) {
+	const token = "itg.fake-api-key-1111"
+
+	now := time.Now()
+	mock := newMockITGlue(token)
+	mock.serverPageSize = 2 // 5 in-window logs => 3 pages
+	mock.setLogs([]utils.Dict{
+		realisticLogRecord("9000001", now.Add(-5*time.Second)),
+		realisticLogRecord("9000002", now.Add(-4*time.Second)),
+		realisticLogRecord("9000003", now.Add(-3*time.Second)),
+		realisticLogRecord("9000004", now.Add(-2*time.Second)),
+		realisticLogRecord("9000005", now.Add(-1*time.Second)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	adapter, _, sink := startAdapter(t, server.URL, token)
+	defer adapter.Close()
+
+	// Wait for several polls so the adapter had every opportunity to follow
+	// the links.next URL it was given.
+	require.Eventually(t, func() bool { return mock.hitsForPage(1) >= 3 },
+		5*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, 0, mock.hitsForPage(2),
+		"the JSON:API links.next cursor is never followed (FindOneString(\"next\") only matches a top-level key)")
+
+	ids := sink.idsShipped()
+	assert.NotContains(t, ids, "9000003", "second-page records never ship")
+	assert.NotContains(t, ids, "9000004", "second-page records never ship")
+	assert.NotContains(t, ids, "9000005", "third-page records never ship")
+	assert.GreaterOrEqual(t, ids["9000001"], 1, "first-page records ship")
+	assert.GreaterOrEqual(t, ids["9000002"], 1, "first-page records ship")
+}
+
+// TestMockBadAPIKeyShipsNothing verifies that with a rejected API key nothing
+// is ever shipped, and pins the adapter's actual error handling: a non-200 is
+// reported through OnWarning and the adapter keeps polling -- it does not stop.
+func TestMockBadAPIKeyShipsNothing(t *testing.T) {
+	mock := newMockITGlue("itg.correct-key-1111")
+	mock.setLogs([]utils.Dict{
+		realisticLogRecord("9000001", time.Now()),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	var non200Warnings atomic.Int32
+	opts := testClientOptions(t)
+	opts.OnWarning = func(msg string) {
+		t.Logf("WRN: %s", msg)
+		if strings.Contains(msg, "non-200") {
+			non200Warnings.Add(1)
+		}
+	}
+
+	sink := &captureSink{}
+	conf := ITGlueConfig{
+		ClientOptions: opts,
+		Token:         "itg.wrong-key-9999",
+		BaseURL:       server.URL,
+		PollInterval:  40 * time.Millisecond,
+	}
+	adapter, chStopped, err := newITGlueAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The adapter keeps polling (and warning) despite the 401s.
+	require.Eventually(t, func() bool { return mock.requestCount() >= 3 },
+		5*time.Second, 10*time.Millisecond, "the adapter should keep retrying on auth failure")
+	require.Eventually(t, func() bool { return non200Warnings.Load() >= 1 },
+		5*time.Second, 10*time.Millisecond, "the 401 should be surfaced via OnWarning")
+
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter stopped on an auth failure; its actual behavior is to keep polling")
+	default:
+	}
+	assert.False(t, adapter.doStop.IsSet())
+}
+
+// TestMockMalformedResponseKeepsPolling pins the handling of a non-JSON 200
+// response: the decode error is reported through OnError, nothing ships, and
+// the adapter keeps polling.
+func TestMockMalformedResponseKeepsPolling(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("this is not json"))
+	}))
+	defer server.Close()
+
+	var jsonErrors atomic.Int32
+	opts := testClientOptions(t)
+	opts.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		if strings.Contains(err.Error(), "invalid json") {
+			jsonErrors.Add(1)
+		}
+	}
+
+	sink := &captureSink{}
+	conf := ITGlueConfig{
+		ClientOptions: opts,
+		Token:         "itg.fake-api-key-1111",
+		BaseURL:       server.URL,
+		PollInterval:  40 * time.Millisecond,
+	}
+	adapter, chStopped, err := newITGlueAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return requests.Load() >= 3 },
+		5*time.Second, 10*time.Millisecond, "the adapter should keep polling")
+	require.Eventually(t, func() bool { return jsonErrors.Load() >= 1 },
+		5*time.Second, 10*time.Millisecond, "the decode failure should be surfaced via OnError")
+
+	assert.Equal(t, 0, sink.count())
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter stopped on a malformed response; its actual behavior is to keep polling")
+	default:
+	}
+}
+
+// TestMockCloseIsClean verifies Close stops the poller and the stopped channel
+// closes.
+func TestMockCloseIsClean(t *testing.T) {
+	const token = "itg.fake-api-key-1111"
+
+	mock := newMockITGlue(token)
+	mock.setLogs([]utils.Dict{realisticLogRecord("9000001", time.Now())})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	adapter, chStopped, sink := startAdapter(t, server.URL, token)
+
+	require.Eventually(t, func() bool { return sink.count() >= 1 },
+		5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, adapter.Close())
+	select {
+	case <-chStopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("chStopped should close after Close()")
+	}
+
+	// No further polls happen after Close.
+	n := mock.requestCount()
+	require.Never(t, func() bool { return mock.requestCount() != n },
+		200*time.Millisecond, 20*time.Millisecond)
+}

--- a/itglue/mock_test.go
+++ b/itglue/mock_test.go
@@ -23,17 +23,31 @@ import (
 // This file exercises the adapter end-to-end against a mock IT Glue API,
 // capturing the exact messages it ships so their content can be asserted.
 //
-// The mock reproduces the IT Glue logs API as the adapter uses it: a GET on
-// /logs authenticated with the x-api-key header, taking filter[created_at]
-// (treated as "created at or after this RFC3339 time", the semantics the
-// adapter's 30s-lookback watermark relies on), sort=created_at and
-// page[size]/page[number] query parameters, and returning the JSON:API
-// envelope: {"data": [...], "links": {...}, "meta": {...}} with pagination
-// URLs nested under "links" per the JSON API spec.
+// The mock reproduces the IT Glue logs API (GET /logs, documented at
+// https://api.itglue.com/developer/ under "Logs") as the adapter uses it:
+// authenticated with the x-api-key header, taking sort=created_at (the only
+// documented sort for /logs) and page[size]/page[number] query parameters
+// (page size capped at 1000 per the docs), and returning the JSON:API
+// envelope: {"data": [...], "links": {...}, "meta": {...}} -- IT Glue states
+// it conforms to the JSON API spec (jsonapi.org), which nests pagination URLs
+// under top-level "links", and the official pagination article
+// (https://help.itglue.kaseya.com/help/Content/1-admin/it-glue-api/pagination-in-the-it-glue-api.html)
+// documents the "meta" page counters (total-pages, total-count). Note the real
+// /logs endpoint is additionally "limited to 5 pages of results" (page[number]
+// "Must be a value between 1 and 5 (inclusive)"); the documented way to iterate
+// further is filter[created_at] plus the created_at sort. The mock does not
+// enforce that cap -- the tests never page past 3 -- but it matters when
+// reasoning about the real API.
+//
+// filter[created_at]: the official docs only document a comma-separated range
+// ("start_date, end_date", with "*" for an unbounded side). The adapter sends
+// a single timestamp instead -- an undocumented form -- so the mock implements
+// the semantics the adapter's 30s-lookback watermark relies on: "created at or
+// after this RFC3339 time".
 
-// itglueTimeLayout matches the timestamp format the adapter sends in
-// filter[created_at] and that IT Glue uses in created-at attributes.
-const itglueTimeLayout = "2006-01-02T15:04:05.000000Z07:00"
+// itglueCreatedAtLayout matches the created-at format in the documented /logs
+// example response ("2021-07-24T00:55:31.000Z": RFC3339, UTC, milliseconds).
+const itglueCreatedAtLayout = "2006-01-02T15:04:05.000Z07:00"
 
 // --- in-memory USP sink -------------------------------------------------------
 
@@ -184,10 +198,12 @@ func (m *mockITGlue) handler() http.HandlerFunc {
 			_, _ = w.Write([]byte(`{"errors":[{"status":"404","title":"Not Found"}]}`))
 			return
 		}
-		// IT Glue authenticates with the key in the x-api-key header.
+		// IT Glue authenticates with the key in the x-api-key header. Per the
+		// developer docs ("API Key" section), "Trying to access the API with
+		// an incorrect key will result in an HTTP 403 error."
 		if rec.apiKey != m.apiKey {
-			w.WriteHeader(http.StatusUnauthorized)
-			_, _ = w.Write([]byte(`{"errors":[{"status":"401","title":"Unauthorized","detail":"invalid or missing api key"}]}`))
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"403","title":"Forbidden","detail":"incorrect api key"}]}`))
 			return
 		}
 
@@ -277,25 +293,30 @@ func (m *mockITGlue) handler() http.HandlerFunc {
 // --- realistic fixtures -------------------------------------------------------
 
 // realisticLogRecord returns a JSON:API resource shaped like an IT Glue
-// activity log: a string id, type "logs", and kebab-case attributes mirroring
-// what the activity log surfaces (who did what to which resource, when, from
-// where). All identifying values are clearly fake (RFC 5737 test addresses,
-// example.com-style names).
+// activity log: a string id, type "logs", and exactly the kebab-case
+// attributes shown in the documented GET /logs example response at
+// https://api.itglue.com/developer/ (created-at, level, account-id, user-id,
+// organization-id, action, resource-type, resource-name, ip-address, ip-city,
+// ip-region, ip-country, user-agent). All identifying values are clearly fake
+// (RFC 5737 test addresses, example-style names).
 func realisticLogRecord(id string, createdAt time.Time) utils.Dict {
 	return utils.Dict{
 		"id":   id,
 		"type": "logs",
 		"attributes": utils.Dict{
-			"created-at":        createdAt.UTC().Format(itglueTimeLayout),
-			"action":            "viewed",
-			"resource-id":       1111111,
-			"resource-type":     "Password",
-			"resource-name":     "Example Firewall Admin",
-			"organization-id":   2222222,
-			"organization-name": "Example Org Inc.",
-			"member-id":         3333333,
-			"member-name":       "Jane Doe",
-			"ip-address":        "203.0.113.10",
+			"created-at":      createdAt.UTC().Format(itglueCreatedAtLayout),
+			"level":           2,
+			"account-id":      1111111,
+			"user-id":         3333333,
+			"organization-id": 2222222,
+			"action":          "viewed",
+			"resource-type":   "Password",
+			"resource-name":   "Example Firewall Admin",
+			"ip-address":      "203.0.113.10",
+			"ip-city":         "Example City",
+			"ip-region":       "EX",
+			"ip-country":      "Exampleland",
+			"user-agent":      "Mozilla/5.0 (TestRunner) ExampleBrowser/1.0",
 		},
 	}
 }
@@ -546,11 +567,11 @@ func TestMockBadAPIKeyShipsNothing(t *testing.T) {
 	require.NoError(t, err)
 	defer adapter.Close()
 
-	// The adapter keeps polling (and warning) despite the 401s.
+	// The adapter keeps polling (and warning) despite the 403s.
 	require.Eventually(t, func() bool { return mock.requestCount() >= 3 },
 		5*time.Second, 10*time.Millisecond, "the adapter should keep retrying on auth failure")
 	require.Eventually(t, func() bool { return non200Warnings.Load() >= 1 },
-		5*time.Second, 10*time.Millisecond, "the 401 should be surfaced via OnWarning")
+		5*time.Second, 10*time.Millisecond, "the 403 should be surfaced via OnWarning")
 
 	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
 	select {

--- a/mimecast/client.go
+++ b/mimecast/client.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -18,14 +19,27 @@ import (
 )
 
 const (
-	baseURL       = "https://api.services.mimecast.com"
-	overlapPeriod = 30 * time.Second
+	defaultBaseURL      = "https://api.services.mimecast.com"
+	overlapPeriod       = 30 * time.Second
+	defaultPollInterval = 30 * time.Second
 )
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
 
 type MimecastAdapter struct {
 	conf       MimecastConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
+
+	baseURL      string
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -89,6 +103,15 @@ type MimecastConfig struct {
 	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 	ClientId      string                  `json:"client_id" yaml:"client_id"`
 	ClientSecret  string                  `json:"client_secret" yaml:"client_secret"`
+
+	// BaseURL overrides the Mimecast API root. Empty means the global API
+	// gateway (https://api.services.mimecast.com).
+	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// PollInterval overrides the wait between polls of the audit events
+	// endpoint. It is not settable through a config file; it exists as a seam
+	// for tests. Defaults to 30 seconds.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *MimecastConfig) Validate() error {
@@ -106,17 +129,36 @@ func (c *MimecastConfig) Validate() error {
 }
 
 func NewMimecastAdapter(ctx context.Context, conf MimecastConfig) (*MimecastAdapter, chan struct{}, error) {
-	var err error
+	return newMimecastAdapter(ctx, conf, nil)
+}
+
+// newMimecastAdapter is the implementation behind NewMimecastAdapter. When
+// sink is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newMimecastAdapter(ctx context.Context, conf MimecastConfig, sink uspSink) (*MimecastAdapter, chan struct{}, error) {
 	a := &MimecastAdapter{
-		conf:   conf,
-		ctx:    context.Background(),
-		doStop: utils.NewEvent(),
-		dedupe: make(map[string]int64),
+		conf:         conf,
+		ctx:          context.Background(),
+		doStop:       utils.NewEvent(),
+		dedupe:       make(map[string]int64),
+		baseURL:      defaultBaseURL,
+		pollInterval: defaultPollInterval,
+	}
+	if conf.BaseURL != "" {
+		a.baseURL = strings.TrimRight(conf.BaseURL, "/")
+	}
+	if conf.PollInterval > 0 {
+		a.pollInterval = conf.PollInterval
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -158,11 +200,11 @@ func (a *MimecastAdapter) Close() error {
 
 func (a *MimecastAdapter) fetchEvents() {
 	defer a.wgSenders.Done()
-	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching of %s events exiting", baseURL))
+	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching of %s events exiting", a.baseURL))
 
 	since := time.Now().Add(-400 * time.Hour)
 
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// The makeOneRequest function handles error
 		// handling and fatal error handling.
 		items, newSince, _ := a.makeOneRequest(since)
@@ -206,7 +248,7 @@ func (a *MimecastAdapter) makeOneRequest(since time.Time) ([]utils.Dict, time.Ti
 	end := currentTime.UTC().Format("2006-01-02T15:04:05-0700")
 
 	pageToken := ""
-	url := baseURL + "/api/audit/get-audit-events"
+	url := a.baseURL + "/api/audit/get-audit-events"
 
 	for {
 		// Prepare the request.
@@ -322,7 +364,7 @@ func (a *MimecastAdapter) makeOneRequest(since time.Time) ([]utils.Dict, time.Ti
 }
 
 func (a *MimecastAdapter) getAuthToken() (string, error) {
-	url := baseURL + "/oauth/token"
+	url := a.baseURL + "/oauth/token"
 	body := "grant_type=client_credentials&client_id=" + a.conf.ClientId + "&client_secret=" + a.conf.ClientSecret
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte(body)))

--- a/mimecast/client_test.go
+++ b/mimecast/client_test.go
@@ -1,0 +1,79 @@
+package usp_mimecast
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("requires client_id", func(t *testing.T) {
+		c := MimecastConfig{ClientOptions: testClientOptions(t), ClientSecret: "s"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires client_secret", func(t *testing.T) {
+		c := MimecastConfig{ClientOptions: testClientOptions(t), ClientId: "i"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("accepts a complete config", func(t *testing.T) {
+		c := MimecastConfig{ClientOptions: testClientOptions(t), ClientId: "i", ClientSecret: "s"}
+		assert.NoError(t, c.Validate())
+	})
+}
+
+func TestConstructorDefaultsAndOverrides(t *testing.T) {
+	t.Run("defaults to the global API root and a 30s poll", func(t *testing.T) {
+		conf := MimecastConfig{
+			ClientOptions: testClientOptions(t),
+			ClientId:      "i",
+			ClientSecret:  "s",
+		}
+		a, chStopped, err := newMimecastAdapter(context.Background(), conf, &captureSink{})
+		require.NoError(t, err)
+		require.NotNil(t, chStopped)
+		defer a.Close()
+
+		assert.Equal(t, "https://api.services.mimecast.com", a.baseURL)
+		assert.Equal(t, defaultPollInterval, a.pollInterval)
+	})
+
+	t.Run("honors base_url and poll interval overrides", func(t *testing.T) {
+		conf := MimecastConfig{
+			ClientOptions: testClientOptions(t),
+			ClientId:      "i",
+			ClientSecret:  "s",
+			BaseURL:       "https://mimecast.example.com/",
+			PollInterval:  5 * time.Second,
+		}
+		a, _, err := newMimecastAdapter(context.Background(), conf, &captureSink{})
+		require.NoError(t, err)
+		defer a.Close()
+
+		assert.Equal(t, "https://mimecast.example.com", a.baseURL,
+			"a trailing slash must be trimmed so path joins stay valid")
+		assert.Equal(t, 5*time.Second, a.pollInterval)
+	})
+}

--- a/mimecast/mock_test.go
+++ b/mimecast/mock_test.go
@@ -60,8 +60,9 @@ func (s *captureSink) snapshot() []*protocol.DataMessage {
 // --- mock Mimecast API 2.0 ----------------------------------------------------
 
 // mimecastRequestTimeLayout is the format the adapter renders startDateTime /
-// endDateTime in ("2006-01-02T15:04:05-0700"), which is also what the real
-// Mimecast API accepts.
+// endDateTime in ("2006-01-02T15:04:05-0700"). It matches the documented
+// format for those fields, yyyy-MM-dd'T'HH:mm:ssZ with a colonless offset
+// (e.g. "2011-12-03T10:15:30+0000").
 const mimecastRequestTimeLayout = "2006-01-02T15:04:05-0700"
 
 // mockAccessToken is the bearer token the mock issues on a successful
@@ -128,7 +129,7 @@ func (m *mockMimecast) handler(t *testing.T) http.HandlerFunc {
 		case "/api/audit/get-audit-events":
 			m.handleAuditEvents(t, w, r)
 		default:
-			http.Error(w, `{"fail":[{"errors":[{"code":"err_not_found","message":"not found","retryable":false}]}]}`, http.StatusNotFound)
+			http.Error(w, `{"fail":[{"errors":[{"code":"endpoint_evaluation_failed_1","message":"Endpoint cannot be found","retryable":false}]}]}`, http.StatusNotFound)
 		}
 	}
 }
@@ -165,7 +166,7 @@ func (m *mockMimecast) handleToken(t *testing.T, w http.ResponseWriter, r *http.
 		form.Get("client_secret") != m.clientSecret {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error":"invalid_client","error_description":"Client authentication failed"}`))
+		_, _ = w.Write([]byte(`{"fail":[{"errors":[{"code":"invalid_client_identifier","message":"Client credentials are invalid","retryable":false}]}]}`))
 		return
 	}
 
@@ -207,14 +208,14 @@ func (m *mockMimecast) handleAuditEvents(t *testing.T, w http.ResponseWriter, r 
 	if r.Header.Get("Authorization") != "Bearer "+mockAccessToken {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"meta":{"status":401},"data":[],"fail":[{"errors":[{"code":"token_verification_failed","message":"Token verification failed","retryable":false}]}]}`))
+		_, _ = w.Write([]byte(`{"meta":{"status":401},"data":[],"fail":[{"errors":[{"code":"invalid_access_token","message":"Access token is invalid","retryable":false}]}]}`))
 		return
 	}
 
 	if forcedStatus != 0 {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(forcedStatus)
-		_, _ = w.Write([]byte(`{"meta":{"status":500},"data":[],"fail":[{"errors":[{"code":"err_internal","message":"internal error","retryable":true}]}]}`))
+		_, _ = w.Write([]byte(`{"meta":{"status":500},"data":[],"fail":[{"errors":[{"code":"internal_server_error_1","message":"Failed to handle request with requestId: fake-request-id","retryable":true}]}]}`))
 		return
 	}
 
@@ -262,7 +263,7 @@ func (m *mockMimecast) handleAuditEvents(t *testing.T, w http.ResponseWriter, r 
 
 	pageSize := req.Meta.Pagination.PageSize
 	if pageSize <= 0 {
-		pageSize = 25 // the real API default
+		pageSize = 10 // the documented default when meta.pagination.pageSize is omitted
 	}
 	offset := 0
 	if tok := req.Meta.Pagination.PageToken; tok != "" {
@@ -306,10 +307,12 @@ func (m *mockMimecast) handleAuditEvents(t *testing.T, w http.ResponseWriter, r 
 // /api/audit/get-audit-events record: the documented id, auditType, user,
 // eventTime, eventInfo and category fields. All identifiers are clearly fake.
 //
-// NOTE on eventTime format: the real API renders eventTime with a numeric
-// offset ("2026-06-11T10:00:00+0000"). The adapter parses eventTime with
-// time.RFC3339, which requires a colon in the offset (or "Z"); fixtures use
-// the RFC3339 "Z" form so the adapter's dedupe bookkeeping behaves as designed.
+// NOTE on eventTime format: the official API 2.0 spec documents eventTime as
+// ISO 8601 in the yyyy-MM-dd'T'HH:mm:ssZ pattern, i.e. a colonless numeric
+// offset like "2026-06-11T10:00:00+0000". The adapter parses eventTime with
+// time.RFC3339, which requires a colon in the offset (or "Z") and so rejects
+// the documented form; fixtures use the RFC3339 "Z" form so the adapter's
+// dedupe bookkeeping behaves as designed.
 func fakeAuditEvent(id, auditType, user, category, info string, eventTime time.Time) utils.Dict {
 	return utils.Dict{
 		"id":        id,

--- a/mimecast/mock_test.go
+++ b/mimecast/mock_test.go
@@ -1,0 +1,586 @@
+package usp_mimecast
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock of the Mimecast
+// API 2.0 (https://api.services.mimecast.com), capturing the exact messages it
+// ships so their content -- payload, timestamp and event type -- can be
+// asserted without live credentials.
+
+// --- in-memory USP sink -------------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Mimecast API 2.0 ----------------------------------------------------
+
+// mimecastRequestTimeLayout is the format the adapter renders startDateTime /
+// endDateTime in ("2006-01-02T15:04:05-0700"), which is also what the real
+// Mimecast API accepts.
+const mimecastRequestTimeLayout = "2006-01-02T15:04:05-0700"
+
+// mockAccessToken is the bearer token the mock issues on a successful
+// client-credentials exchange. Clearly fake.
+const mockAccessToken = "fake-mimecast-access-token-1111111111111111"
+
+// mockMimecast is an in-memory stand-in for the Mimecast API 2.0. It exposes
+// the two endpoints the adapter uses:
+//
+//   - POST /oauth/token: OAuth2 client-credentials exchange, form-encoded
+//     grant_type/client_id/client_secret, returning {"access_token": ...}.
+//   - POST /api/audit/get-audit-events: Bearer-authenticated JSON request with
+//     a {"meta":{"pagination":{...}},"data":[{"startDateTime","endDateTime"}]}
+//     envelope, returning {"meta":{"pagination":{"next": ...}},"data":[...]}
+//     filtered to the requested time window and paginated by an opaque
+//     meta.pagination.next token echoed back as meta.pagination.pageToken.
+type mockMimecast struct {
+	mu           sync.Mutex
+	clientID     string
+	clientSecret string
+	events       []utils.Dict // audit logs, oldest first
+
+	tokenRequests int
+	auditRequests int
+
+	// Captures of the first requests seen, for request-shape assertions.
+	lastTokenContentType string
+	lastTokenForm        url.Values
+	firstAuditAuth       string
+	firstAuditBody       []byte
+
+	// auditStatus, when non-zero, forces the audit endpoint to return that
+	// HTTP status (the token endpoint keeps working).
+	auditStatus int
+}
+
+func newMockMimecast(clientID, clientSecret string) *mockMimecast {
+	return &mockMimecast{clientID: clientID, clientSecret: clientSecret}
+}
+
+func (m *mockMimecast) addEvent(e utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, e)
+}
+
+func (m *mockMimecast) tokenCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests
+}
+
+func (m *mockMimecast) auditCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.auditRequests
+}
+
+func (m *mockMimecast) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			m.handleToken(t, w, r)
+		case "/api/audit/get-audit-events":
+			m.handleAuditEvents(t, w, r)
+		default:
+			http.Error(w, `{"fail":[{"errors":[{"code":"err_not_found","message":"not found","retryable":false}]}]}`, http.StatusNotFound)
+		}
+	}
+}
+
+func (m *mockMimecast) handleToken(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.tokenRequests++
+	m.mu.Unlock()
+
+	// Handlers run on server goroutines: use assert (not require) so a failure
+	// is reported without calling runtime.Goexit off the test goroutine.
+	if !assert.Equal(t, http.MethodPost, r.Method, "token exchange must be a POST") {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if !assert.NoError(t, err) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	form, err := url.ParseQuery(string(body))
+	if !assert.NoError(t, err, "token request body must be form-encoded") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	m.mu.Lock()
+	m.lastTokenContentType = r.Header.Get("Content-Type")
+	m.lastTokenForm = form
+	m.mu.Unlock()
+
+	if form.Get("grant_type") != "client_credentials" ||
+		form.Get("client_id") != m.clientID ||
+		form.Get("client_secret") != m.clientSecret {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_client","error_description":"Client authentication failed"}`))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"access_token": mockAccessToken,
+		"token_type":   "Bearer",
+		"expires_in":   1800,
+	})
+}
+
+// auditRequestBody mirrors the request envelope the adapter sends to
+// /api/audit/get-audit-events.
+type auditRequestBody struct {
+	Meta struct {
+		Pagination struct {
+			PageSize  int    `json:"pageSize"`
+			PageToken string `json:"pageToken"`
+		} `json:"pagination"`
+	} `json:"meta"`
+	Data []struct {
+		StartDateTime string `json:"startDateTime"`
+		EndDateTime   string `json:"endDateTime"`
+	} `json:"data"`
+}
+
+func (m *mockMimecast) handleAuditEvents(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.auditRequests++
+	forcedStatus := m.auditStatus
+	m.mu.Unlock()
+
+	if !assert.Equal(t, http.MethodPost, r.Method, "get-audit-events must be a POST") {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	if r.Header.Get("Authorization") != "Bearer "+mockAccessToken {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"meta":{"status":401},"data":[],"fail":[{"errors":[{"code":"token_verification_failed","message":"Token verification failed","retryable":false}]}]}`))
+		return
+	}
+
+	if forcedStatus != 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(forcedStatus)
+		_, _ = w.Write([]byte(`{"meta":{"status":500},"data":[],"fail":[{"errors":[{"code":"err_internal","message":"internal error","retryable":true}]}]}`))
+		return
+	}
+
+	raw, err := io.ReadAll(r.Body)
+	if !assert.NoError(t, err) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	var req auditRequestBody
+	if !assert.NoError(t, json.Unmarshal(raw, &req), "audit request body must be JSON") ||
+		!assert.Len(t, req.Data, 1, "audit request must carry exactly one date range") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	m.mu.Lock()
+	if m.firstAuditBody == nil {
+		m.firstAuditBody = raw
+		m.firstAuditAuth = r.Header.Get("Authorization")
+	}
+	m.mu.Unlock()
+
+	start, errS := time.Parse(mimecastRequestTimeLayout, req.Data[0].StartDateTime)
+	end, errE := time.Parse(mimecastRequestTimeLayout, req.Data[0].EndDateTime)
+	if !assert.NoError(t, errS, "startDateTime must parse as %s", mimecastRequestTimeLayout) ||
+		!assert.NoError(t, errE, "endDateTime must parse as %s", mimecastRequestTimeLayout) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Filter the dataset to the requested window (inclusive bounds), the way
+	// the real API constrains results to startDateTime..endDateTime.
+	m.mu.Lock()
+	var matched []utils.Dict
+	for _, e := range m.events {
+		ts, perr := time.Parse(time.RFC3339, e["eventTime"].(string))
+		if perr != nil {
+			continue
+		}
+		if !ts.Before(start) && !ts.After(end) {
+			matched = append(matched, e)
+		}
+	}
+	m.mu.Unlock()
+
+	pageSize := req.Meta.Pagination.PageSize
+	if pageSize <= 0 {
+		pageSize = 25 // the real API default
+	}
+	offset := 0
+	if tok := req.Meta.Pagination.PageToken; tok != "" {
+		n, perr := strconv.Atoi(strings.TrimPrefix(tok, "offset-"))
+		if !assert.NoError(t, perr, "pageToken must be a token previously returned in meta.pagination.next") {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		offset = n
+	}
+
+	page := []utils.Dict{}
+	if offset < len(matched) {
+		endIdx := offset + pageSize
+		if endIdx > len(matched) {
+			endIdx = len(matched)
+		}
+		page = matched[offset:endIdx]
+	}
+
+	pagination := map[string]interface{}{"pageSize": pageSize}
+	if offset+pageSize < len(matched) {
+		pagination["next"] = fmt.Sprintf("offset-%d", offset+pageSize)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"meta": map[string]interface{}{
+			"status":     200,
+			"pagination": pagination,
+		},
+		"data": page,
+		"fail": []interface{}{},
+	})
+}
+
+// --- realistic fixtures ---------------------------------------------------------
+
+// fakeAuditEvent returns an audit log shaped like a real Mimecast
+// /api/audit/get-audit-events record: the documented id, auditType, user,
+// eventTime, eventInfo and category fields. All identifiers are clearly fake.
+//
+// NOTE on eventTime format: the real API renders eventTime with a numeric
+// offset ("2026-06-11T10:00:00+0000"). The adapter parses eventTime with
+// time.RFC3339, which requires a colon in the offset (or "Z"); fixtures use
+// the RFC3339 "Z" form so the adapter's dedupe bookkeeping behaves as designed.
+func fakeAuditEvent(id, auditType, user, category, info string, eventTime time.Time) utils.Dict {
+	return utils.Dict{
+		"id":        id,
+		"auditType": auditType,
+		"user":      user,
+		"eventTime": eventTime.UTC().Truncate(time.Second).Format(time.RFC3339),
+		"eventInfo": info,
+		"category":  category,
+	}
+}
+
+func fakeLogonEvent(id string, eventTime time.Time) utils.Dict {
+	return fakeAuditEvent(
+		id,
+		"Logon Authentication Failed",
+		"jdoe@example.com",
+		"authentication_logs",
+		"Failed authentication for jdoe@example.com, Application: fake-app, Source IP: 192.0.2.10",
+		eventTime)
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// startTestAdapter wires the adapter to the mock server and the capture sink
+// with a fast poll interval.
+func startTestAdapter(t *testing.T, serverURL string, sink uspSink, clientID, clientSecret string) *MimecastAdapter {
+	t.Helper()
+	conf := MimecastConfig{
+		ClientOptions: testClientOptions(t),
+		ClientId:      clientID,
+		ClientSecret:  clientSecret,
+		BaseURL:       serverURL,
+		PollInterval:  30 * time.Millisecond,
+	}
+	require.NoError(t, conf.Validate())
+	adapter, _, err := newMimecastAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	return adapter
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestMimecastEndToEnd drives the adapter against the mock API and asserts the
+// exact events shipped: every audit log in the polled window ships with its
+// fields intact, the OAuth exchange and audit request are shaped like the real
+// API expects, and re-polling does not re-ship.
+func TestMimecastEndToEnd(t *testing.T) {
+	const clientID = "11111111-1111-1111-1111-111111111111"
+	const clientSecret = "fake-client-secret-0000000000000000"
+
+	now := time.Now()
+	want := []utils.Dict{
+		fakeAuditEvent("fake-audit-id-0001", "Logon Authentication Failed", "jdoe@example.com",
+			"authentication_logs", "Failed authentication for jdoe@example.com, Source IP: 192.0.2.10", now.Add(-12*time.Second)),
+		fakeAuditEvent("fake-audit-id-0002", "Search", "asmith@example.com",
+			"case_review_logs", "Search performed by asmith@example.com: subject contains invoice", now.Add(-8*time.Second)),
+		fakeAuditEvent("fake-audit-id-0003", "Policy Definition Updated", "admin@example.com",
+			"account_logs", "Policy Anti-Spoofing updated by admin@example.com", now.Add(-4*time.Second)),
+	}
+
+	mock := newMockMimecast(clientID, clientSecret)
+	for _, e := range want {
+		mock.addEvent(e)
+	}
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	testStartMs := uint64(time.Now().UnixMilli())
+	adapter := startTestAdapter(t, server.URL, sink, clientID, clientSecret)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 audit events to ship")
+
+	// Re-polling must not re-ship: the mock keeps returning the same events
+	// for any window that covers them, and the dedupe map must absorb them.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "events were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	nowMs := uint64(time.Now().UnixMilli())
+	for _, msg := range sink.snapshot() {
+		// The adapter does not tag an event type; the platform config decides.
+		assert.Empty(t, msg.EventType)
+		// The adapter stamps ship time (not the record's eventTime).
+		assert.GreaterOrEqual(t, msg.TimestampMs, testStartMs)
+		assert.LessOrEqual(t, msg.TimestampMs, nowMs)
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	// Every audit field round-trips into the shipped payload.
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "event %s was not shipped", id)
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must carry the Mimecast audit fields verbatim")
+	}
+
+	// The OAuth exchange is shaped as the real endpoint requires.
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	assert.Equal(t, "application/x-www-form-urlencoded", mock.lastTokenContentType)
+	assert.Equal(t, "client_credentials", mock.lastTokenForm.Get("grant_type"))
+	assert.Equal(t, clientID, mock.lastTokenForm.Get("client_id"))
+	assert.Equal(t, clientSecret, mock.lastTokenForm.Get("client_secret"))
+
+	// The audit request carries the issued bearer token and the documented
+	// envelope: meta.pagination.pageSize=50 plus one start/end window.
+	assert.Equal(t, "Bearer "+mockAccessToken, mock.firstAuditAuth)
+	var audit auditRequestBody
+	require.NoError(t, json.Unmarshal(mock.firstAuditBody, &audit))
+	assert.Equal(t, 50, audit.Meta.Pagination.PageSize)
+	assert.Empty(t, audit.Meta.Pagination.PageToken, "the first page must not carry a pageToken")
+	require.Len(t, audit.Data, 1)
+	startT, err := time.Parse(mimecastRequestTimeLayout, audit.Data[0].StartDateTime)
+	require.NoError(t, err)
+	endT, err := time.Parse(mimecastRequestTimeLayout, audit.Data[0].EndDateTime)
+	require.NoError(t, err)
+	assert.False(t, endT.Before(startT), "the request window must not be inverted")
+}
+
+// TestMimecastMidRunEventShipsOnce verifies an audit event appearing after the
+// first poll ships exactly once, and already-shipped events are never re-sent.
+func TestMimecastMidRunEventShipsOnce(t *testing.T) {
+	const clientID = "client-id-test"
+	const clientSecret = "client-secret-test"
+
+	mock := newMockMimecast(clientID, clientSecret)
+	mock.addEvent(fakeLogonEvent("fake-audit-id-000a", time.Now().Add(-10*time.Second)))
+	mock.addEvent(fakeLogonEvent("fake-audit-id-000b", time.Now().Add(-5*time.Second)))
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter := startTestAdapter(t, server.URL, sink, clientID, clientSecret)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new audit event occurs mid-run.
+	mock.addEvent(fakeLogonEvent("fake-audit-id-000c", time.Now()))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new event should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond, "no event may ship twice")
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{
+		"fake-audit-id-000a": 1,
+		"fake-audit-id-000b": 1,
+		"fake-audit-id-000c": 1,
+	}, shippedPerID, "every event must ship exactly once")
+}
+
+// TestMimecastPaginationMultiPage verifies a window holding more events than
+// one page (the adapter requests pageSize 50) is fully consumed by following
+// meta.pagination.next tokens, shipping every event exactly once.
+func TestMimecastPaginationMultiPage(t *testing.T) {
+	const clientID = "client-id-test"
+	const clientSecret = "client-secret-test"
+	const total = 120 // 3 pages at the adapter's pageSize of 50
+
+	mock := newMockMimecast(clientID, clientSecret)
+	base := time.Now().Add(-20 * time.Second)
+	for i := 0; i < total; i++ {
+		mock.addEvent(fakeLogonEvent(
+			fmt.Sprintf("fake-audit-id-%04d", i),
+			base.Add(time.Duration(i)*150*time.Millisecond)))
+	}
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter := startTestAdapter(t, server.URL, sink, clientID, clientSecret)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		5*time.Second, 20*time.Millisecond, "all paginated events should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 30*time.Millisecond, "no paginated event may ship twice")
+
+	assert.GreaterOrEqual(t, mock.auditCount(), 3,
+		"120 events at pageSize 50 require at least 3 audit requests")
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["id"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct event should be shipped once")
+}
+
+// TestMimecastBadCredentialsShipsNothing pins the adapter's behavior on a
+// rejected client-credentials exchange: nothing ships, the audit endpoint is
+// never called, and the adapter keeps retrying (it does not stop itself).
+func TestMimecastBadCredentialsShipsNothing(t *testing.T) {
+	mock := newMockMimecast("client-id-test", "correct-secret")
+	mock.addEvent(fakeLogonEvent("fake-audit-id-0001", time.Now().Add(-5*time.Second)))
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter := startTestAdapter(t, server.URL, sink, "client-id-test", "wrong-secret")
+	chStopped := adapter.chStopped
+	defer adapter.Close()
+
+	// Wait for at least two failed token exchanges (= two poll cycles).
+	require.Eventually(t, func() bool { return mock.tokenCount() >= 2 },
+		5*time.Second, 20*time.Millisecond, "the adapter should keep attempting the token exchange")
+
+	assert.Equal(t, 0, sink.count(), "nothing may ship when authentication fails")
+	assert.Equal(t, 0, mock.auditCount(), "the audit endpoint must not be called without a token")
+
+	// Current behavior: an auth failure does not stop the adapter; it retries
+	// on the next poll.
+	select {
+	case <-chStopped:
+		t.Fatal("adapter unexpectedly stopped on an auth failure (current behavior is to keep polling)")
+	default:
+	}
+}
+
+// TestMimecastAPIErrorKeepsPolling pins the adapter's behavior on a failing
+// audit endpoint: the poll yields nothing, nothing ships, and the adapter
+// retries on the next interval rather than stopping.
+func TestMimecastAPIErrorKeepsPolling(t *testing.T) {
+	mock := newMockMimecast("client-id-test", "client-secret-test")
+	mock.addEvent(fakeLogonEvent("fake-audit-id-0001", time.Now().Add(-5*time.Second)))
+	mock.auditStatus = http.StatusInternalServerError
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter := startTestAdapter(t, server.URL, sink, "client-id-test", "client-secret-test")
+	chStopped := adapter.chStopped
+	defer adapter.Close()
+
+	// Wait for at least two failed polls of the audit endpoint.
+	require.Eventually(t, func() bool { return mock.auditCount() >= 2 },
+		5*time.Second, 20*time.Millisecond, "the adapter should keep polling through API errors")
+	assert.Equal(t, 0, sink.count(), "nothing may ship when the API errors")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter unexpectedly stopped on an API error")
+	default:
+	}
+
+	// Once the API recovers, the pending event ships exactly once.
+	mock.mu.Lock()
+	mock.auditStatus = 0
+	mock.mu.Unlock()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the event should ship after the API recovers")
+	require.Never(t, func() bool { return sink.count() != 1 },
+		300*time.Millisecond, 30*time.Millisecond)
+	assert.Equal(t, "fake-audit-id-0001", sink.snapshot()[0].JsonPayload["id"])
+}

--- a/ms_graph/client.go
+++ b/ms_graph/client.go
@@ -20,13 +20,26 @@ import (
 
 const scope = "https://graph.microsoft.com/.default"
 const URLPrefix = "https://graph.microsoft.com/v1.0/"
+const defaultLoginEndpoint = "https://login.microsoftonline.com"
+const defaultPollInterval = 30 * time.Second
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
 
 type MsGraphAdapter struct {
 	conf       MsGraphConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
 
-	endpoint string
+	endpoint      string
+	loginEndpoint string
+	pollInterval  time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -41,6 +54,20 @@ type MsGraphConfig struct {
 	ClientID      string                  `json:"client_id" yaml:"client_id"`
 	ClientSecret  string                  `json:"client_secret" yaml:"client_secret"`
 	URL           string                  `json:"url" yaml:"url"`
+
+	// LoginEndpoint overrides the Azure AD authority used for the OAuth2
+	// client_credentials token exchange. Empty means the public cloud
+	// endpoint (https://login.microsoftonline.com).
+	LoginEndpoint string `json:"login_endpoint" yaml:"login_endpoint"`
+
+	// GraphEndpoint overrides the Microsoft Graph API root the relative URL
+	// is appended to. Empty means the public cloud v1.0 root
+	// (https://graph.microsoft.com/v1.0/).
+	GraphEndpoint string `json:"graph_endpoint" yaml:"graph_endpoint"`
+
+	// PollInterval is the wait between polls of the Graph endpoint. It is
+	// not settable through a config file; it exists as a seam for tests.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *MsGraphConfig) Validate() error {
@@ -63,16 +90,36 @@ func (c *MsGraphConfig) Validate() error {
 }
 
 func NewMsGraphAdapter(ctx context.Context, conf MsGraphConfig) (*MsGraphAdapter, chan struct{}, error) {
-	var err error
+	return newMsGraphAdapter(ctx, conf, nil)
+}
+
+// newMsGraphAdapter is the implementation behind NewMsGraphAdapter. When sink
+// is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newMsGraphAdapter(ctx context.Context, conf MsGraphConfig, sink uspSink) (*MsGraphAdapter, chan struct{}, error) {
 	a := &MsGraphAdapter{
 		conf:   conf,
 		ctx:    context.Background(),
 		doStop: utils.NewEvent(),
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	a.loginEndpoint = strings.TrimSuffix(conf.LoginEndpoint, "/")
+	if a.loginEndpoint == "" {
+		a.loginEndpoint = defaultLoginEndpoint
+	}
+	a.pollInterval = conf.PollInterval
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -86,13 +133,21 @@ func NewMsGraphAdapter(ctx context.Context, conf MsGraphConfig) (*MsGraphAdapter
 
 	a.chStopped = make(chan struct{})
 
+	graphRoot := a.conf.GraphEndpoint
+	if graphRoot == "" {
+		graphRoot = URLPrefix
+	}
+	if !strings.HasSuffix(graphRoot, "/") {
+		graphRoot += "/"
+	}
+
 	// Strip the / prefix if in the URL.
 	url := strings.TrimPrefix(a.conf.URL, "/")
 
-	a.conf.ClientOptions.DebugLog(fmt.Sprintf("starting to fetch alerts from %s", URLPrefix+url))
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf("starting to fetch alerts from %s", graphRoot+url))
 
 	a.wgSenders.Add(1)
-	go a.fetchEvents(URLPrefix + url)
+	go a.fetchEvents(graphRoot + url)
 
 	go func() {
 		a.wgSenders.Wait()
@@ -119,7 +174,7 @@ func (a *MsGraphAdapter) Close() error {
 
 func (a *MsGraphAdapter) fetchToken() (string, error) {
 
-	url := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", a.conf.TenantID)
+	url := fmt.Sprintf("%s/%s/oauth2/v2.0/token", a.loginEndpoint, a.conf.TenantID)
 	payload := fmt.Sprintf("client_id=%s&scope=%s&grant_type=%s&client_secret=%s", a.conf.ClientID, scope, "client_credentials", a.conf.ClientSecret)
 
 	req, err := http.NewRequest("POST", url, bytes.NewBufferString(payload))
@@ -163,7 +218,7 @@ func (a *MsGraphAdapter) fetchEvents(url string) {
 	// since := time.Date(2022, time.June, 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02T15:04:05.000000Z")
 	since := time.Now().Format("2006-01-02T15:04:05.000000Z")
 
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// The makeOneRequest function handles error
 		// handling and fatal error handling.
 		items, newSince, eventId, _ := a.makeOneListRequest(url, since, lastEventId)

--- a/ms_graph/client_test.go
+++ b/ms_graph/client_test.go
@@ -1,0 +1,101 @@
+package usp_ms_graph
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real
+// LimaCharlie connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func validTestConfig(t *testing.T) MsGraphConfig {
+	t.Helper()
+	return MsGraphConfig{
+		ClientOptions: testClientOptions(t),
+		TenantID:      testTenantID,
+		ClientID:      testClientID,
+		ClientSecret:  testClientSecret,
+		URL:           testResource,
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("complete config passes", func(t *testing.T) {
+		c := validTestConfig(t)
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("requires tenant_id", func(t *testing.T) {
+		c := validTestConfig(t)
+		c.TenantID = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires client_id", func(t *testing.T) {
+		c := validTestConfig(t)
+		c.ClientID = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires client_secret", func(t *testing.T) {
+		c := validTestConfig(t)
+		c.ClientSecret = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires url", func(t *testing.T) {
+		c := validTestConfig(t)
+		c.URL = ""
+		assert.Error(t, c.Validate())
+	})
+}
+
+// TestConstructorDefaults verifies the endpoint and poll-interval overrides
+// default to the production Microsoft endpoints and 30s cadence when unset.
+// The default poll interval also means the fetch goroutine never issues a
+// request before Close() stops it, so no network is touched here.
+func TestConstructorDefaults(t *testing.T) {
+	t.Run("empty overrides use production defaults", func(t *testing.T) {
+		sink := &captureSink{}
+		adapter, _, err := newMsGraphAdapter(context.Background(), validTestConfig(t), sink)
+		require.NoError(t, err)
+		defer adapter.Close()
+
+		assert.Equal(t, defaultLoginEndpoint, adapter.loginEndpoint)
+		assert.Equal(t, defaultPollInterval, adapter.pollInterval)
+	})
+
+	t.Run("overrides are honored and normalized", func(t *testing.T) {
+		conf := validTestConfig(t)
+		conf.LoginEndpoint = "https://login.example.com/"
+		conf.PollInterval = defaultPollInterval + time.Minute
+
+		sink := &captureSink{}
+		adapter, _, err := newMsGraphAdapter(context.Background(), conf, sink)
+		require.NoError(t, err)
+		defer adapter.Close()
+
+		assert.Equal(t, "https://login.example.com", adapter.loginEndpoint,
+			"trailing slash should be trimmed")
+		assert.Equal(t, defaultPollInterval+time.Minute, adapter.pollInterval)
+	})
+}

--- a/ms_graph/mock_test.go
+++ b/ms_graph/mock_test.go
@@ -1,0 +1,668 @@
+package usp_ms_graph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock of the two
+// Microsoft endpoints it talks to:
+//
+//   - the Azure AD OAuth2 token endpoint
+//     (login.microsoftonline.com/<tenant>/oauth2/v2.0/token), which it hits
+//     with a client_credentials form exchange before every poll, and
+//   - a Microsoft Graph resource endpoint (graph.microsoft.com/v1.0/<url>),
+//     which it polls with a Bearer token and an OData
+//     `$filter=createdDateTime ge <since>` query, expecting the standard
+//     Graph envelope {"@odata.context": ..., "value": [...]}.
+//
+// All fixture identifiers are deliberately fake (example.com, all-1s UUIDs,
+// made-up tokens).
+
+const (
+	testTenantID     = "11111111-1111-1111-1111-111111111111"
+	testClientID     = "22222222-2222-2222-2222-222222222222"
+	testClientSecret = "fake-test-client-secret-0001"
+	testAccessToken  = "fake-test-access-token-0001"
+	testResource     = "security/alerts_v2"
+)
+
+// --- in-memory USP sink -------------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Microsoft endpoints ---------------------------------------------------
+
+// graphRecord pairs a record's payload with its parsed createdDateTime so the
+// mock can evaluate the adapter's `createdDateTime ge <since>` filter.
+type graphRecord struct {
+	t       time.Time
+	payload map[string]interface{}
+}
+
+// mockMsGraph is an in-memory stand-in for the Azure AD token endpoint and a
+// Microsoft Graph list endpoint. The token endpoint validates the
+// client_credentials exchange; the Graph endpoint validates the Bearer token,
+// honours the adapter's createdDateTime filter (inclusive `ge`, like OData),
+// returns records in ascending createdDateTime order inside the standard
+// {"value": [...]} envelope, and advertises @odata.nextLink when pageSize
+// truncates the result set.
+type mockMsGraph struct {
+	mu      sync.Mutex
+	baseURL string // set once the httptest server is up; used for nextLink
+
+	records  []graphRecord // kept in ascending createdDateTime order
+	pageSize int           // 0 = unlimited
+
+	graphFailStatus    int // when non-zero, the graph endpoint fails with this
+	graphFailRemaining int // how many failures to serve; < 0 = forever
+
+	tokenRequests     int
+	graphRequests     int
+	skipTokenRequests int
+	lastTokenForm     url.Values
+	lastGraphPath     string
+	lastGraphFilter   string
+}
+
+func newMockMsGraph() *mockMsGraph {
+	return &mockMsGraph{}
+}
+
+// start serves the mock and returns the httptest server (closed via t.Cleanup).
+func (m *mockMsGraph) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(m)
+	t.Cleanup(server.Close)
+	m.mu.Lock()
+	m.baseURL = server.URL
+	m.mu.Unlock()
+	return server
+}
+
+// addRecord appends a record. Records must be added in ascending
+// createdDateTime order, matching how tests model a growing event stream.
+func (m *mockMsGraph) addRecord(payload map[string]interface{}) {
+	created, err := time.Parse(time.RFC3339Nano, payload["createdDateTime"].(string))
+	if err != nil {
+		panic(fmt.Sprintf("fixture createdDateTime unparseable: %v", err))
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.records = append(m.records, graphRecord{t: created, payload: payload})
+}
+
+// failGraph makes the Graph endpoint answer `status` for the next `times`
+// requests (times < 0 = every request).
+func (m *mockMsGraph) failGraph(status int, times int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.graphFailStatus = status
+	m.graphFailRemaining = times
+}
+
+func (m *mockMsGraph) counts() (tokenReqs, graphReqs, skipTokenReqs int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests, m.graphRequests, m.skipTokenRequests
+}
+
+func (m *mockMsGraph) tokenForm() url.Values {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastTokenForm
+}
+
+func (m *mockMsGraph) graphPathAndFilter() (string, string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastGraphPath, m.lastGraphFilter
+}
+
+func (m *mockMsGraph) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/"+testTenantID+"/oauth2/v2.0/token":
+		m.serveToken(w, r)
+	case strings.HasPrefix(r.URL.Path, "/v1.0/"):
+		m.serveGraph(w, r)
+	default:
+		writeJSON(w, http.StatusNotFound, map[string]interface{}{
+			"error": map[string]interface{}{"code": "BadRequest", "message": "unknown path " + r.URL.Path},
+		})
+	}
+}
+
+// serveToken implements the Azure AD client_credentials token exchange.
+func (m *mockMsGraph) serveToken(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.tokenRequests++
+	m.mu.Unlock()
+
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/x-www-form-urlencoded") {
+		writeJSON(w, http.StatusBadRequest, aadError("AADSTS900144", "the request body must be form-urlencoded"))
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, aadError("AADSTS900144", "unreadable body"))
+		return
+	}
+	form, err := url.ParseQuery(string(body))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, aadError("AADSTS900144", "unparseable form body"))
+		return
+	}
+	m.mu.Lock()
+	m.lastTokenForm = form
+	m.mu.Unlock()
+
+	if form.Get("grant_type") != "client_credentials" {
+		writeJSON(w, http.StatusBadRequest, aadError("AADSTS70003", "unsupported grant type"))
+		return
+	}
+	if form.Get("scope") != scope {
+		writeJSON(w, http.StatusBadRequest, aadError("AADSTS70011", "invalid scope"))
+		return
+	}
+	if form.Get("client_id") != testClientID {
+		writeJSON(w, http.StatusBadRequest, aadError("AADSTS700016", "application not found in the directory"))
+		return
+	}
+	if form.Get("client_secret") != testClientSecret {
+		// Like the real endpoint, a bad secret yields a 401 with no
+		// access_token -- which is all the adapter's fetchToken looks at.
+		writeJSON(w, http.StatusUnauthorized, aadError("AADSTS7000215", "invalid client secret provided"))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"token_type":     "Bearer",
+		"expires_in":     3599,
+		"ext_expires_in": 3599,
+		"access_token":   testAccessToken,
+	})
+}
+
+// serveGraph implements a Graph v1.0 list endpoint with an OData
+// createdDateTime filter and the standard value/@odata.nextLink envelope.
+func (m *mockMsGraph) serveGraph(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.graphRequests++
+	m.lastGraphPath = r.URL.Path
+	if r.URL.Query().Get("$skiptoken") != "" {
+		m.skipTokenRequests++
+	}
+	failStatus := 0
+	if m.graphFailStatus != 0 && m.graphFailRemaining != 0 {
+		failStatus = m.graphFailStatus
+		if m.graphFailRemaining > 0 {
+			m.graphFailRemaining--
+		}
+	}
+	m.mu.Unlock()
+
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, graphError("BadRequest", "method not allowed"))
+		return
+	}
+	if r.Header.Get("Authorization") != "Bearer "+testAccessToken {
+		writeJSON(w, http.StatusUnauthorized, graphError("InvalidAuthenticationToken", "access token is empty or invalid"))
+		return
+	}
+	if failStatus != 0 {
+		writeJSON(w, failStatus, graphError("ServiceUnavailable", "injected failure"))
+		return
+	}
+
+	const filterPrefix = "createdDateTime ge "
+	filter := r.URL.Query().Get("$filter")
+	m.mu.Lock()
+	m.lastGraphFilter = filter
+	m.mu.Unlock()
+	if !strings.HasPrefix(filter, filterPrefix) {
+		writeJSON(w, http.StatusBadRequest, graphError("BadRequest", "unsupported $filter: "+filter))
+		return
+	}
+	since, err := time.Parse(time.RFC3339Nano, strings.TrimPrefix(filter, filterPrefix))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, graphError("BadRequest", "unparseable filter timestamp: "+err.Error()))
+		return
+	}
+
+	m.mu.Lock()
+	var matching []map[string]interface{}
+	for _, rec := range m.records {
+		// OData `ge` is inclusive.
+		if !rec.t.Before(since) {
+			matching = append(matching, rec.payload)
+		}
+	}
+	pageSize := m.pageSize
+	baseURL := m.baseURL
+	m.mu.Unlock()
+
+	page := matching
+	truncated := false
+	if pageSize > 0 && len(matching) > pageSize {
+		page = matching[:pageSize]
+		truncated = true
+	}
+	if page == nil {
+		page = []map[string]interface{}{}
+	}
+
+	envelope := map[string]interface{}{
+		"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#" + strings.TrimPrefix(r.URL.Path, "/v1.0/"),
+		"value":          page,
+	}
+	if truncated {
+		envelope["@odata.nextLink"] = baseURL + r.URL.Path + "?$skiptoken=fakeskiptoken1111"
+	}
+	writeJSON(w, http.StatusOK, envelope)
+}
+
+func writeJSON(w http.ResponseWriter, status int, body map[string]interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func aadError(code, description string) map[string]interface{} {
+	return map[string]interface{}{
+		"error":             "invalid_client",
+		"error_description": fmt.Sprintf("%s: %s", code, description),
+		"error_codes":       []interface{}{code},
+	}
+}
+
+func graphError(code, message string) map[string]interface{} {
+	return map[string]interface{}{
+		"error": map[string]interface{}{"code": code, "message": message},
+	}
+}
+
+// --- fixtures -----------------------------------------------------------------
+
+// graphTimestamp renders a time the way Graph does: UTC with 7 fractional
+// digits and a Z suffix.
+func graphTimestamp(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05.0000000Z")
+}
+
+// fixtureBase returns a time safely later than the adapter's startup `since`
+// filter. The adapter formats its initial `since` from the local clock with a
+// literal Z suffix, so on a machine east of UTC that boundary can sit up to 14
+// hours in the future; +24h clears it on any timezone.
+func fixtureBase() time.Time {
+	return time.Now().UTC().Add(24 * time.Hour)
+}
+
+// graphSecurityAlert is shaped like a real Graph security alerts_v2 record:
+// the documented top-level fields plus nested objects and arrays, with clearly
+// fake identifiers.
+func graphSecurityAlert(id string, createdDateTime string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":                 id,
+		"providerAlertId":    "11111111-1111-1111-1111-111111111111",
+		"incidentId":         "1111",
+		"status":             "new",
+		"severity":           "high",
+		"classification":     nil,
+		"determination":      nil,
+		"serviceSource":      "microsoftDefenderForEndpoint",
+		"detectionSource":    "antivirus",
+		"detectorId":         "11111111-1111-1111-1111-111111111111",
+		"tenantId":           testTenantID,
+		"title":              "Suspicious process injection observed",
+		"description":        "A process injected code into another process.",
+		"category":           "DefenseEvasion",
+		"createdDateTime":    createdDateTime,
+		"lastUpdateDateTime": createdDateTime,
+		"mitreTechniques":    []interface{}{"T1055", "T1055.001"},
+		"vendorInformation": map[string]interface{}{
+			"provider": "Microsoft 365 Defender",
+			"vendor":   "Microsoft",
+		},
+		"evidence": []interface{}{
+			map[string]interface{}{
+				"@odata.type":     "#microsoft.graph.security.processEvidence",
+				"processId":       4242,
+				"imageFile":       map[string]interface{}{"fileName": "evil.exe", "filePath": `C:\Users\jdoe\Downloads`},
+				"userAccount":     map[string]interface{}{"accountName": "jdoe", "userPrincipalName": "jdoe@example.com"},
+				"detectionStatus": "detected",
+			},
+		},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// --- helpers ------------------------------------------------------------------
+
+// testConfig builds an adapter config pointed at the mock server.
+func testConfig(t *testing.T, server *httptest.Server) MsGraphConfig {
+	t.Helper()
+	return MsGraphConfig{
+		ClientOptions: testClientOptions(t),
+		TenantID:      testTenantID,
+		ClientID:      testClientID,
+		ClientSecret:  testClientSecret,
+		URL:           testResource,
+		LoginEndpoint: server.URL,
+		GraphEndpoint: server.URL + "/v1.0/",
+		PollInterval:  50 * time.Millisecond,
+	}
+}
+
+// startAdapter starts the adapter with a capture sink and registers cleanup.
+func startAdapter(t *testing.T, conf MsGraphConfig) (*captureSink, *MsGraphAdapter, chan struct{}) {
+	t.Helper()
+	sink := &captureSink{}
+	adapter, chStopped, err := newMsGraphAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adapter.Close() })
+	return sink, adapter, chStopped
+}
+
+// --- tests ----------------------------------------------------------------------
+
+// TestMsGraphEndToEnd drives the adapter against the mock endpoints and pins
+// the full contract: the client_credentials token exchange, the Bearer-auth'd
+// GET with a createdDateTime filter against the configured resource (leading
+// "/" stripped), every record shipped verbatim exactly once, the adapter's
+// ingestion-time TimestampMs and empty EventType, and no re-shipping on
+// subsequent polls.
+func TestMsGraphEndToEnd(t *testing.T) {
+	mock := newMockMsGraph()
+	base := fixtureBase()
+	want := []map[string]interface{}{
+		graphSecurityAlert("alert-0001", graphTimestamp(base.Add(1*time.Minute))),
+		graphSecurityAlert("alert-0002", graphTimestamp(base.Add(2*time.Minute))),
+		graphSecurityAlert("alert-0003", graphTimestamp(base.Add(3*time.Minute))),
+	}
+	for _, rec := range want {
+		mock.addRecord(rec)
+	}
+	server := mock.start(t)
+
+	conf := testConfig(t, server)
+	conf.URL = "/" + testResource // leading slash must be stripped
+
+	before := uint64(time.Now().UnixMilli())
+	sink, _, chStopped := startAdapter(t, conf)
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 alerts to ship")
+	after := uint64(time.Now().UnixMilli())
+
+	// Re-polling must not re-ship: the boundary record keeps coming back
+	// (inclusive `ge` filter) but is suppressed via the last-event-id check.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "records were re-shipped on a later poll")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped unexpectedly")
+	default:
+	}
+
+	// The token exchange carried the full client_credentials contract (the
+	// mock rejects anything else, but pin the form fields explicitly too).
+	form := mock.tokenForm()
+	require.NotNil(t, form)
+	assert.Equal(t, "client_credentials", form.Get("grant_type"))
+	assert.Equal(t, scope, form.Get("scope"))
+	assert.Equal(t, testClientID, form.Get("client_id"))
+	assert.Equal(t, testClientSecret, form.Get("client_secret"))
+
+	// The Graph request targeted the configured resource with a
+	// createdDateTime filter.
+	path, filter := mock.graphPathAndFilter()
+	assert.Equal(t, "/v1.0/"+testResource, path)
+	assert.True(t, strings.HasPrefix(filter, "createdDateTime ge "), "unexpected $filter: %q", filter)
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		// The generic Graph adapter does not tag an event type and stamps
+		// ingestion time rather than the record's createdDateTime -- pin
+		// that behavior.
+		assert.Empty(t, msg.EventType)
+		assert.GreaterOrEqual(t, msg.TimestampMs, before, "TimestampMs should be ingestion time")
+		assert.LessOrEqual(t, msg.TimestampMs, after, "TimestampMs should be ingestion time")
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	// Payloads ship verbatim -- nested objects, arrays and nulls included.
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "record %s was not shipped", id)
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Graph record")
+	}
+}
+
+// TestMsGraphMidRunRecordShipsOnce verifies a record appearing while the
+// adapter is running is picked up by the advancing createdDateTime filter and
+// shipped exactly once.
+func TestMsGraphMidRunRecordShipsOnce(t *testing.T) {
+	mock := newMockMsGraph()
+	base := fixtureBase()
+	mock.addRecord(graphSecurityAlert("alert-a", graphTimestamp(base.Add(1*time.Minute))))
+	mock.addRecord(graphSecurityAlert("alert-b", graphTimestamp(base.Add(2*time.Minute))))
+	server := mock.start(t)
+
+	sink, _, _ := startAdapter(t, testConfig(t, server))
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new alert lands after a few polls have already gone by.
+	mock.addRecord(graphSecurityAlert("alert-c", graphTimestamp(base.Add(5*time.Minute))))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new alert should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{"alert-a": 1, "alert-b": 1, "alert-c": 1}, shippedPerID,
+		"every alert must ship exactly once")
+}
+
+// TestMsGraphPagedSetFullyConsumed verifies behavior when Graph truncates a
+// result set and advertises @odata.nextLink: the adapter does not follow the
+// nextLink (pinning current behavior), but still consumes the full set across
+// successive polls because each shipped batch advances the createdDateTime
+// filter -- and every record ships exactly once.
+func TestMsGraphPagedSetFullyConsumed(t *testing.T) {
+	mock := newMockMsGraph()
+	mock.pageSize = 2
+	base := fixtureBase()
+	const total = 5
+	for i := 1; i <= total; i++ {
+		mock.addRecord(graphSecurityAlert(
+			fmt.Sprintf("alert-%04d", i),
+			graphTimestamp(base.Add(time.Duration(i)*time.Minute))))
+	}
+	server := mock.start(t)
+
+	sink, _, _ := startAdapter(t, testConfig(t, server))
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 25*time.Millisecond, "the full paginated set should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["id"].(string)]++
+	}
+	require.Len(t, shippedPerID, total)
+	for id, n := range shippedPerID {
+		assert.Equalf(t, 1, n, "record %s shipped %d times", id, n)
+	}
+
+	// The adapter never follows @odata.nextLink; it relies on the advancing
+	// time filter instead.
+	_, _, skipTokenReqs := mock.counts()
+	assert.Equal(t, 0, skipTokenReqs, "the adapter is not expected to follow @odata.nextLink")
+}
+
+// TestMsGraphBadClientSecretShipsNothing pins the adapter's behavior on a
+// failed credential exchange: fetchToken is retried 3 times, an error is
+// surfaced, nothing ships, the Graph endpoint is never called -- and the
+// adapter keeps running (it does not stop on auth failure).
+func TestMsGraphBadClientSecretShipsNothing(t *testing.T) {
+	mock := newMockMsGraph()
+	base := fixtureBase()
+	mock.addRecord(graphSecurityAlert("alert-a", graphTimestamp(base.Add(1*time.Minute))))
+	server := mock.start(t)
+
+	var tokenFailures atomic.Int32
+	conf := testConfig(t, server)
+	conf.ClientSecret = "wrong-secret"
+	conf.ClientOptions.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		if strings.Contains(err.Error(), "error fetching token after 3 attempts") {
+			tokenFailures.Add(1)
+		}
+	}
+
+	sink, _, chStopped := startAdapter(t, conf)
+
+	// The retry path sleeps 1s + 2s inside the adapter before giving up.
+	require.Eventually(t, func() bool { return tokenFailures.Load() >= 1 },
+		15*time.Second, 50*time.Millisecond, "expected the token failure to be reported")
+
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	tokenReqs, graphReqs, _ := mock.counts()
+	assert.GreaterOrEqual(t, tokenReqs, 3, "the token exchange should be retried 3 times")
+	assert.Equal(t, 0, graphReqs, "Graph must not be called without a token")
+
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter is not expected to stop on an auth failure; it keeps polling")
+	default:
+	}
+}
+
+// TestMsGraphRejectedTokenKeepsPolling pins the adapter's behavior when Graph
+// itself rejects the Bearer token (e.g. missing API permissions): the error is
+// surfaced without retry, nothing ships, and the adapter keeps polling on its
+// interval rather than stopping.
+func TestMsGraphRejectedTokenKeepsPolling(t *testing.T) {
+	mock := newMockMsGraph()
+	base := fixtureBase()
+	mock.addRecord(graphSecurityAlert("alert-a", graphTimestamp(base.Add(1*time.Minute))))
+	mock.failGraph(http.StatusUnauthorized, -1)
+	server := mock.start(t)
+
+	var graphErrors atomic.Int32
+	conf := testConfig(t, server)
+	conf.ClientOptions.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		if strings.Contains(err.Error(), "verify permissions") {
+			graphErrors.Add(1)
+		}
+	}
+
+	sink, _, chStopped := startAdapter(t, conf)
+
+	// At least two poll cycles must report the error -- proof the adapter
+	// keeps polling instead of stopping or retrying a non-retryable status.
+	require.Eventually(t, func() bool { return graphErrors.Load() >= 2 },
+		5*time.Second, 20*time.Millisecond, "expected repeated Graph auth errors across polls")
+
+	assert.Equal(t, 0, sink.count(), "nothing should ship when Graph rejects the token")
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter is not expected to stop on a Graph 401; it keeps polling")
+	default:
+	}
+}
+
+// TestMsGraphTransient503Retried verifies a 503 from Graph is retried within
+// the same poll and the records ship once the endpoint recovers.
+func TestMsGraphTransient503Retried(t *testing.T) {
+	mock := newMockMsGraph()
+	base := fixtureBase()
+	want := graphSecurityAlert("alert-a", graphTimestamp(base.Add(1*time.Minute)))
+	mock.addRecord(want)
+	mock.failGraph(http.StatusServiceUnavailable, 2)
+	server := mock.start(t)
+
+	sink, _, chStopped := startAdapter(t, testConfig(t, server))
+
+	// The retry path sleeps 1s + 2s inside the adapter before the third try.
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		15*time.Second, 50*time.Millisecond, "the record should ship after the 503s clear")
+
+	_, graphReqs, _ := mock.counts()
+	assert.GreaterOrEqual(t, graphReqs, 3, "two 503s then a success")
+	assert.JSONEq(t, mustJSON(t, want), mustJSON(t, sink.snapshot()[0].JsonPayload))
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter should survive transient 503s")
+	default:
+	}
+}

--- a/ms_graph/mock_test.go
+++ b/ms_graph/mock_test.go
@@ -85,10 +85,21 @@ type graphRecord struct {
 // mockMsGraph is an in-memory stand-in for the Azure AD token endpoint and a
 // Microsoft Graph list endpoint. The token endpoint validates the
 // client_credentials exchange; the Graph endpoint validates the Bearer token,
-// honours the adapter's createdDateTime filter (inclusive `ge`, like OData),
-// returns records in ascending createdDateTime order inside the standard
-// {"value": [...]} envelope, and advertises @odata.nextLink when pageSize
-// truncates the result set.
+// honours the adapter's createdDateTime filter (`ge` is "greater than or
+// equal to" per https://learn.microsoft.com/en-us/graph/filter-query-parameter)
+// inside the standard {"value": [...]} envelope, and advertises
+// @odata.nextLink when pageSize truncates the result set
+// (https://learn.microsoft.com/en-us/graph/paging).
+//
+// The mock returns records in ascending createdDateTime order. That is a
+// deliberate modeling choice, not a Graph guarantee: the adapter sends no
+// $orderby (List alerts_v2 doesn't even offer one -- only $count, $filter,
+// $skip and $top are supported, and the official docs say "The most recent
+// alerts are displayed at the top of the list", i.e. newest first:
+// https://learn.microsoft.com/en-us/graph/api/security-list-alerts_v2).
+// Ascending order is the only ordering under which the adapter's
+// last-element watermark ships every record exactly once, which is the
+// behavior these tests pin.
 type mockMsGraph struct {
 	mu      sync.Mutex
 	baseURL string // set once the httptest server is up; used for nextLink
@@ -185,17 +196,17 @@ func (m *mockMsGraph) serveToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/x-www-form-urlencoded") {
-		writeJSON(w, http.StatusBadRequest, aadError("AADSTS900144", "the request body must be form-urlencoded"))
+		writeJSON(w, http.StatusBadRequest, aadError("invalid_request", 900144, "The request body must contain the following parameter: 'grant_type'."))
 		return
 	}
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, aadError("AADSTS900144", "unreadable body"))
+		writeJSON(w, http.StatusBadRequest, aadError("invalid_request", 900144, "The request body must contain the following parameter: 'grant_type'."))
 		return
 	}
 	form, err := url.ParseQuery(string(body))
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, aadError("AADSTS900144", "unparseable form body"))
+		writeJSON(w, http.StatusBadRequest, aadError("invalid_request", 900144, "The request body must contain the following parameter: 'grant_type'."))
 		return
 	}
 	m.mu.Lock()
@@ -203,21 +214,25 @@ func (m *mockMsGraph) serveToken(w http.ResponseWriter, r *http.Request) {
 	m.mu.Unlock()
 
 	if form.Get("grant_type") != "client_credentials" {
-		writeJSON(w, http.StatusBadRequest, aadError("AADSTS70003", "unsupported grant type"))
+		// AADSTS70003: UnsupportedGrantType.
+		writeJSON(w, http.StatusBadRequest, aadError("unsupported_grant_type", 70003, "The app returned an unsupported grant type."))
 		return
 	}
 	if form.Get("scope") != scope {
-		writeJSON(w, http.StatusBadRequest, aadError("AADSTS70011", "invalid scope"))
+		// AADSTS70011: InvalidScope.
+		writeJSON(w, http.StatusBadRequest, aadError("invalid_scope", 70011, "The provided value for the input parameter 'scope' is not valid."))
 		return
 	}
 	if form.Get("client_id") != testClientID {
-		writeJSON(w, http.StatusBadRequest, aadError("AADSTS700016", "application not found in the directory"))
+		// AADSTS700016: application not found in the directory/tenant.
+		writeJSON(w, http.StatusBadRequest, aadError("unauthorized_client", 700016, "Application with the given identifier was not found in the directory."))
 		return
 	}
 	if form.Get("client_secret") != testClientSecret {
-		// Like the real endpoint, a bad secret yields a 401 with no
+		// A bad secret yields AADSTS7000215 (invalid_client) with no
 		// access_token -- which is all the adapter's fetchToken looks at.
-		writeJSON(w, http.StatusUnauthorized, aadError("AADSTS7000215", "invalid client secret provided"))
+		// invalid_client uses HTTP 401 per RFC 6749 section 5.2.
+		writeJSON(w, http.StatusUnauthorized, aadError("invalid_client", 7000215, "Invalid client secret provided."))
 		return
 	}
 
@@ -302,7 +317,11 @@ func (m *mockMsGraph) serveGraph(w http.ResponseWriter, r *http.Request) {
 		"value":          page,
 	}
 	if truncated {
-		envelope["@odata.nextLink"] = baseURL + r.URL.Path + "?$skiptoken=fakeskiptoken1111"
+		// Per https://learn.microsoft.com/en-us/graph/paging the nextLink is
+		// an opaque URL carrying a $skiptoken (or $skip) plus the original
+		// query parameters.
+		envelope["@odata.nextLink"] = baseURL + r.URL.Path +
+			"?$filter=" + url.QueryEscape(filter) + "&$skiptoken=fakeskiptoken1111"
 	}
 	writeJSON(w, http.StatusOK, envelope)
 }
@@ -313,17 +332,39 @@ func writeJSON(w http.ResponseWriter, status int, body map[string]interface{}) {
 	_ = json.NewEncoder(w).Encode(body)
 }
 
-func aadError(code, description string) map[string]interface{} {
+// aadError mirrors the documented Microsoft identity platform token error
+// shape: an OAuth2 error string, an AADSTS-prefixed description, a list of
+// numeric STS error codes, and the diagnostic fields the real endpoint adds.
+// https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#error-response
+// (AADSTS codes: https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes)
+func aadError(oauthError string, stsCode int, description string) map[string]interface{} {
+	const fakeGUID = "11111111-1111-1111-1111-111111111111"
+	const fakeTime = "2026-01-01 00:00:00Z"
 	return map[string]interface{}{
-		"error":             "invalid_client",
-		"error_description": fmt.Sprintf("%s: %s", code, description),
-		"error_codes":       []interface{}{code},
+		"error": oauthError,
+		"error_description": fmt.Sprintf(
+			"AADSTS%d: %s\r\nTrace ID: %s\r\nCorrelation ID: %s\r\nTimestamp: %s",
+			stsCode, description, fakeGUID, fakeGUID, fakeTime),
+		"error_codes":    []interface{}{stsCode},
+		"timestamp":      fakeTime,
+		"trace_id":       fakeGUID,
+		"correlation_id": fakeGUID,
 	}
 }
 
+// graphError mirrors the documented Microsoft Graph error envelope:
+// a single "error" object with code, message and an optional innerError.
+// https://learn.microsoft.com/en-us/graph/errors
 func graphError(code, message string) map[string]interface{} {
 	return map[string]interface{}{
-		"error": map[string]interface{}{"code": code, "message": message},
+		"error": map[string]interface{}{
+			"code":    code,
+			"message": message,
+			"innerError": map[string]interface{}{
+				"request-id": "11111111-1111-1111-1111-111111111111",
+				"date":       "2026-01-01T00:00:00",
+			},
+		},
 	}
 }
 
@@ -343,39 +384,79 @@ func fixtureBase() time.Time {
 	return time.Now().UTC().Add(24 * time.Hour)
 }
 
-// graphSecurityAlert is shaped like a real Graph security alerts_v2 record:
-// the documented top-level fields plus nested objects and arrays, with clearly
-// fake identifiers.
+// graphSecurityAlert is shaped like a real Graph security alerts_v2 record
+// (microsoft.graph.security.alert), mirroring the documented properties and
+// example response with clearly fake identifiers:
+//   - https://learn.microsoft.com/en-us/graph/api/resources/security-alert?view=graph-rest-1.0
+//   - https://learn.microsoft.com/en-us/graph/api/security-list-alerts_v2?view=graph-rest-1.0
+//   - https://learn.microsoft.com/en-us/graph/api/resources/security-processevidence?view=graph-rest-1.0
 func graphSecurityAlert(id string, createdDateTime string) map[string]interface{} {
 	return map[string]interface{}{
-		"id":                 id,
-		"providerAlertId":    "11111111-1111-1111-1111-111111111111",
-		"incidentId":         "1111",
-		"status":             "new",
-		"severity":           "high",
-		"classification":     nil,
-		"determination":      nil,
-		"serviceSource":      "microsoftDefenderForEndpoint",
-		"detectionSource":    "antivirus",
-		"detectorId":         "11111111-1111-1111-1111-111111111111",
-		"tenantId":           testTenantID,
-		"title":              "Suspicious process injection observed",
-		"description":        "A process injected code into another process.",
-		"category":           "DefenseEvasion",
-		"createdDateTime":    createdDateTime,
-		"lastUpdateDateTime": createdDateTime,
-		"mitreTechniques":    []interface{}{"T1055", "T1055.001"},
-		"vendorInformation": map[string]interface{}{
-			"provider": "Microsoft 365 Defender",
-			"vendor":   "Microsoft",
-		},
+		"@odata.type":           "#microsoft.graph.security.alert",
+		"id":                    id,
+		"providerAlertId":       id,
+		"incidentId":            "1111",
+		"status":                "new",
+		"severity":              "high",
+		"classification":        "unknown",
+		"determination":         "unknown",
+		"serviceSource":         "microsoftDefenderForEndpoint",
+		"detectionSource":       "antivirus",
+		"detectorId":            "11111111-1111-1111-1111-111111111111",
+		"tenantId":              testTenantID,
+		"title":                 "Suspicious process injection observed",
+		"description":           "A process injected code into another process.",
+		"recommendedActions":    "Isolate the device and investigate the process tree.",
+		"category":              "DefenseEvasion",
+		"assignedTo":            nil,
+		"alertWebUrl":           "https://security.microsoft.com/alerts/" + id + "?tid=" + testTenantID,
+		"incidentWebUrl":        "https://security.microsoft.com/incidents/1111?tid=" + testTenantID,
+		"actorDisplayName":      nil,
+		"threatDisplayName":     nil,
+		"threatFamilyName":      nil,
+		"mitreTechniques":       []interface{}{"T1055", "T1055.001"},
+		"createdDateTime":       createdDateTime,
+		"lastUpdateDateTime":    createdDateTime,
+		"resolvedDateTime":      nil,
+		"firstActivityDateTime": createdDateTime,
+		"lastActivityDateTime":  createdDateTime,
+		"comments":              []interface{}{},
+		"systemTags":            []interface{}{},
 		"evidence": []interface{}{
 			map[string]interface{}{
-				"@odata.type":     "#microsoft.graph.security.processEvidence",
-				"processId":       4242,
-				"imageFile":       map[string]interface{}{"fileName": "evil.exe", "filePath": `C:\Users\jdoe\Downloads`},
-				"userAccount":     map[string]interface{}{"accountName": "jdoe", "userPrincipalName": "jdoe@example.com"},
-				"detectionStatus": "detected",
+				"@odata.type":                   "#microsoft.graph.security.processEvidence",
+				"createdDateTime":               createdDateTime,
+				"verdict":                       "suspicious",
+				"remediationStatus":             "none",
+				"remediationStatusDetails":      nil,
+				"processId":                     4242,
+				"parentProcessId":               668,
+				"processCommandLine":            `"evil.exe" --inject`,
+				"processCreationDateTime":       createdDateTime,
+				"parentProcessCreationDateTime": createdDateTime,
+				"detectionStatus":               "detected",
+				"mdeDeviceId":                   "1111111111111111111111111111111111111111",
+				"roles":                         []interface{}{},
+				"detailedRoles":                 []interface{}{},
+				"tags":                          []interface{}{},
+				"imageFile": map[string]interface{}{
+					"sha1":          "1111111111111111111111111111111111111111",
+					"sha256":        "1111111111111111111111111111111111111111111111111111111111111111",
+					"fileName":      "evil.exe",
+					"filePath":      `C:\Users\jdoe\Downloads`,
+					"fileSize":      123456,
+					"filePublisher": nil,
+					"signer":        nil,
+					"issuer":        nil,
+				},
+				"userAccount": map[string]interface{}{
+					"accountName":       "jdoe",
+					"domainName":        "EXAMPLE",
+					"userSid":           "S-1-5-21-1111111111-1111111111-1111111111-1111",
+					"azureAdUserId":     nil,
+					"userPrincipalName": "jdoe@example.com",
+					"displayName":       "Jane Doe",
+				},
 			},
 		},
 	}

--- a/o365/client.go
+++ b/o365/client.go
@@ -22,6 +22,19 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 )
 
+// defaultPollInterval is how long fetchEvents waits between polling cycles
+// once all immediately-available pages have been consumed.
+const defaultPollInterval = 5 * time.Minute
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type listItem struct {
 	ContentType       string `json:"contentType,omitempty"`
 	ContentID         string `json:"contentId,omitempty"`
@@ -62,7 +75,7 @@ var ResourceScope = map[string]string{
 
 type Office365Adapter struct {
 	conf       Office365Config
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
 
 	endpoint     string
@@ -86,7 +99,18 @@ type Office365Config struct {
 	ContentTypes  string                  `json:"content_types" yaml:"content_types"`
 	StartTime     string                  `json:"start_time" yaml:"start_time"`
 
+	// TokenURL, when set, fully overrides the OAuth2 token endpoint URL. When
+	// empty (the default), the token endpoint is derived from Endpoint /
+	// Domain / TenantID as usual. It exists for tests and for private cloud
+	// deployments fronting their own AAD endpoint.
+	TokenURL string `json:"token_url" yaml:"token_url"`
+
 	Deduper utils.Deduper `json:"-" yaml:"-"`
+
+	// PollInterval is how long to wait between polling cycles. It is not
+	// settable through a config file; it exists as a seam for tests. Defaults
+	// to 5 minutes.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *Office365Config) Validate() error {
@@ -112,14 +136,32 @@ func (c *Office365Config) Validate() error {
 		return errors.New("missing endpoint")
 	}
 	_, ok := URL[c.Endpoint]
-	if !strings.HasPrefix(c.Endpoint, "https://") && !ok {
+	if !isURLEndpoint(c.Endpoint) && !ok {
 		return fmt.Errorf("invalid endpoint, not https or in %v", URL)
 	}
 	return nil
 }
 
+// isURLEndpoint reports whether the configured endpoint is an explicit URL
+// rather than one of the named environments. http is accepted (in addition to
+// https) so local mocks/tests can stand in for the Management API.
+func isURLEndpoint(endpoint string) bool {
+	return strings.HasPrefix(endpoint, "https://") || strings.HasPrefix(endpoint, "http://")
+}
+
 func NewOffice365Adapter(ctx context.Context, conf Office365Config) (*Office365Adapter, chan struct{}, error) {
+	return newOffice365Adapter(ctx, conf, nil)
+}
+
+// newOffice365Adapter is the implementation behind NewOffice365Adapter. When
+// sink is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newOffice365Adapter(ctx context.Context, conf Office365Config, sink uspSink) (*Office365Adapter, chan struct{}, error) {
 	var err error
+
+	if conf.PollInterval <= 0 {
+		conf.PollInterval = defaultPollInterval
+	}
 
 	// If no deduper is provided, use a local one.
 	if conf.Deduper == nil {
@@ -135,7 +177,7 @@ func NewOffice365Adapter(ctx context.Context, conf Office365Config) (*Office365A
 		doStop: utils.NewEvent(),
 	}
 
-	if strings.HasPrefix(conf.Endpoint, "https://") {
+	if isURLEndpoint(conf.Endpoint) {
 		a.endpoint = conf.Endpoint
 		a.endpointType = "custom"
 	} else if v, ok := URL[conf.Endpoint]; ok {
@@ -145,9 +187,13 @@ func NewOffice365Adapter(ctx context.Context, conf Office365Config) (*Office365A
 		return nil, nil, fmt.Errorf("not a valid api endpoint: %s", conf.Endpoint)
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	a.httpClient = &http.Client{
@@ -232,7 +278,7 @@ func (a *Office365Adapter) fetchEvents(url string) {
 
 	nextPage := ""
 	isFirstRun := true
-	for isFirstRun || (nextPage != "" && !a.doStop.IsSet()) || !a.doStop.WaitFor(5*time.Minute) {
+	for isFirstRun || (nextPage != "" && !a.doStop.IsSet()) || !a.doStop.WaitFor(a.conf.PollInterval) {
 		if nextPage == "" {
 			now := time.Now().UTC()
 			start := a.conf.StartTime
@@ -327,6 +373,11 @@ func (a *Office365Adapter) updateBearerToken() error {
 		// Fallback to enterprise settings
 		tokenURL = fmt.Sprintf("https://login.windows.net/%s/oauth2/token?api-version=1.0", a.conf.Domain)
 		resourceScope = "https://manage.office.com"
+	}
+
+	// An explicit token_url overrides whatever was derived above.
+	if a.conf.TokenURL != "" {
+		tokenURL = a.conf.TokenURL
 	}
 
 	var conf *clientcredentials.Config

--- a/o365/client_test.go
+++ b/o365/client_test.go
@@ -1,0 +1,103 @@
+package usp_o365
+
+import (
+	"testing"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// validConfig returns a config that passes Validate; individual tests blank out
+// fields to assert each one is required.
+func validConfig(t *testing.T) Office365Config {
+	t.Helper()
+	return Office365Config{
+		ClientOptions: testClientOptions(t),
+		Domain:        testDomain,
+		TenantID:      testTenantID,
+		PublisherID:   testPublisherID,
+		ClientID:      testClientID,
+		ClientSecret:  testClientSecret,
+		Endpoint:      "enterprise",
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("valid named endpoint passes", func(t *testing.T) {
+		c := validConfig(t)
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("every named endpoint passes", func(t *testing.T) {
+		for name := range URL {
+			c := validConfig(t)
+			c.Endpoint = name
+			assert.NoError(t, c.Validate(), "endpoint %q should be accepted", name)
+		}
+	})
+
+	t.Run("custom https endpoint passes", func(t *testing.T) {
+		c := validConfig(t)
+		c.Endpoint = "https://manage.contoso.example.com/api/v1.0/"
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("invalid endpoint rejected", func(t *testing.T) {
+		c := validConfig(t)
+		c.Endpoint = "not-a-real-endpoint"
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("required fields", func(t *testing.T) {
+		for name, blank := range map[string]func(*Office365Config){
+			"domain":        func(c *Office365Config) { c.Domain = "" },
+			"tenant_id":     func(c *Office365Config) { c.TenantID = "" },
+			"publisher_id":  func(c *Office365Config) { c.PublisherID = "" },
+			"client_id":     func(c *Office365Config) { c.ClientID = "" },
+			"client_secret": func(c *Office365Config) { c.ClientSecret = "" },
+			"endpoint":      func(c *Office365Config) { c.Endpoint = "" },
+		} {
+			t.Run(name, func(t *testing.T) {
+				c := validConfig(t)
+				blank(&c)
+				assert.Error(t, c.Validate(), "missing %s must fail validation", name)
+			})
+		}
+	})
+
+	t.Run("invalid client_options rejected", func(t *testing.T) {
+		c := validConfig(t)
+		c.ClientOptions = uspclient.ClientOptions{}
+		assert.Error(t, c.Validate())
+	})
+}
+
+// TestNamedEndpointTables verifies every named endpoint has a matching token
+// URL and resource scope -- the constructor and updateBearerToken index these
+// maps by the same key.
+func TestNamedEndpointTables(t *testing.T) {
+	for name := range URL {
+		_, hasToken := TokenURL[name]
+		require.True(t, hasToken, "endpoint %q has no token URL", name)
+		_, hasScope := ResourceScope[name]
+		require.True(t, hasScope, "endpoint %q has no resource scope", name)
+	}
+}

--- a/o365/mock_test.go
+++ b/o365/mock_test.go
@@ -1,0 +1,829 @@
+package usp_o365
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock of the Office 365
+// Management Activity API (token endpoint, subscription start, content listing
+// with NextPageUri pagination, and content blobs), capturing the exact messages
+// shipped so their content can be asserted.
+
+// All fixture identifiers are deliberately fake (example.com users, all-same
+// digit UUIDs, made-up tokens).
+const (
+	testTenantID     = "11111111-1111-1111-1111-111111111111"
+	testPublisherID  = "22222222-2222-2222-2222-222222222222"
+	testClientID     = "33333333-3333-3333-3333-333333333333"
+	testClientSecret = "fake-client-secret-for-tests"
+	testAccessToken  = "fake-access-token-1111111111"
+	testDomain       = "tenant.example.com"
+
+	// aadTimeLayout is the (zone-less) layout the adapter renders startTime /
+	// endTime in, and the layout the real Management Activity API uses for
+	// CreationTime.
+	aadTimeLayout = "2006-01-02T15:04:05"
+)
+
+// --- in-memory USP sink -------------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// payloadCounts returns, per shipped TextPayload, how many times it shipped.
+func (s *captureSink) payloadCounts() map[string]int {
+	out := map[string]int{}
+	for _, m := range s.snapshot() {
+		out[m.TextPayload]++
+	}
+	return out
+}
+
+// --- realistic record fixtures ------------------------------------------------
+
+// auditRecord returns a compact-JSON Management Activity audit record with the
+// documented common-schema fields (Id, RecordType, CreationTime, Operation,
+// OrganizationId, UserType, UserKey, Workload, ResultStatus, ObjectId, UserId,
+// ClientIP) plus an ExtendedProperties array. The returned string is the exact
+// byte sequence the mock serves inside a content blob, so tests can assert the
+// adapter ships it verbatim.
+func auditRecord(t *testing.T, id, operation, workload, userID string, creationTime time.Time) string {
+	t.Helper()
+	rec := map[string]interface{}{
+		"Id":             id,
+		"RecordType":     15,
+		"CreationTime":   creationTime.UTC().Format(aadTimeLayout),
+		"Operation":      operation,
+		"OrganizationId": testTenantID,
+		"UserType":       0,
+		"UserKey":        userID,
+		"Workload":       workload,
+		"ResultStatus":   "Succeeded",
+		"ObjectId":       "Unknown",
+		"UserId":         userID,
+		"ClientIP":       "203.0.113.42",
+		"ExtendedProperties": []map[string]interface{}{
+			{"Name": "UserAgent", "Value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"},
+			{"Name": "RequestType", "Value": "OAuth2:Authorize"},
+		},
+	}
+	b, err := json.Marshal(rec)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// --- mock Office 365 Management Activity API ----------------------------------
+
+// contentBlob is one unit of available content: a listItem in the content
+// listing pointing at a blob URI that serves an array of audit records.
+type contentBlob struct {
+	id      string
+	created time.Time
+	records []string // pre-marshaled JSON objects, served verbatim
+}
+
+// mockO365 reproduces the parts of the AAD token endpoint and the Office 365
+// Management Activity API the adapter relies on:
+//
+//   - POST /oauth2/token: OAuth2 client-credentials grant. Accepts the
+//     credentials either as HTTP basic auth or as form values (the oauth2
+//     library auto-detects the style), requires grant_type=client_credentials
+//     and the manage.office.com resource, and returns a bearer token.
+//   - POST /api/v1.0/{tenant}/activity/feed/subscriptions/start: requires the
+//     bearer token and a contentType / PublisherIdentifier query.
+//   - GET /api/v1.0/{tenant}/activity/feed/subscriptions/content: lists the
+//     blobs of a content type whose contentCreated falls inside the request's
+//     [startTime, endTime] window, paginating via the NextPageUri response
+//     header when listPageSize is set.
+//   - GET /api/v1.0/{tenant}/activity/feed/audit/{contentId}: serves the
+//     blob's records as a JSON array.
+type mockO365 struct {
+	t *testing.T
+
+	mu      sync.Mutex
+	baseURL string
+
+	clientID     string
+	clientSecret string
+
+	listPageSize int // 0 = everything in one page
+
+	alreadyEnabled bool // subscriptions/start answers 400 "already enabled"
+
+	blobs map[string][]contentBlob // contentType -> available blobs
+
+	tokenRequests     int
+	subscriptionStart map[string]int // contentType -> times started
+	listRequests      int
+	pagedListRequests int             // list requests that carried a nextPage token
+	listWindows       []time.Duration // endTime-startTime per (unpaged) list request
+}
+
+func newMockO365(t *testing.T) *mockO365 {
+	t.Helper()
+	m := &mockO365{
+		t:                 t,
+		clientID:          testClientID,
+		clientSecret:      testClientSecret,
+		blobs:             map[string][]contentBlob{},
+		subscriptionStart: map[string]int{},
+	}
+	server := httptest.NewServer(m.handler())
+	m.mu.Lock()
+	m.baseURL = server.URL
+	m.mu.Unlock()
+	t.Cleanup(server.Close)
+	return m
+}
+
+func (m *mockO365) base() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.baseURL
+}
+
+// endpoint returns the Management API root to put in the adapter config; the
+// adapter appends "{tenant}/activity/feed/..." to it, so it ends with "/".
+func (m *mockO365) endpoint() string { return m.base() + "/api/v1.0/" }
+
+// tokenURL returns the OAuth2 token endpoint to put in the adapter config.
+func (m *mockO365) tokenURL() string { return m.base() + "/oauth2/token" }
+
+func (m *mockO365) addBlob(contentType string, blob contentBlob) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.blobs[contentType] = append(m.blobs[contentType], blob)
+}
+
+func (m *mockO365) tokenRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests
+}
+
+func (m *mockO365) startCount(contentType string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.subscriptionStart[contentType]
+}
+
+func (m *mockO365) pagedListCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pagedListRequests
+}
+
+func (m *mockO365) windows() []time.Duration {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]time.Duration, len(m.listWindows))
+	copy(out, m.listWindows)
+	return out
+}
+
+func (m *mockO365) handler() http.Handler {
+	apiRoot := "/api/v1.0/" + testTenantID
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oauth2/token":
+			m.handleToken(w, r)
+		case r.URL.Path == apiRoot+"/activity/feed/subscriptions/start":
+			m.handleStart(w, r)
+		case r.URL.Path == apiRoot+"/activity/feed/subscriptions/content":
+			m.handleList(w, r)
+		case strings.HasPrefix(r.URL.Path, apiRoot+"/activity/feed/audit/"):
+			m.handleBlob(w, r, strings.TrimPrefix(r.URL.Path, apiRoot+"/activity/feed/audit/"))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// handleToken implements the AAD v1.0 client-credentials token endpoint.
+func (m *mockO365) handleToken(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.tokenRequests++
+	m.mu.Unlock()
+
+	if !assert.Equal(m.t, http.MethodPost, r.Method, "token endpoint expects POST") {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "invalid_request"})
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_request"})
+		return
+	}
+
+	if r.PostFormValue("grant_type") != "client_credentials" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":             "unsupported_grant_type",
+			"error_description": "AADSTS70003: The app requested an unsupported grant type.",
+		})
+		return
+	}
+
+	// The oauth2 library auto-detects the auth style: it may send the client
+	// credentials as (query-escaped) HTTP basic auth or as form values.
+	id, secret := r.PostFormValue("client_id"), r.PostFormValue("client_secret")
+	if u, p, ok := r.BasicAuth(); ok {
+		id, _ = url.QueryUnescape(u)
+		secret, _ = url.QueryUnescape(p)
+	}
+	if id != m.clientID || secret != m.clientSecret {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{
+			"error":             "invalid_client",
+			"error_description": "AADSTS7000215: Invalid client secret provided.",
+		})
+		return
+	}
+
+	// The v1.0 endpoint requires the resource the token is for; the adapter
+	// must request the Management API resource or the real AAD would mint a
+	// token the Management API rejects.
+	if res := r.PostFormValue("resource"); !assert.Equal(m.t, "https://manage.office.com", res, "token request must carry the manage.office.com resource") {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":             "invalid_resource",
+			"error_description": "AADSTS500011: The resource principal was not found.",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"token_type":   "Bearer",
+		"expires_in":   3599,
+		"access_token": testAccessToken,
+		"resource":     "https://manage.office.com",
+	})
+}
+
+func (m *mockO365) authorized(w http.ResponseWriter, r *http.Request) bool {
+	if r.Header.Get("Authorization") == "Bearer "+testAccessToken {
+		return true
+	}
+	writeJSON(w, http.StatusUnauthorized, map[string]interface{}{
+		"error": map[string]string{"code": "AF10001", "message": "The permission set on the request does not allow access."},
+	})
+	return false
+}
+
+func (m *mockO365) handleStart(w http.ResponseWriter, r *http.Request) {
+	if !assert.Equal(m.t, http.MethodPost, r.Method, "subscriptions/start expects POST") {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "invalid_request"})
+		return
+	}
+	if !m.authorized(w, r) {
+		return
+	}
+	q := r.URL.Query()
+	ct := q.Get("contentType")
+	if !assert.NotEmpty(m.t, ct, "subscriptions/start must carry contentType") ||
+		!assert.Equal(m.t, testPublisherID, q.Get("PublisherIdentifier"), "subscriptions/start must carry PublisherIdentifier") {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"error": map[string]string{"code": "AF20055", "message": "Invalid parameters."},
+		})
+		return
+	}
+
+	m.mu.Lock()
+	m.subscriptionStart[ct]++
+	alreadyEnabled := m.alreadyEnabled
+	m.mu.Unlock()
+
+	if alreadyEnabled {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"error": map[string]string{"code": "AF20024", "message": "The subscription is already enabled. No property change."},
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"contentType": ct,
+		"status":      "enabled",
+		"webhook":     nil,
+	})
+}
+
+func (m *mockO365) handleList(w http.ResponseWriter, r *http.Request) {
+	if !assert.Equal(m.t, http.MethodGet, r.Method, "subscriptions/content expects GET") {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "invalid_request"})
+		return
+	}
+	if !m.authorized(w, r) {
+		return
+	}
+	q := r.URL.Query()
+	ct := q.Get("contentType")
+	if !assert.NotEmpty(m.t, ct, "subscriptions/content must carry contentType") ||
+		!assert.Equal(m.t, testPublisherID, q.Get("PublisherIdentifier"), "subscriptions/content must carry PublisherIdentifier") {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"error": map[string]string{"code": "AF20055", "message": "Invalid parameters."},
+		})
+		return
+	}
+
+	start, errS := time.Parse(aadTimeLayout, q.Get("startTime"))
+	end, errE := time.Parse(aadTimeLayout, q.Get("endTime"))
+	if !assert.NoError(m.t, errS, "startTime must be yyyy-MM-ddTHH:mm:ss") ||
+		!assert.NoError(m.t, errE, "endTime must be yyyy-MM-ddTHH:mm:ss") {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"error": map[string]string{"code": "AF20055", "message": "Invalid startTime/endTime."},
+		})
+		return
+	}
+
+	page := 0
+	if v := q.Get("nextPage"); v != "" {
+		page, _ = strconv.Atoi(v)
+	}
+
+	m.mu.Lock()
+	m.listRequests++
+	if page > 0 {
+		m.pagedListRequests++
+	} else {
+		m.listWindows = append(m.listWindows, end.Sub(start))
+	}
+	var inWindow []contentBlob
+	for _, b := range m.blobs[ct] {
+		created := b.created.UTC()
+		if !created.Before(start) && !created.After(end) {
+			inWindow = append(inWindow, b)
+		}
+	}
+	pageSize := m.listPageSize
+	base := m.baseURL
+	m.mu.Unlock()
+
+	if pageSize <= 0 {
+		pageSize = len(inWindow) + 1
+	}
+	lo := page * pageSize
+	hi := lo + pageSize
+	if lo > len(inWindow) {
+		lo = len(inWindow)
+	}
+	if hi > len(inWindow) {
+		hi = len(inWindow)
+	}
+
+	// More content available: hand back a NextPageUri header pointing at the
+	// next page, the way the real API paginates.
+	if hi < len(inWindow) {
+		nq := r.URL.Query()
+		nq.Set("nextPage", strconv.Itoa(page+1))
+		w.Header().Set("NextPageUri", base+r.URL.Path+"?"+nq.Encode())
+	}
+
+	items := make([]map[string]string, 0, hi-lo)
+	for _, b := range inWindow[lo:hi] {
+		items = append(items, map[string]string{
+			"contentType":       ct,
+			"contentId":         b.id,
+			"contentUri":        base + "/api/v1.0/" + testTenantID + "/activity/feed/audit/" + b.id,
+			"contentCreated":    b.created.UTC().Format("2006-01-02T15:04:05.000Z"),
+			"contentExpiration": b.created.UTC().Add(7 * 24 * time.Hour).Format("2006-01-02T15:04:05.000Z"),
+		})
+	}
+	writeJSON(w, http.StatusOK, items)
+}
+
+func (m *mockO365) handleBlob(w http.ResponseWriter, r *http.Request, id string) {
+	if !m.authorized(w, r) {
+		return
+	}
+	m.mu.Lock()
+	var records []string
+	found := false
+	for _, blobs := range m.blobs {
+		for _, b := range blobs {
+			if b.id == id {
+				records = b.records
+				found = true
+			}
+		}
+	}
+	m.mu.Unlock()
+
+	if !found {
+		writeJSON(w, http.StatusNotFound, map[string]interface{}{
+			"error": map[string]string{"code": "AF20051", "message": "Content not found."},
+		})
+		return
+	}
+
+	// Serve the records verbatim so tests can assert byte-for-byte payloads.
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("[" + strings.Join(records, ",") + "]"))
+}
+
+// --- test plumbing --------------------------------------------------------------
+
+// newTestConfig returns an adapter config pointed at the mock, with a fast
+// poll interval.
+func newTestConfig(t *testing.T, m *mockO365, contentTypes string) Office365Config {
+	t.Helper()
+	return Office365Config{
+		ClientOptions: testClientOptions(t),
+		Domain:        testDomain,
+		TenantID:      testTenantID,
+		PublisherID:   testPublisherID,
+		ClientID:      testClientID,
+		ClientSecret:  testClientSecret,
+		Endpoint:      m.endpoint(),
+		TokenURL:      m.tokenURL(),
+		ContentTypes:  contentTypes,
+		PollInterval:  50 * time.Millisecond,
+	}
+}
+
+// --- tests ----------------------------------------------------------------------
+
+// TestMockEndToEnd drives the adapter against the mock API and asserts the
+// exact events shipped: the OAuth2 token is acquired, the subscription is
+// started exactly once, every audit record ships verbatim exactly once with a
+// plausible ship-time timestamp, and re-polling does not re-ship.
+func TestMockEndToEnd(t *testing.T) {
+	const ct = "Audit.AzureActiveDirectory"
+	m := newMockO365(t)
+
+	created := time.Now().UTC().Add(-10 * time.Minute)
+	want := []string{
+		auditRecord(t, "aaaaaaaa-1111-1111-1111-111111111111", "UserLoggedIn", "AzureActiveDirectory", "jdoe@example.com", created),
+		auditRecord(t, "aaaaaaaa-2222-2222-2222-222222222222", "UserLoginFailed", "AzureActiveDirectory", "asmith@example.com", created),
+		auditRecord(t, "aaaaaaaa-3333-3333-3333-333333333333", "Add user.", "AzureActiveDirectory", "admin@example.com", created),
+	}
+	m.addBlob(ct, contentBlob{id: "blob-0001", created: created, records: want[:2]})
+	m.addBlob(ct, contentBlob{id: "blob-0002", created: created, records: want[2:]})
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	before := uint64(time.Now().UnixMilli())
+	adapter, chStopped, err := newOffice365Adapter(ctx, newTestConfig(t, m, ct), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 audit records to ship")
+
+	// Re-polling (poll interval is 50ms, so several polls happen here) must
+	// not re-ship: the count stays at 3.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		400*time.Millisecond, 30*time.Millisecond, "records were re-shipped on a later poll")
+	after := uint64(time.Now().UnixMilli())
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped unexpectedly")
+	default:
+	}
+
+	// Each record shipped verbatim, exactly once.
+	counts := sink.payloadCounts()
+	require.Len(t, counts, 3)
+	for _, rec := range want {
+		assert.Equal(t, 1, counts[rec], "record must ship verbatim exactly once: %s", rec)
+	}
+
+	// The adapter stamps events with the ship time and sets no event type
+	// (the platform mapping handles typing for office365).
+	for _, msg := range sink.snapshot() {
+		assert.Empty(t, msg.EventType)
+		assert.Empty(t, msg.JsonPayload, "o365 ships TextPayload, not JsonPayload")
+		assert.GreaterOrEqual(t, msg.TimestampMs, before)
+		assert.LessOrEqual(t, msg.TimestampMs, after)
+	}
+
+	assert.GreaterOrEqual(t, m.tokenRequestCount(), 1, "the OAuth2 token endpoint must have been used")
+	assert.Equal(t, 1, m.startCount(ct), "the subscription must be started exactly once")
+}
+
+// TestMockMidRunRecordShipsOnce verifies new content appearing between polls is
+// picked up on a later poll and shipped exactly once.
+func TestMockMidRunRecordShipsOnce(t *testing.T) {
+	const ct = "Audit.Exchange"
+	m := newMockO365(t)
+
+	first := auditRecord(t, "bbbbbbbb-1111-1111-1111-111111111111", "MailItemsAccessed", "Exchange", "jdoe@example.com", time.Now().UTC().Add(-15*time.Minute))
+	m.addBlob(ct, contentBlob{id: "blob-first", created: time.Now().UTC().Add(-15 * time.Minute), records: []string{first}})
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newOffice365Adapter(ctx, newTestConfig(t, m, ct), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the initial record should ship")
+
+	// New content becomes available mid-run.
+	second := auditRecord(t, "bbbbbbbb-2222-2222-2222-222222222222", "Send", "Exchange", "asmith@example.com", time.Now().UTC())
+	m.addBlob(ct, contentBlob{id: "blob-second", created: time.Now().UTC(), records: []string{second}})
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "the mid-run record should ship")
+	require.Never(t, func() bool { return sink.count() > 2 },
+		400*time.Millisecond, 30*time.Millisecond, "no record may ship twice")
+
+	counts := sink.payloadCounts()
+	assert.Equal(t, 1, counts[first])
+	assert.Equal(t, 1, counts[second])
+}
+
+// TestMockPaginationNextPageUri verifies a listing spread over several pages
+// (via the NextPageUri response header) is fully consumed within a single poll.
+func TestMockPaginationNextPageUri(t *testing.T) {
+	const ct = "Audit.SharePoint"
+	const total = 5
+	m := newMockO365(t)
+	m.listPageSize = 2 // 5 blobs => 3 pages
+
+	created := time.Now().UTC().Add(-20 * time.Minute)
+	want := make([]string, 0, total)
+	for i := 0; i < total; i++ {
+		rec := auditRecord(t,
+			fmt.Sprintf("cccccccc-%04d-1111-1111-111111111111", i),
+			"FileAccessed", "SharePoint", "jdoe@example.com", created)
+		want = append(want, rec)
+		m.addBlob(ct, contentBlob{id: fmt.Sprintf("blob-%04d", i), created: created, records: []string{rec}})
+	}
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := newTestConfig(t, m, ct)
+	// Only the very first poll may run during the test: every record arriving
+	// proves the NextPageUri chain was walked to the end within one poll.
+	conf.PollInterval = 1 * time.Hour
+	adapter, _, err := newOffice365Adapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		5*time.Second, 20*time.Millisecond, "all paginated records should ship in the first poll")
+	require.Never(t, func() bool { return sink.count() != total },
+		400*time.Millisecond, 30*time.Millisecond)
+
+	assert.GreaterOrEqual(t, m.pagedListCount(), 2, "pages 2 and 3 must be fetched via NextPageUri")
+	counts := sink.payloadCounts()
+	require.Len(t, counts, total)
+	for _, rec := range want {
+		assert.Equal(t, 1, counts[rec], "record must ship exactly once: %s", rec)
+	}
+}
+
+// TestMockMultipleContentTypes verifies each configured content type gets its
+// own subscription and collector, and every record of every type ships once.
+func TestMockMultipleContentTypes(t *testing.T) {
+	m := newMockO365(t)
+	created := time.Now().UTC().Add(-5 * time.Minute)
+
+	aad := []string{
+		auditRecord(t, "dddddddd-1111-1111-1111-111111111111", "UserLoggedIn", "AzureActiveDirectory", "jdoe@example.com", created),
+		auditRecord(t, "dddddddd-2222-2222-2222-222222222222", "Update user.", "AzureActiveDirectory", "admin@example.com", created),
+	}
+	exch := []string{
+		auditRecord(t, "eeeeeeee-1111-1111-1111-111111111111", "MailItemsAccessed", "Exchange", "asmith@example.com", created),
+		auditRecord(t, "eeeeeeee-2222-2222-2222-222222222222", "New-InboxRule", "Exchange", "asmith@example.com", created),
+	}
+	m.addBlob("Audit.AzureActiveDirectory", contentBlob{id: "blob-aad", created: created, records: aad})
+	m.addBlob("Audit.Exchange", contentBlob{id: "blob-exch", created: created, records: exch})
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newOffice365Adapter(ctx,
+		newTestConfig(t, m, "Audit.AzureActiveDirectory, Audit.Exchange"), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 4 },
+		5*time.Second, 20*time.Millisecond, "records of both content types should ship")
+	require.Never(t, func() bool { return sink.count() != 4 },
+		400*time.Millisecond, 30*time.Millisecond)
+
+	assert.Equal(t, 1, m.startCount("Audit.AzureActiveDirectory"))
+	assert.Equal(t, 1, m.startCount("Audit.Exchange"))
+
+	counts := sink.payloadCounts()
+	require.Len(t, counts, 4)
+	for _, rec := range append(append([]string{}, aad...), exch...) {
+		assert.Equal(t, 1, counts[rec])
+	}
+}
+
+// TestMockDefaultContentTypes verifies an empty content_types config falls back
+// to the five standard Management Activity content types, each subscribed.
+func TestMockDefaultContentTypes(t *testing.T) {
+	m := newMockO365(t)
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newOffice365Adapter(ctx, newTestConfig(t, m, ""), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	for _, ct := range []string{
+		"Audit.AzureActiveDirectory", "Audit.Exchange", "Audit.SharePoint", "Audit.General", "DLP.All",
+	} {
+		assert.Equal(t, 1, m.startCount(ct), "default content type %s must be subscribed", ct)
+	}
+	assert.Equal(t, 0, sink.count(), "no content available, nothing should ship")
+}
+
+// TestMockSubscriptionAlreadyEnabled verifies the "subscription already
+// enabled" 400 from subscriptions/start is treated as success and collection
+// proceeds.
+func TestMockSubscriptionAlreadyEnabled(t *testing.T) {
+	const ct = "Audit.General"
+	m := newMockO365(t)
+	m.alreadyEnabled = true
+
+	created := time.Now().UTC().Add(-5 * time.Minute)
+	rec := auditRecord(t, "ffffffff-1111-1111-1111-111111111111", "AlertTriggered", "SecurityComplianceCenter", "admin@example.com", created)
+	m.addBlob(ct, contentBlob{id: "blob-already", created: created, records: []string{rec}})
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newOffice365Adapter(ctx, newTestConfig(t, m, ct), sink)
+	require.NoError(t, err, "an already-enabled subscription is not an error")
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "collection should proceed past 'already enabled'")
+	assert.Equal(t, rec, sink.snapshot()[0].TextPayload)
+}
+
+// TestMockBadCredentials verifies the adapter constructor fails -- and nothing
+// ships -- when AAD rejects the client credentials.
+func TestMockBadCredentials(t *testing.T) {
+	const ct = "Audit.AzureActiveDirectory"
+	m := newMockO365(t)
+	created := time.Now().UTC().Add(-5 * time.Minute)
+	m.addBlob(ct, contentBlob{id: "blob-x", created: created, records: []string{
+		auditRecord(t, "99999999-1111-1111-1111-111111111111", "UserLoggedIn", "AzureActiveDirectory", "jdoe@example.com", created),
+	}})
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := newTestConfig(t, m, ct)
+	conf.ClientSecret = "wrong-secret"
+	adapter, chStopped, err := newOffice365Adapter(ctx, conf, sink)
+	require.Error(t, err, "bad credentials must fail the constructor")
+	assert.Nil(t, adapter)
+	assert.Nil(t, chStopped)
+	assert.GreaterOrEqual(t, m.tokenRequestCount(), 1, "the token endpoint must have been tried")
+	assert.Equal(t, 0, sink.count(), "nothing may ship when authentication fails")
+}
+
+// TestMockTimeWindowHonored verifies polls request a 3-hour lookback window and
+// that only content inside the window is collected.
+func TestMockTimeWindowHonored(t *testing.T) {
+	const ct = "Audit.SharePoint"
+	m := newMockO365(t)
+
+	oldRec := auditRecord(t, "11110000-1111-1111-1111-111111111111", "FileDeleted", "SharePoint", "jdoe@example.com", time.Now().UTC().Add(-5*time.Hour))
+	newRec := auditRecord(t, "22220000-2222-2222-2222-222222222222", "FileAccessed", "SharePoint", "asmith@example.com", time.Now().UTC().Add(-10*time.Minute))
+	m.addBlob(ct, contentBlob{id: "blob-old", created: time.Now().UTC().Add(-5 * time.Hour), records: []string{oldRec}})
+	m.addBlob(ct, contentBlob{id: "blob-new", created: time.Now().UTC().Add(-10 * time.Minute), records: []string{newRec}})
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newOffice365Adapter(ctx, newTestConfig(t, m, ct), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the in-window record should ship")
+	require.Never(t, func() bool { return sink.count() != 1 },
+		400*time.Millisecond, 30*time.Millisecond, "the out-of-window record must not ship")
+	assert.Equal(t, newRec, sink.snapshot()[0].TextPayload)
+
+	// Every (unpaged) listing must have asked for exactly a 3-hour window.
+	windows := m.windows()
+	require.NotEmpty(t, windows)
+	for _, w := range windows {
+		assert.Equal(t, 3*time.Hour, w, "list requests must use a 3h lookback window")
+	}
+}
+
+// TestMockDuplicateEventIDAcrossBlobs verifies per-event Id deduplication: the
+// Management Activity API makes no uniqueness guarantee, so the same record
+// appearing in two different content blobs must ship only once.
+func TestMockDuplicateEventIDAcrossBlobs(t *testing.T) {
+	const ct = "Audit.General"
+	m := newMockO365(t)
+
+	created := time.Now().UTC().Add(-5 * time.Minute)
+	dup := auditRecord(t, "55550000-1111-1111-1111-111111111111", "AlertEntityGenerated", "SecurityComplianceCenter", "admin@example.com", created)
+	other := auditRecord(t, "55550000-2222-2222-2222-222222222222", "AlertTriggered", "SecurityComplianceCenter", "admin@example.com", created)
+	m.addBlob(ct, contentBlob{id: "blob-a", created: created, records: []string{dup, other}})
+	m.addBlob(ct, contentBlob{id: "blob-b", created: created, records: []string{dup}})
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newOffice365Adapter(ctx, newTestConfig(t, m, ct), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "two distinct records should ship")
+	require.Never(t, func() bool { return sink.count() != 2 },
+		400*time.Millisecond, 30*time.Millisecond, "the duplicated Id must not ship twice")
+
+	counts := sink.payloadCounts()
+	assert.Equal(t, 1, counts[dup], "duplicate Id across blobs ships once")
+	assert.Equal(t, 1, counts[other])
+}
+
+// TestMockStartTimeFirstPoll verifies a configured start_time widens the very
+// first poll's window so older content is collected once.
+func TestMockStartTimeFirstPoll(t *testing.T) {
+	const ct = "Audit.Exchange"
+	m := newMockO365(t)
+
+	oldRec := auditRecord(t, "33330000-1111-1111-1111-111111111111", "HardDelete", "Exchange", "jdoe@example.com", time.Now().UTC().Add(-5*time.Hour))
+	newRec := auditRecord(t, "44440000-2222-2222-2222-222222222222", "Send", "Exchange", "asmith@example.com", time.Now().UTC().Add(-10*time.Minute))
+	m.addBlob(ct, contentBlob{id: "blob-old", created: time.Now().UTC().Add(-5 * time.Hour), records: []string{oldRec}})
+	m.addBlob(ct, contentBlob{id: "blob-new", created: time.Now().UTC().Add(-10 * time.Minute), records: []string{newRec}})
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := newTestConfig(t, m, ct)
+	conf.StartTime = time.Now().UTC().Add(-6 * time.Hour).Format(aadTimeLayout)
+	adapter, _, err := newOffice365Adapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "start_time should pull in the older record too")
+	require.Never(t, func() bool { return sink.count() != 2 },
+		400*time.Millisecond, 30*time.Millisecond, "nothing may ship twice after the first poll")
+
+	counts := sink.payloadCounts()
+	assert.Equal(t, 1, counts[oldRec])
+	assert.Equal(t, 1, counts[newRec])
+}

--- a/o365/mock_test.go
+++ b/o365/mock_test.go
@@ -82,17 +82,31 @@ func (s *captureSink) payloadCounts() map[string]int {
 
 // --- realistic record fixtures ------------------------------------------------
 
+// recordTypes maps a workload to a documented AuditLogRecordType value, per
+// https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-schema
+// (15 = AzureActiveDirectoryStsLogon, 2 = ExchangeItem, 6 =
+// SharePointFileOperation, 40 = SecurityComplianceAlerts).
+var recordTypes = map[string]int{
+	"AzureActiveDirectory":     15,
+	"Exchange":                 2,
+	"SharePoint":               6,
+	"SecurityComplianceCenter": 40,
+}
+
 // auditRecord returns a compact-JSON Management Activity audit record with the
 // documented common-schema fields (Id, RecordType, CreationTime, Operation,
 // OrganizationId, UserType, UserKey, Workload, ResultStatus, ObjectId, UserId,
-// ClientIP) plus an ExtendedProperties array. The returned string is the exact
-// byte sequence the mock serves inside a content blob, so tests can assert the
-// adapter ships it verbatim.
+// ClientIP). AzureActiveDirectory records additionally carry the
+// ExtendedProperties Name/Value array of the documented Entra ID base schema.
+// The returned string is the exact byte sequence the mock serves inside a
+// content blob, so tests can assert the adapter ships it verbatim.
 func auditRecord(t *testing.T, id, operation, workload, userID string, creationTime time.Time) string {
 	t.Helper()
+	recordType, ok := recordTypes[workload]
+	require.True(t, ok, "no documented RecordType mapped for workload %q", workload)
 	rec := map[string]interface{}{
 		"Id":             id,
-		"RecordType":     15,
+		"RecordType":     recordType,
 		"CreationTime":   creationTime.UTC().Format(aadTimeLayout),
 		"Operation":      operation,
 		"OrganizationId": testTenantID,
@@ -103,10 +117,12 @@ func auditRecord(t *testing.T, id, operation, workload, userID string, creationT
 		"ObjectId":       "Unknown",
 		"UserId":         userID,
 		"ClientIP":       "203.0.113.42",
-		"ExtendedProperties": []map[string]interface{}{
+	}
+	if workload == "AzureActiveDirectory" {
+		rec["ExtendedProperties"] = []map[string]interface{}{
 			{"Name": "UserAgent", "Value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"},
 			{"Name": "RequestType", "Value": "OAuth2:Authorize"},
-		},
+		}
 	}
 	b, err := json.Marshal(rec)
 	require.NoError(t, err)
@@ -134,8 +150,8 @@ type contentBlob struct {
 //     bearer token and a contentType / PublisherIdentifier query.
 //   - GET /api/v1.0/{tenant}/activity/feed/subscriptions/content: lists the
 //     blobs of a content type whose contentCreated falls inside the request's
-//     [startTime, endTime] window, paginating via the NextPageUri response
-//     header when listPageSize is set.
+//     window (startTime <= contentCreated < endTime, per the API reference),
+//     paginating via the NextPageUri response header when listPageSize is set.
 //   - GET /api/v1.0/{tenant}/activity/feed/audit/{contentId}: serves the
 //     blob's records as a JSON array.
 type mockO365 struct {
@@ -337,6 +353,11 @@ func (m *mockO365) handleStart(w http.ResponseWriter, r *http.Request) {
 	m.mu.Unlock()
 
 	if alreadyEnabled {
+		// Observed live behavior of subscriptions/start on an already-enabled
+		// subscription: HTTP 400 with code AF20024. The code/message is not in
+		// the official error table (MicrosoftDocs/office-365-management-api
+		// issue #387) but the message text is what the real API returns; the
+		// adapter matches on its "already enabled" substring.
 		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
 			"error": map[string]string{"code": "AF20024", "message": "The subscription is already enabled. No property change."},
 		})
@@ -391,8 +412,10 @@ func (m *mockO365) handleList(w http.ResponseWriter, r *http.Request) {
 	}
 	var inWindow []contentBlob
 	for _, b := range m.blobs[ct] {
+		// The documented window is inclusive of startTime and exclusive of
+		// endTime: startTime <= contentCreated < endTime.
 		created := b.created.UTC()
-		if !created.Before(start) && !created.After(end) {
+		if !created.Before(start) && created.Before(end) {
 			inWindow = append(inWindow, b)
 		}
 	}

--- a/okta/client.go
+++ b/okta/client.go
@@ -19,7 +19,20 @@ import (
 const (
 	logsURL       = "/api/v1/logs"
 	overlapPeriod = 30 * time.Minute
+
+	// defaultPollInterval is how long fetchEvents idles between polls of the
+	// System Log endpoint.
+	defaultPollInterval = 30 * time.Second
 )
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
 
 type opRequest struct {
 	Limit     int    `json:"page[size],omitempty"`
@@ -29,8 +42,10 @@ type opRequest struct {
 
 type OktaAdapter struct {
 	conf       OktaConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
+
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -45,6 +60,11 @@ type OktaConfig struct {
 	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 	ApiKey        string                  `json:"apikey" yaml:"apikey"`
 	URL           string                  `json:"url" yaml:"url"`
+
+	// PollInterval overrides the wait between polls of the System Log endpoint
+	// (default 30s). It is not settable through a config file; it exists as a
+	// seam for tests.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *OktaConfig) Validate() error {
@@ -61,7 +81,13 @@ func (c *OktaConfig) Validate() error {
 }
 
 func NewOktaAdapter(ctx context.Context, conf OktaConfig) (*OktaAdapter, chan struct{}, error) {
-	var err error
+	return newOktaAdapter(ctx, conf, nil)
+}
+
+// newOktaAdapter is the implementation behind NewOktaAdapter. When sink is
+// non-nil it is used in place of a real LimaCharlie client -- the seam tests
+// use to capture shipped events.
+func newOktaAdapter(ctx context.Context, conf OktaConfig, sink uspSink) (*OktaAdapter, chan struct{}, error) {
 	a := &OktaAdapter{
 		conf:   conf,
 		ctx:    context.Background(),
@@ -69,9 +95,19 @@ func NewOktaAdapter(ctx context.Context, conf OktaConfig) (*OktaAdapter, chan st
 		dedupe: make(map[string]int64),
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	a.pollInterval = conf.PollInterval
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -116,7 +152,7 @@ func (a *OktaAdapter) fetchEvents(url string) {
 	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching of %s events exiting", url))
 
 	adapterStart := time.Now()
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// The makeOneRequest function handles error
 		// handling and fatal error handling.
 		items := a.makeOneRequest(url, adapterStart)

--- a/okta/client_test.go
+++ b/okta/client_test.go
@@ -1,0 +1,178 @@
+package usp_okta
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "okta",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// newDirectAdapter builds an adapter wired to a server without starting any
+// goroutines -- for unit testing makeOneRequest in isolation.
+func newDirectAdapter(t *testing.T, baseURL, token string) *OktaAdapter {
+	t.Helper()
+	return &OktaAdapter{
+		conf: OktaConfig{
+			ClientOptions: testClientOptions(t),
+			ApiKey:        token,
+			URL:           baseURL,
+		},
+		httpClient:   &http.Client{Timeout: 5 * time.Second},
+		pollInterval: time.Hour,
+		doStop:       utils.NewEvent(),
+		dedupe:       map[string]int64{},
+		ctx:          context.Background(),
+	}
+}
+
+// --- unit tests ---------------------------------------------------------------
+
+func TestValidate(t *testing.T) {
+	t.Run("requires url", func(t *testing.T) {
+		c := OktaConfig{ClientOptions: testClientOptions(t), ApiKey: "k"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires api key", func(t *testing.T) {
+		c := OktaConfig{ClientOptions: testClientOptions(t), URL: "https://example.okta.com"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("accepts a complete config", func(t *testing.T) {
+		c := OktaConfig{ClientOptions: testClientOptions(t), ApiKey: "k", URL: "https://example.okta.com"}
+		assert.NoError(t, c.Validate())
+	})
+}
+
+func TestPollIntervalSeam(t *testing.T) {
+	t.Run("defaults to 30s", func(t *testing.T) {
+		sink := &captureSink{}
+		conf := OktaConfig{
+			ClientOptions: testClientOptions(t),
+			ApiKey:        "k",
+			URL:           "http://127.0.0.1:1", // never polled: the first poll waits pollInterval
+		}
+		adapter, _, err := newOktaAdapter(context.Background(), conf, sink)
+		require.NoError(t, err)
+		defer adapter.Close()
+		assert.Equal(t, defaultPollInterval, adapter.pollInterval)
+	})
+
+	t.Run("test override applies", func(t *testing.T) {
+		sink := &captureSink{}
+		conf := OktaConfig{
+			ClientOptions: testClientOptions(t),
+			ApiKey:        "k",
+			URL:           "http://127.0.0.1:1",
+			PollInterval:  time.Hour,
+		}
+		adapter, _, err := newOktaAdapter(context.Background(), conf, sink)
+		require.NoError(t, err)
+		defer adapter.Close()
+		assert.Equal(t, time.Hour, adapter.pollInterval)
+	})
+}
+
+// TestMakeOneRequestDedupe verifies a second poll over the same (overlapping)
+// window returns no events: the per-uuid deduper suppresses everything already
+// reported.
+func TestMakeOneRequestDedupe(t *testing.T) {
+	const token = "tok-dedupe"
+
+	mock := newMockOktaSystemLog(token)
+	published := time.Now().UTC().Add(-5 * time.Minute)
+	mock.addEvent(systemLogEvent("11111111-aaaa-1111-1111-111111111111", "user.session.start", published))
+	mock.addEvent(systemLogEvent("22222222-aaaa-1111-1111-111111111111", "user.session.end", published))
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	a := newDirectAdapter(t, server.URL, token)
+	notBefore := time.Now().Add(-10 * time.Minute)
+
+	first := a.makeOneRequest(logsURL, notBefore)
+	require.Len(t, first, 2, "first poll must return both events")
+
+	second := a.makeOneRequest(logsURL, notBefore)
+	assert.Empty(t, second, "re-polling the same window must not return already-seen events")
+	assert.Equal(t, 2, mock.requestCount())
+}
+
+// TestMakeOneRequestNon200 verifies a non-200 response yields no items and is
+// reported via OnError (the adapter keeps running and retries next poll).
+func TestMakeOneRequestNon200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"errorCode":"E0000009","errorSummary":"Internal Server Error"}`))
+	}))
+	defer server.Close()
+
+	var mu sync.Mutex
+	var errCount int
+	a := newDirectAdapter(t, server.URL, "tok")
+	a.conf.ClientOptions.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		mu.Lock()
+		errCount++
+		mu.Unlock()
+	}
+
+	items := a.makeOneRequest(logsURL, time.Now().Add(-10*time.Minute))
+	assert.Nil(t, items)
+	mu.Lock()
+	assert.Equal(t, 1, errCount, "a non-200 must be reported via OnError")
+	mu.Unlock()
+	assert.False(t, a.doStop.IsSet(), "a non-200 must not stop the adapter")
+}
+
+// TestMakeOneRequestInvalidJSON verifies a malformed body yields no items and
+// is reported via OnError.
+func TestMakeOneRequestInvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`this is not json`))
+	}))
+	defer server.Close()
+
+	var mu sync.Mutex
+	var errCount int
+	a := newDirectAdapter(t, server.URL, "tok")
+	a.conf.ClientOptions.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		mu.Lock()
+		errCount++
+		mu.Unlock()
+	}
+
+	items := a.makeOneRequest(logsURL, time.Now().Add(-10*time.Minute))
+	assert.Nil(t, items)
+	mu.Lock()
+	assert.Equal(t, 1, errCount, "invalid JSON must be reported via OnError")
+	mu.Unlock()
+	assert.False(t, a.doStop.IsSet(), "invalid JSON must not stop the adapter")
+}

--- a/okta/mock_test.go
+++ b/okta/mock_test.go
@@ -1,0 +1,525 @@
+package usp_okta
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock Okta System Log
+// API (GET /api/v1/logs), capturing the exact messages it ships so their
+// content -- timestamp and verbatim payload -- can be asserted.
+//
+// Mock fidelity notes:
+//   - Authentication is the SSWS API token scheme: `Authorization: SSWS <token>`;
+//     a bad token gets Okta's E0000011 error body with HTTP 401.
+//   - The mock honours the `since`/`until` query parameters the adapter sends
+//     (both RFC3339): only events whose `published` falls inside the inclusive
+//     window are returned, exactly like the real System Log bounded query.
+//   - The response is a bare JSON array of System Log events. The mock also
+//     sets a `Link: rel="self"` header like the real API. It does NOT emulate
+//     Link rel="next" pagination: the real API caps a response (default 100,
+//     max 1000 events) and exposes the rest through an `after` cursor in a
+//     Link header -- but the adapter performs exactly one request per poll and
+//     never follows Link headers, so the mock returns the full window in a
+//     single response, matching how the adapter consumes the API.
+
+// --- in-memory USP sink -------------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Okta System Log API ---------------------------------------------------
+
+// mockOktaSystemLog is an in-memory stand-in for the Okta System Log API.
+type mockOktaSystemLog struct {
+	mu     sync.Mutex
+	token  string
+	events []utils.Dict
+
+	requests   int
+	lastMethod string
+	lastPath   string
+	lastAuth   string
+	lastSince  string
+	lastUntil  string
+}
+
+func newMockOktaSystemLog(token string) *mockOktaSystemLog {
+	return &mockOktaSystemLog{token: token}
+}
+
+// addEvent appends an event to the log, as the real API would when a new
+// System Log event is recorded.
+func (m *mockOktaSystemLog) addEvent(event utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, event)
+}
+
+func (m *mockOktaSystemLog) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+func (m *mockOktaSystemLog) lastRequest() (method, path, auth, since, until string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastMethod, m.lastPath, m.lastAuth, m.lastSince, m.lastUntil
+}
+
+func oktaError(w http.ResponseWriter, status int, code, summary string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"errorCode":    code,
+		"errorSummary": summary,
+		"errorLink":    code,
+		"errorId":      "oae1111111111111111111111",
+		"errorCauses":  []interface{}{},
+	})
+}
+
+func (m *mockOktaSystemLog) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+
+		m.mu.Lock()
+		m.requests++
+		m.lastMethod = r.Method
+		m.lastPath = r.URL.Path
+		m.lastAuth = r.Header.Get("Authorization")
+		m.lastSince = q.Get("since")
+		m.lastUntil = q.Get("until")
+		token := m.token
+		events := append([]utils.Dict(nil), m.events...)
+		m.mu.Unlock()
+
+		if r.Method != http.MethodGet {
+			oktaError(w, http.StatusMethodNotAllowed, "E0000022", "The endpoint does not support the provided HTTP method")
+			return
+		}
+		if r.URL.Path != logsURL {
+			oktaError(w, http.StatusNotFound, "E0000007", "Not found")
+			return
+		}
+		if r.Header.Get("Authorization") != "SSWS "+token {
+			oktaError(w, http.StatusUnauthorized, "E0000011", "Invalid token provided")
+			return
+		}
+
+		since, err := time.Parse(time.RFC3339, q.Get("since"))
+		if err != nil {
+			oktaError(w, http.StatusBadRequest, "E0000031", "The request was invalid: since")
+			return
+		}
+		until, err := time.Parse(time.RFC3339, q.Get("until"))
+		if err != nil {
+			oktaError(w, http.StatusBadRequest, "E0000031", "The request was invalid: until")
+			return
+		}
+
+		// A bounded query returns the events whose `published` falls inside
+		// the inclusive [since, until] window.
+		page := []utils.Dict{}
+		for _, e := range events {
+			published, perr := time.Parse(time.RFC3339, fmt.Sprintf("%v", e["published"]))
+			if perr != nil {
+				continue
+			}
+			if published.Before(since) || published.After(until) {
+				continue
+			}
+			page = append(page, e)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", fmt.Sprintf("<http://%s%s?since=%s&until=%s>; rel=\"self\"", r.Host, logsURL, q.Get("since"), q.Get("until")))
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(page)
+	}
+}
+
+// --- realistic fixtures ---------------------------------------------------------
+
+// systemLogEvent returns a record shaped like a real Okta System Log event:
+// uuid, published, eventType plus the actor/client/target/outcome/transaction/
+// debugContext structures the real API emits (nested objects, arrays, nulls
+// and mixed scalar types).
+func systemLogEvent(uuid, eventType string, published time.Time) utils.Dict {
+	return utils.Dict{
+		"uuid":           uuid,
+		"published":      published.UTC().Format(time.RFC3339),
+		"eventType":      eventType,
+		"version":        "0",
+		"severity":       "INFO",
+		"displayMessage": "User login to Okta",
+		"actor": utils.Dict{
+			"id":          "00u1111111111111111",
+			"type":        "User",
+			"alternateId": "jdoe@example.com",
+			"displayName": "Jane Doe",
+			"detailEntry": nil,
+		},
+		"client": utils.Dict{
+			"userAgent": utils.Dict{
+				"rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+				"os":           "Mac OS X",
+				"browser":      "CHROME",
+			},
+			"zone":      "null",
+			"device":    "Computer",
+			"id":        nil,
+			"ipAddress": "198.51.100.23",
+			"geographicalContext": utils.Dict{
+				"city":       "Springfield",
+				"state":      "Illinois",
+				"country":    "United States",
+				"postalCode": "62701",
+				"geolocation": utils.Dict{
+					"lat": 39.781,
+					"lon": -89.644,
+				},
+			},
+		},
+		"outcome": utils.Dict{
+			"result": "SUCCESS",
+			"reason": nil,
+		},
+		"target": []interface{}{
+			utils.Dict{
+				"id":          "0oa1111111111111111",
+				"type":        "AppInstance",
+				"alternateId": "Example App",
+				"displayName": "Example App",
+				"detailEntry": nil,
+			},
+		},
+		"transaction": utils.Dict{
+			"type":   "WEB",
+			"id":     "AaAaAaAaAaAaAaAaAaAa11",
+			"detail": utils.Dict{},
+		},
+		"authenticationContext": utils.Dict{
+			"authenticationStep": 0,
+			"externalSessionId":  "102Aa11aAaAaAaAaAaAaAaAa1",
+		},
+		"securityContext": utils.Dict{
+			"asNumber": 64496,
+			"asOrg":    "example isp",
+			"isp":      "example isp inc",
+			"domain":   "example.com",
+			"isProxy":  false,
+		},
+		"debugContext": utils.Dict{
+			"debugData": utils.Dict{
+				"requestId":       "req1111111111111111111",
+				"requestUri":      "/api/v1/authn",
+				"threatSuspected": "false",
+			},
+		},
+		"legacyEventType": "core.user_auth.login_success",
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// startMockAdapter builds an adapter wired to the mock server through the
+// injected sink, with a short poll interval so tests run fast.
+func startMockAdapter(t *testing.T, serverURL, token string, sink uspSink) *OktaAdapter {
+	t.Helper()
+	conf := OktaConfig{
+		ClientOptions: testClientOptions(t),
+		ApiKey:        token,
+		URL:           serverURL,
+		PollInterval:  25 * time.Millisecond,
+	}
+	require.NoError(t, conf.Validate())
+	adapter, _, err := newOktaAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	return adapter
+}
+
+// --- tests ----------------------------------------------------------------------
+
+// TestMockSystemLogEndToEnd drives the adapter against the mock API and asserts
+// the exact events shipped: every event arrives exactly once with its payload
+// preserved verbatim (nested objects, arrays and nulls included), and re-polling
+// the same window does not re-ship.
+//
+// It also pins two intentional behaviors of this adapter: events are stamped
+// with ingestion time (TimestampMs is "now", not the event's `published`), and
+// EventType is left empty (the platform's parsing config tags them).
+func TestMockSystemLogEndToEnd(t *testing.T) {
+	const token = "00aBcDeFgHiJkLmNoPqRsTuVwXyZ1111111111111"
+
+	mock := newMockOktaSystemLog(token)
+	// `published` must be >= the adapter's start time: the adapter clamps the
+	// `since` bound of its poll window to its own start, and the mock honours
+	// that bound the way the real API does. A small future offset keeps the
+	// events inside the first polls' windows regardless of second-truncation.
+	publishBase := time.Now().UTC().Add(2 * time.Second)
+	want := []utils.Dict{
+		systemLogEvent("11111111-1111-1111-1111-111111111111", "user.session.start", publishBase),
+		systemLogEvent("22222222-2222-2222-2222-222222222222", "user.authentication.sso", publishBase),
+		systemLogEvent("33333333-3333-3333-3333-333333333333", "policy.lifecycle.update", publishBase),
+	}
+	for _, e := range want {
+		mock.addEvent(e)
+	}
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	before := uint64(time.Now().UnixMilli())
+	adapter := startMockAdapter(t, server.URL, token, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		10*time.Second, 20*time.Millisecond, "expected all 3 System Log events to ship")
+	after := uint64(time.Now().UnixMilli())
+
+	// Re-polling the (overlapping) window must not re-ship: the count stays at 3.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "events were re-shipped on a later poll")
+
+	byUUID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		// The adapter does not tag an event type; LimaCharlie's platform
+		// config does the parsing.
+		assert.Empty(t, msg.EventType)
+		// The adapter stamps ingestion time, not the event's `published`.
+		assert.GreaterOrEqual(t, msg.TimestampMs, before)
+		assert.LessOrEqual(t, msg.TimestampMs, after)
+
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["uuid"].(string)
+		require.NotEmpty(t, id)
+		byUUID[id] = msg
+	}
+	require.Len(t, byUUID, 3)
+
+	for _, src := range want {
+		id := src["uuid"].(string)
+		msg := byUUID[id]
+		require.NotNil(t, msg, "event %s was not shipped", id)
+		// The payload is shipped verbatim -- nested objects, arrays and nulls
+		// included.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original System Log event")
+	}
+}
+
+// TestMockRequestContract verifies the request the adapter sends matches the
+// System Log API contract: GET /api/v1/logs with an `Authorization: SSWS <token>`
+// header and RFC3339 `since`/`until` bounds where since <= until and since is
+// clamped to no earlier than the adapter's start.
+func TestMockRequestContract(t *testing.T) {
+	const token = "contract-test-token"
+
+	mock := newMockOktaSystemLog(token)
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	testStart := time.Now()
+	sink := &captureSink{}
+	adapter := startMockAdapter(t, server.URL, token, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return mock.requestCount() >= 1 },
+		5*time.Second, 10*time.Millisecond, "adapter never called the API")
+
+	method, path, auth, sinceStr, untilStr := mock.lastRequest()
+	assert.Equal(t, http.MethodGet, method)
+	assert.Equal(t, "/api/v1/logs", path)
+	assert.Equal(t, "SSWS "+token, auth)
+
+	since, err := time.Parse(time.RFC3339, sinceStr)
+	require.NoError(t, err, "since must be RFC3339")
+	until, err := time.Parse(time.RFC3339, untilStr)
+	require.NoError(t, err, "until must be RFC3339")
+
+	assert.False(t, until.Before(since), "since must be <= until")
+	// On a fresh adapter the 30-minute overlap window is clamped to the
+	// adapter's start time (RFC3339 truncates to the second, hence the slack).
+	assert.False(t, since.Before(testStart.Add(-2*time.Second).UTC()),
+		"since %v must be clamped to the adapter start (~%v), not 30 minutes back", since, testStart.UTC())
+	assert.False(t, until.After(time.Now().UTC().Add(2*time.Second)), "until must be ~now")
+}
+
+// TestMockEventMidRunShipsExactlyOnce verifies an event that appears while the
+// adapter is running is shipped exactly once, and already-shipped events are
+// never re-sent.
+func TestMockEventMidRunShipsExactlyOnce(t *testing.T) {
+	const token = "tok-mid-run"
+
+	mock := newMockOktaSystemLog(token)
+	publishBase := time.Now().UTC().Add(2 * time.Second)
+	mock.addEvent(systemLogEvent("aaaaaaaa-1111-1111-1111-111111111111", "user.session.start", publishBase))
+	mock.addEvent(systemLogEvent("bbbbbbbb-1111-1111-1111-111111111111", "user.session.end", publishBase))
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter := startMockAdapter(t, server.URL, token, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		10*time.Second, 20*time.Millisecond, "initial events should ship")
+
+	// A new event is recorded while the adapter is running.
+	mock.addEvent(systemLogEvent("cccccccc-1111-1111-1111-111111111111", "user.account.lock",
+		time.Now().UTC().Add(2*time.Second)))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		10*time.Second, 20*time.Millisecond, "the new event should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond, "no event may ship twice")
+
+	shippedPerUUID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerUUID[msg.JsonPayload["uuid"].(string)]++
+	}
+	assert.Equal(t, map[string]int{
+		"aaaaaaaa-1111-1111-1111-111111111111": 1,
+		"bbbbbbbb-1111-1111-1111-111111111111": 1,
+		"cccccccc-1111-1111-1111-111111111111": 1,
+	}, shippedPerUUID, "every event must ship exactly once")
+}
+
+// TestMockLargeBatchShipsOnce verifies a large window of events is fully
+// consumed in one poll and each event ships exactly once across re-polls.
+//
+// Note on pagination fidelity: the real System Log API caps a response (100 by
+// default, 1000 max) and exposes the remainder through Link rel="next"
+// after-cursors. This adapter performs a single request per poll and does not
+// follow Link headers, so the mock -- mirroring how the adapter consumes the
+// API -- returns the entire window in one response. This test therefore covers
+// "large dataset fully consumed" as far as the adapter's design allows.
+func TestMockLargeBatchShipsOnce(t *testing.T) {
+	const token = "tok-large-batch"
+	const total = 250
+
+	mock := newMockOktaSystemLog(token)
+	publishBase := time.Now().UTC().Add(2 * time.Second)
+	for i := 0; i < total; i++ {
+		mock.addEvent(systemLogEvent(
+			fmt.Sprintf("dddddddd-1111-1111-1111-%012d", i),
+			"user.session.start",
+			publishBase))
+	}
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter := startMockAdapter(t, server.URL, token, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		15*time.Second, 25*time.Millisecond, "all events should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 30*time.Millisecond, "no duplicates across re-polls")
+
+	uuids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		uuids[msg.JsonPayload["uuid"].(string)] = true
+	}
+	assert.Len(t, uuids, total, "every distinct event should be shipped once")
+}
+
+// TestMockBadTokenShipsNothing pins the adapter's behavior on an auth failure:
+// the API rejects the token with 401/E0000011, the adapter reports the error
+// and ships nothing -- and (unlike adapters that abort on 401) it keeps
+// polling rather than stopping.
+func TestMockBadTokenShipsNothing(t *testing.T) {
+	mock := newMockOktaSystemLog("the-real-token")
+	mock.addEvent(systemLogEvent("eeeeeeee-1111-1111-1111-111111111111", "user.session.start",
+		time.Now().UTC().Add(2*time.Second)))
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	var mu sync.Mutex
+	var apiErrors int
+	opts := testClientOptions(t)
+	opts.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		mu.Lock()
+		apiErrors++
+		mu.Unlock()
+	}
+
+	sink := &captureSink{}
+	conf := OktaConfig{
+		ClientOptions: opts,
+		ApiKey:        "wrong-token",
+		URL:           server.URL,
+		PollInterval:  25 * time.Millisecond,
+	}
+	require.NoError(t, conf.Validate())
+	adapter, chStopped, err := newOktaAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// Let several polls fail authentication.
+	require.Eventually(t, func() bool { return mock.requestCount() >= 3 },
+		5*time.Second, 10*time.Millisecond, "adapter should keep polling on auth failure")
+
+	assert.Equal(t, 0, sink.count(), "nothing may ship when authentication fails")
+	mu.Lock()
+	assert.GreaterOrEqual(t, apiErrors, 1, "the auth failure must be reported via OnError")
+	mu.Unlock()
+
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter does not stop on a 401; it reports the error and retries")
+	default:
+		// Expected: still running.
+	}
+}

--- a/okta/mock_test.go
+++ b/okta/mock_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -138,7 +139,8 @@ func (m *mockOktaSystemLog) handler() http.HandlerFunc {
 			return
 		}
 		if r.URL.Path != logsURL {
-			oktaError(w, http.StatusNotFound, "E0000007", "Not found")
+			// E0000007 is "Not found: {0}" in Okta's error code reference.
+			oktaError(w, http.StatusNotFound, "E0000007", fmt.Sprintf("Not found: %s", r.URL.Path))
 			return
 		}
 		if r.Header.Get("Authorization") != "SSWS "+token {
@@ -146,19 +148,23 @@ func (m *mockOktaSystemLog) handler() http.HandlerFunc {
 			return
 		}
 
+		// A malformed timestamp gets Okta's documented validation error:
+		// HTTP 400 with errorCode E0000001 ("Api validation failed").
 		since, err := time.Parse(time.RFC3339, q.Get("since"))
 		if err != nil {
-			oktaError(w, http.StatusBadRequest, "E0000031", "The request was invalid: since")
+			oktaError(w, http.StatusBadRequest, "E0000001", "Api validation failed: 'since': The date format in your query is not recognized. Please enter dates using ISO8601 string format.")
 			return
 		}
 		until, err := time.Parse(time.RFC3339, q.Get("until"))
 		if err != nil {
-			oktaError(w, http.StatusBadRequest, "E0000031", "The request was invalid: until")
+			oktaError(w, http.StatusBadRequest, "E0000001", "Api validation failed: 'until': The date format in your query is not recognized. Please enter dates using ISO8601 string format.")
 			return
 		}
 
 		// A bounded query returns the events whose `published` falls inside
-		// the inclusive [since, until] window.
+		// the inclusive [since, until] window. Bounded requests are
+		// "guaranteed to be in order according to the published field"
+		// (default sortOrder is ASCENDING), so the mock sorts the page.
 		page := []utils.Dict{}
 		for _, e := range events {
 			published, perr := time.Parse(time.RFC3339, fmt.Sprintf("%v", e["published"]))
@@ -170,6 +176,9 @@ func (m *mockOktaSystemLog) handler() http.HandlerFunc {
 			}
 			page = append(page, e)
 		}
+		sort.SliceStable(page, func(i, j int) bool {
+			return fmt.Sprintf("%v", page[i]["published"]) < fmt.Sprintf("%v", page[j]["published"])
+		})
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Link", fmt.Sprintf("<http://%s%s?since=%s&until=%s>; rel=\"self\"", r.Host, logsURL, q.Get("since"), q.Get("until")))
@@ -181,13 +190,15 @@ func (m *mockOktaSystemLog) handler() http.HandlerFunc {
 // --- realistic fixtures ---------------------------------------------------------
 
 // systemLogEvent returns a record shaped like a real Okta System Log event:
-// uuid, published, eventType plus the actor/client/target/outcome/transaction/
-// debugContext structures the real API emits (nested objects, arrays, nulls
-// and mixed scalar types).
+// uuid, published, eventType plus the actor/client/request/target/outcome/
+// transaction/debugContext structures the real API emits (nested objects,
+// arrays, nulls and mixed scalar types).
 func systemLogEvent(uuid, eventType string, published time.Time) utils.Dict {
 	return utils.Dict{
-		"uuid":           uuid,
-		"published":      published.UTC().Format(time.RFC3339),
+		"uuid": uuid,
+		// The real API emits `published` at millisecond precision, e.g.
+		// "2017-09-31T22:23:07.777Z" in the official LogEvent example.
+		"published":      published.UTC().Format("2006-01-02T15:04:05.000Z"),
 		"eventType":      eventType,
 		"version":        "0",
 		"severity":       "INFO",

--- a/pandadoc/client.go
+++ b/pandadoc/client.go
@@ -17,9 +17,21 @@ import (
 )
 
 const (
-	logsEndpoint  = "https://api.pandadoc.com/public/v1/logs"
-	overlapPeriod = 30 * time.Second
+	defaultLogsEndpoint = "https://api.pandadoc.com/public/v1/logs"
+	overlapPeriod       = 30 * time.Second
+
+	// defaultPollInterval is how long fetchEvents idles between polling ticks.
+	defaultPollInterval = 30 * time.Second
 )
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
 
 type opRequest struct {
 	Limit     int    `json:"page[size],omitempty"`
@@ -29,8 +41,11 @@ type opRequest struct {
 
 type PandaDocAdapter struct {
 	conf       PandaDocConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
+
+	logsURL      string
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -44,6 +59,15 @@ type PandaDocAdapter struct {
 type PandaDocConfig struct {
 	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 	ApiKey        string                  `json:"api_key" yaml:"api_key"`
+
+	// URL overrides the PandaDoc audit-logs endpoint. Empty means the public
+	// PandaDoc API (https://api.pandadoc.com/public/v1/logs).
+	URL string `json:"url" yaml:"url"`
+
+	// PollInterval is the wait between polls of the logs endpoint. It is not
+	// settable through a config file; it exists as a seam for tests. Empty
+	// means the default of 30 seconds.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *PandaDocConfig) Validate() error {
@@ -58,17 +82,36 @@ func (c *PandaDocConfig) Validate() error {
 }
 
 func NewPandaDocAdapter(ctx context.Context, conf PandaDocConfig) (*PandaDocAdapter, chan struct{}, error) {
-	var err error
+	return newPandaDocAdapter(ctx, conf, nil)
+}
+
+// newPandaDocAdapter is the implementation behind NewPandaDocAdapter. When
+// sink is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newPandaDocAdapter(ctx context.Context, conf PandaDocConfig, sink uspSink) (*PandaDocAdapter, chan struct{}, error) {
 	a := &PandaDocAdapter{
-		conf:   conf,
-		ctx:    context.Background(),
-		doStop: utils.NewEvent(),
-		dedupe: make(map[string]int64),
+		conf:         conf,
+		ctx:          context.Background(),
+		doStop:       utils.NewEvent(),
+		dedupe:       make(map[string]int64),
+		logsURL:      conf.URL,
+		pollInterval: conf.PollInterval,
+	}
+	if a.logsURL == "" {
+		a.logsURL = defaultLogsEndpoint
+	}
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -110,11 +153,11 @@ func (a *PandaDocAdapter) Close() error {
 
 func (a *PandaDocAdapter) fetchEvents() {
 	defer a.wgSenders.Done()
-	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching of %s events exiting", logsEndpoint))
+	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching of %s events exiting", a.logsURL))
 
 	since := time.Now()
 
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// The makeOneRequest function handles error
 		// handling and fatal error handling.
 		items, newSince, _ := a.makeOneRequest(since)
@@ -159,8 +202,8 @@ func (a *PandaDocAdapter) makeOneRequest(since time.Time) ([]utils.Dict, time.Ti
 
 	for page := 1; ; page++ {
 		// Prepare the request.
-		a.conf.ClientOptions.DebugLog(fmt.Sprintf("requesting from %s?since=%s&to=%s&page=%d", logsEndpoint, start, until, page))
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s?since=%s&to=%s&page=%d", logsEndpoint, start, until, page), nil)
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf("requesting from %s?since=%s&to=%s&page=%d", a.logsURL, start, until, page))
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s?since=%s&to=%s&page=%d", a.logsURL, start, until, page), nil)
 		if err != nil {
 			a.doStop.Set()
 			return nil, lastDetectionTime, err

--- a/pandadoc/client_test.go
+++ b/pandadoc/client_test.go
@@ -1,0 +1,71 @@
+package usp_pandadoc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("requires api_key", func(t *testing.T) {
+		c := PandaDocConfig{ClientOptions: testClientOptions(t)}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("accepts a complete config", func(t *testing.T) {
+		c := PandaDocConfig{ClientOptions: testClientOptions(t), ApiKey: "fake-test-api-key"}
+		assert.NoError(t, c.Validate())
+	})
+}
+
+// TestConstructorDefaults verifies the URL and PollInterval seams default to
+// production values when left empty, and are honored when set.
+func TestConstructorDefaults(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		sink := &captureSink{}
+		conf := PandaDocConfig{ClientOptions: testClientOptions(t), ApiKey: "fake-test-api-key"}
+		adapter, _, err := newPandaDocAdapter(context.Background(), conf, sink)
+		require.NoError(t, err)
+		defer adapter.Close()
+
+		assert.Equal(t, defaultLogsEndpoint, adapter.logsURL)
+		assert.Equal(t, defaultPollInterval, adapter.pollInterval)
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		sink := &captureSink{}
+		conf := PandaDocConfig{
+			ClientOptions: testClientOptions(t),
+			ApiKey:        "fake-test-api-key",
+			URL:           "https://pandadoc.example.com/public/v1/logs",
+			PollInterval:  time.Hour,
+		}
+		adapter, _, err := newPandaDocAdapter(context.Background(), conf, sink)
+		require.NoError(t, err)
+		defer adapter.Close()
+
+		assert.Equal(t, "https://pandadoc.example.com/public/v1/logs", adapter.logsURL)
+		assert.Equal(t, time.Hour, adapter.pollInterval)
+	})
+}

--- a/pandadoc/mock_test.go
+++ b/pandadoc/mock_test.go
@@ -22,6 +22,12 @@ import (
 // This file exercises the adapter end-to-end against a mock PandaDoc API
 // (GET /public/v1/logs), capturing the exact messages it ships so their
 // content -- timestamp and verbatim payload -- can be asserted.
+//
+// Note: PandaDoc marks /public/v1/logs deprecated (sunset 2027-02-04) in
+// favor of the identically-shaped /public/v2/logs
+// (https://developers.pandadoc.com/reference/list-api-logs,
+// https://developers.pandadoc.com/reference/listlogsv2); the adapter still
+// targets v1, so the mock does too.
 
 // mockPageSize mirrors the PandaDoc API's default page size of 100 records;
 // the adapter does not send a `count` parameter and assumes a short page
@@ -126,8 +132,10 @@ func (m *mockPandaDoc) maxPageSeen() int {
 }
 
 // checkAuth validates the Authorization header. The adapter sends
-// "Api-Key <key>"; PandaDoc documents the scheme as "API-Key", so the scheme is
-// matched case-insensitively while the key itself must match exactly.
+// "Api-Key <key>"; PandaDoc documents the scheme as "API-Key"
+// (https://developers.pandadoc.com/reference/api-key-authentication-process),
+// and HTTP auth schemes are case-insensitive (RFC 9110 §11.1), so the scheme
+// is matched case-insensitively while the key itself must match exactly.
 func (m *mockPandaDoc) checkAuth(header string) bool {
 	parts := strings.SplitN(header, " ", 2)
 	if len(parts) != 2 {
@@ -231,22 +239,26 @@ func writeJSONStatus(w http.ResponseWriter, status int, d utils.Dict) {
 
 // --- realistic log fixtures ---------------------------------------------------
 
-// auditLogEntry returns a record shaped like a real PandaDoc API log entry:
-// the documented id/url/status/request_time/response_time fields plus the
-// request metadata PandaDoc reports for an API call.
+// fixtureTimeLayout renders fixture timestamps with millisecond precision and
+// an explicit zone designator. PandaDoc's documented example timestamps
+// ("2024-07-15T18:59:38.000") carry millisecond precision but no zone; the
+// fixture appends one because the adapter parses request_time with
+// time.RFC3339Nano (see makeOneRequest in client.go), which requires it.
+const fixtureTimeLayout = "2006-01-02T15:04:05.000Z07:00"
+
+// auditLogEntry returns a record shaped like a documented PandaDoc API log
+// list entry (https://developers.pandadoc.com/reference/list-api-logs):
+// exactly id, url, method, status, request_time and response_time. Richer
+// fields (request_body, token_type, application, ...) only appear on the log
+// details endpoint (/public/v1/logs/{id}), which the adapter never calls.
 func auditLogEntry(id string, requestTime time.Time) utils.Dict {
 	return utils.Dict{
 		"id":            id,
-		"url":           "/public/v1/documents?count=50&status=2",
+		"url":           "/public/v1/documents/00000000000000000000000/send",
 		"method":        "POST",
 		"status":        201,
-		"request_time":  requestTime.UTC().Format(time.RFC3339Nano),
-		"response_time": requestTime.Add(150 * time.Millisecond).UTC().Format(time.RFC3339Nano),
-		"token_type":    "api_key",
-		"application": utils.Dict{
-			"id":   "11111111-1111-1111-1111-111111111111",
-			"name": "Example Integration",
-		},
+		"request_time":  requestTime.UTC().Format(fixtureTimeLayout),
+		"response_time": requestTime.Add(150 * time.Millisecond).UTC().Format(fixtureTimeLayout),
 	}
 }
 
@@ -285,10 +297,10 @@ func shippedIDCounts(msgs []*protocol.DataMessage) map[string]int {
 // --- tests ---------------------------------------------------------------------
 
 // TestMockLogsEndToEnd drives the adapter against the mock API and asserts the
-// exact events shipped: the payload preserved verbatim (nested objects
-// included), TimestampMs stamped at ship time (the adapter's actual behavior --
-// it does not use the record's request_time for the message timestamp), no
-// EventType set, and that re-polling the same window does not re-ship.
+// exact events shipped: the payload preserved verbatim, TimestampMs stamped at
+// ship time (the adapter's actual behavior -- it does not use the record's
+// request_time for the message timestamp), no EventType set, and that
+// re-polling the same window does not re-ship.
 func TestMockLogsEndToEnd(t *testing.T) {
 	const apiKey = "fake-test-api-key-0000000000000000"
 
@@ -336,7 +348,7 @@ func TestMockLogsEndToEnd(t *testing.T) {
 		id := src["id"].(string)
 		msg := byID[id]
 		require.NotNil(t, msg, "record %s was not shipped", id)
-		// The payload is shipped verbatim -- nested objects included.
+		// The payload is shipped verbatim, every documented field intact.
 		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
 			"shipped payload must match the original PandaDoc log entry")
 	}

--- a/pandadoc/mock_test.go
+++ b/pandadoc/mock_test.go
@@ -1,0 +1,499 @@
+package usp_pandadoc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock PandaDoc API
+// (GET /public/v1/logs), capturing the exact messages it ships so their
+// content -- timestamp and verbatim payload -- can be asserted.
+
+// mockPageSize mirrors the PandaDoc API's default page size of 100 records;
+// the adapter does not send a `count` parameter and assumes a short page
+// (fewer than 100 records) means the result set is exhausted.
+const mockPageSize = 100
+
+// queryTimeLayout is the layout the adapter renders `since`/`to` in: ISO-8601
+// with millisecond precision and no zone designator (interpreted as UTC).
+const queryTimeLayout = "2006-01-02T15:04:05.000"
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock PandaDoc API --------------------------------------------------------
+
+// recordedRequest captures the shape of one request the adapter made, so tests
+// can pin the wire contract (method, auth header, query parameters).
+type recordedRequest struct {
+	method string
+	auth   string
+	since  string
+	to     string
+	page   int
+}
+
+// mockPandaDoc is an in-memory stand-in for the PandaDoc audit-logs API
+// (GET /public/v1/logs). It validates the `Authorization: Api-Key <key>`
+// header, honours the adapter's `since`/`to` time window and 1-based `page`
+// parameter, paginates over an in-memory log set in pages of 100 (the API's
+// default `count`), and returns the {"results": [...]} envelope.
+type mockPandaDoc struct {
+	mu       sync.Mutex
+	apiKey   string
+	logs     []utils.Dict // ordered oldest-first
+	requests []recordedRequest
+}
+
+func newMockPandaDoc(apiKey string) *mockPandaDoc {
+	return &mockPandaDoc{apiKey: apiKey}
+}
+
+func (m *mockPandaDoc) addLogs(entries ...utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, entries...)
+}
+
+func (m *mockPandaDoc) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.requests)
+}
+
+func (m *mockPandaDoc) requestsSnapshot() []recordedRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]recordedRequest, len(m.requests))
+	copy(out, m.requests)
+	return out
+}
+
+// maxPageSeen reports the largest `page` query value any request carried.
+func (m *mockPandaDoc) maxPageSeen() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	max := 0
+	for _, r := range m.requests {
+		if r.page > max {
+			max = r.page
+		}
+	}
+	return max
+}
+
+// checkAuth validates the Authorization header. The adapter sends
+// "Api-Key <key>"; PandaDoc documents the scheme as "API-Key", so the scheme is
+// matched case-insensitively while the key itself must match exactly.
+func (m *mockPandaDoc) checkAuth(header string) bool {
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	return strings.EqualFold(parts[0], "api-key") && parts[1] == m.apiKey
+}
+
+func (m *mockPandaDoc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	q := r.URL.Query()
+	page := 1
+	if p, err := strconv.Atoi(q.Get("page")); err == nil && p >= 1 {
+		page = p
+	}
+	m.requests = append(m.requests, recordedRequest{
+		method: r.Method,
+		auth:   r.Header.Get("Authorization"),
+		since:  q.Get("since"),
+		to:     q.Get("to"),
+		page:   page,
+	})
+
+	if r.Method != http.MethodGet {
+		writeJSONStatus(w, http.StatusMethodNotAllowed, utils.Dict{"detail": "method not allowed"})
+		return
+	}
+	if !m.checkAuth(r.Header.Get("Authorization")) {
+		writeJSONStatus(w, http.StatusUnauthorized, utils.Dict{
+			"type":   "authorization_error",
+			"detail": "Authentication credentials were not provided or are incorrect.",
+		})
+		return
+	}
+
+	since, err := parseQueryTime(q, "since")
+	if err != nil {
+		writeJSONStatus(w, http.StatusBadRequest, utils.Dict{"type": "request_error", "detail": err.Error()})
+		return
+	}
+	to, err := parseQueryTime(q, "to")
+	if err != nil {
+		writeJSONStatus(w, http.StatusBadRequest, utils.Dict{"type": "request_error", "detail": err.Error()})
+		return
+	}
+
+	// Filter the dataset to the requested window (inclusive bounds).
+	var window []utils.Dict
+	for _, entry := range m.logs {
+		rt, ok := entry["request_time"].(string)
+		if !ok {
+			continue
+		}
+		t, perr := time.Parse(time.RFC3339Nano, rt)
+		if perr != nil {
+			continue
+		}
+		if t.Before(since) || t.After(to) {
+			continue
+		}
+		window = append(window, entry)
+	}
+
+	// Paginate; page is 1-based, pages hold mockPageSize records.
+	var pageItems []utils.Dict
+	if start := (page - 1) * mockPageSize; start < len(window) {
+		end := start + mockPageSize
+		if end > len(window) {
+			end = len(window)
+		}
+		pageItems = window[start:end]
+	}
+	if pageItems == nil {
+		pageItems = []utils.Dict{}
+	}
+
+	writeJSONStatus(w, http.StatusOK, utils.Dict{"results": pageItems})
+}
+
+// parseQueryTime parses a `since`/`to` query value in the exact layout the
+// adapter renders, interpreted as UTC.
+func parseQueryTime(q url.Values, key string) (time.Time, error) {
+	v := q.Get(key)
+	if v == "" {
+		return time.Time{}, fmt.Errorf("missing %q query parameter", key)
+	}
+	t, err := time.ParseInLocation(queryTimeLayout, v, time.UTC)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid %q query parameter %q: %v", key, v, err)
+	}
+	return t, nil
+}
+
+func writeJSONStatus(w http.ResponseWriter, status int, d utils.Dict) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(d)
+}
+
+// --- realistic log fixtures ---------------------------------------------------
+
+// auditLogEntry returns a record shaped like a real PandaDoc API log entry:
+// the documented id/url/status/request_time/response_time fields plus the
+// request metadata PandaDoc reports for an API call.
+func auditLogEntry(id string, requestTime time.Time) utils.Dict {
+	return utils.Dict{
+		"id":            id,
+		"url":           "/public/v1/documents?count=50&status=2",
+		"method":        "POST",
+		"status":        201,
+		"request_time":  requestTime.UTC().Format(time.RFC3339Nano),
+		"response_time": requestTime.Add(150 * time.Millisecond).UTC().Format(time.RFC3339Nano),
+		"token_type":    "api_key",
+		"application": utils.Dict{
+			"id":   "11111111-1111-1111-1111-111111111111",
+			"name": "Example Integration",
+		},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// startTestAdapter builds the adapter against the mock server with the capture
+// sink injected and a fast poll interval.
+func startTestAdapter(t *testing.T, serverURL string, apiKey string, sink uspSink) (*PandaDocAdapter, chan struct{}) {
+	t.Helper()
+	conf := PandaDocConfig{
+		ClientOptions: testClientOptions(t),
+		ApiKey:        apiKey,
+		URL:           serverURL,
+		PollInterval:  20 * time.Millisecond,
+	}
+	adapter, chStopped, err := newPandaDocAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	return adapter, chStopped
+}
+
+// shippedIDCounts tallies how many times each log id was shipped.
+func shippedIDCounts(msgs []*protocol.DataMessage) map[string]int {
+	counts := map[string]int{}
+	for _, m := range msgs {
+		id, _ := m.JsonPayload["id"].(string)
+		counts[id]++
+	}
+	return counts
+}
+
+// --- tests ---------------------------------------------------------------------
+
+// TestMockLogsEndToEnd drives the adapter against the mock API and asserts the
+// exact events shipped: the payload preserved verbatim (nested objects
+// included), TimestampMs stamped at ship time (the adapter's actual behavior --
+// it does not use the record's request_time for the message timestamp), no
+// EventType set, and that re-polling the same window does not re-ship.
+func TestMockLogsEndToEnd(t *testing.T) {
+	const apiKey = "fake-test-api-key-0000000000000000"
+
+	mock := newMockPandaDoc(apiKey)
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	// The adapter only collects logs newer than its start time, so fixtures are
+	// stamped slightly in the future of the adapter's startup instant.
+	base := time.Now().Add(100 * time.Millisecond)
+	want := []utils.Dict{
+		auditLogEntry("log-aaaaaaaaaaaaaaaaaaaa01", base),
+		auditLogEntry("log-aaaaaaaaaaaaaaaaaaaa02", base.Add(2*time.Millisecond)),
+		auditLogEntry("log-aaaaaaaaaaaaaaaaaaaa03", base.Add(4*time.Millisecond)),
+	}
+	mock.addLogs(want...)
+
+	before := uint64(time.Now().UnixMilli())
+	sink := &captureSink{}
+	adapter, _ := startTestAdapter(t, server.URL, apiKey, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond, "expected all 3 log entries to ship")
+	after := uint64(time.Now().UnixMilli())
+
+	// Re-polling must not re-ship: the count stays at 3 across many polls.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 20*time.Millisecond, "records were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		require.NotNil(t, msg.JsonPayload)
+		assert.Empty(t, msg.EventType, "the adapter does not tag an EventType")
+		// The adapter stamps messages at ship time, not from request_time.
+		assert.GreaterOrEqual(t, msg.TimestampMs, before)
+		assert.LessOrEqual(t, msg.TimestampMs, after)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "record %s was not shipped", id)
+		// The payload is shipped verbatim -- nested objects included.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original PandaDoc log entry")
+	}
+}
+
+// TestMockRequestShape pins the wire contract the adapter speaks: GET requests
+// carrying the Api-Key Authorization header, a millisecond-precision since/to
+// window, and a 1-based page counter starting at 1.
+func TestMockRequestShape(t *testing.T) {
+	const apiKey = "fake-test-api-key-1111111111111111"
+
+	mock := newMockPandaDoc(apiKey)
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startTestAdapter(t, server.URL, apiKey, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return mock.requestCount() >= 2 },
+		5*time.Second, 10*time.Millisecond, "the adapter should poll repeatedly")
+
+	for _, req := range mock.requestsSnapshot() {
+		assert.Equal(t, http.MethodGet, req.method)
+		assert.Equal(t, "Api-Key "+apiKey, req.auth)
+		assert.Equal(t, 1, req.page, "an empty result set never advances past page 1")
+
+		since, err := time.ParseInLocation(queryTimeLayout, req.since, time.UTC)
+		require.NoError(t, err, "since must use the %s layout", queryTimeLayout)
+		to, err := time.ParseInLocation(queryTimeLayout, req.to, time.UTC)
+		require.NoError(t, err, "to must use the %s layout", queryTimeLayout)
+		assert.False(t, to.Before(since), "the window must not be inverted")
+	}
+}
+
+// TestMockMidRunEventShipsOnce verifies a log entry that appears mid-run is
+// shipped exactly once, and already-shipped entries are never re-sent.
+func TestMockMidRunEventShipsOnce(t *testing.T) {
+	const apiKey = "fake-test-api-key-2222222222222222"
+
+	mock := newMockPandaDoc(apiKey)
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	base := time.Now().Add(100 * time.Millisecond)
+	mock.addLogs(
+		auditLogEntry("log-bbbbbbbbbbbbbbbbbbbb01", base),
+		auditLogEntry("log-bbbbbbbbbbbbbbbbbbbb02", base.Add(2*time.Millisecond)),
+	)
+
+	sink := &captureSink{}
+	adapter, _ := startTestAdapter(t, server.URL, apiKey, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 10*time.Millisecond)
+
+	// A new API call gets logged while the adapter is running.
+	mock.addLogs(auditLogEntry("log-bbbbbbbbbbbbbbbbbbbb03", time.Now().Add(100*time.Millisecond)))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond, "the new log entry should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 20*time.Millisecond)
+
+	assert.Equal(t, map[string]int{
+		"log-bbbbbbbbbbbbbbbbbbbb01": 1,
+		"log-bbbbbbbbbbbbbbbbbbbb02": 1,
+		"log-bbbbbbbbbbbbbbbbbbbb03": 1,
+	}, shippedIDCounts(sink.snapshot()), "every log entry must ship exactly once")
+}
+
+// TestMockPaginationFullDataset verifies a window holding more than one page of
+// records (the adapter assumes 100-record pages) is walked completely and every
+// record ships exactly once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const apiKey = "fake-test-api-key-3333333333333333"
+	const total = 250 // 3 pages: 100 + 100 + 50
+
+	mock := newMockPandaDoc(apiKey)
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	// All records share one request_time so a single poll window holds the
+	// entire dataset, forcing a multi-page walk.
+	at := time.Now().Add(100 * time.Millisecond)
+	entries := make([]utils.Dict, total)
+	for i := range entries {
+		entries[i] = auditLogEntry(fmt.Sprintf("log-page-%03d", i), at)
+	}
+	mock.addLogs(entries...)
+
+	sink := &captureSink{}
+	adapter, _ := startTestAdapter(t, server.URL, apiKey, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 10*time.Millisecond, "all paginated records should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 20*time.Millisecond, "no record may ship twice")
+
+	counts := shippedIDCounts(sink.snapshot())
+	assert.Len(t, counts, total, "every distinct record should ship")
+	for id, n := range counts {
+		assert.Equalf(t, 1, n, "record %s shipped %d times", id, n)
+	}
+
+	// The adapter walked past page 2: a 100-record page means "maybe more".
+	assert.GreaterOrEqual(t, mock.maxPageSeen(), 3, "a 250-record window requires 3 pages")
+}
+
+// TestMockBadAPIKeyShipsNothing pins the adapter's actual behavior on an auth
+// failure: nothing is shipped, the error is surfaced via OnError, and the
+// adapter does not stop -- it keeps polling on its interval.
+func TestMockBadAPIKeyShipsNothing(t *testing.T) {
+	mock := newMockPandaDoc("the-correct-fake-key")
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	mock.addLogs(auditLogEntry("log-cccccccccccccccccccc01", time.Now().Add(100*time.Millisecond)))
+
+	var mu sync.Mutex
+	var apiErrors int
+	opts := testClientOptions(t)
+	innerOnError := opts.OnError
+	opts.OnError = func(err error) {
+		innerOnError(err)
+		mu.Lock()
+		apiErrors++
+		mu.Unlock()
+	}
+
+	sink := &captureSink{}
+	conf := PandaDocConfig{
+		ClientOptions: opts,
+		ApiKey:        "the-wrong-fake-key",
+		URL:           server.URL,
+		PollInterval:  20 * time.Millisecond,
+	}
+	adapter, chStopped, err := newPandaDocAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The adapter keeps polling despite the 401s...
+	require.Eventually(t, func() bool { return mock.requestCount() >= 3 },
+		5*time.Second, 10*time.Millisecond, "the adapter should keep polling after a 401")
+	// ...reports the failure...
+	mu.Lock()
+	gotErrors := apiErrors
+	mu.Unlock()
+	assert.GreaterOrEqual(t, gotErrors, 1, "a 401 must be surfaced via OnError")
+	// ...does not stop on its own...
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter is not expected to stop on an auth failure (current behavior)")
+	default:
+	}
+	// ...and never ships anything.
+	assert.Equal(t, 0, sink.count(), "nothing may ship when authentication fails")
+}

--- a/proofpoint_tap/client.go
+++ b/proofpoint_tap/client.go
@@ -22,10 +22,22 @@ const (
 	warnDedupeSize = 100000
 )
 
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type ProofpointTapAdapter struct {
 	conf       ProofpointTapConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
+
+	apiURL       string
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -39,6 +51,15 @@ type ProofpointTapConfig struct {
 	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 	Principal     string                  `json:"principal" yaml:"principal"`
 	Secret        string                  `json:"secret" yaml:"secret"`
+
+	// URL overrides the SIEM endpoint queried. Empty means the standard
+	// Proofpoint TAP endpoint (https://tap-api-v2.proofpoint.com/v2/siem/all).
+	URL string `json:"url" yaml:"url"`
+
+	// PollInterval overrides the wait between polls of the SIEM endpoint. It
+	// is not settable through a config file; it exists as a seam for tests.
+	// Zero means the default (60 seconds).
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *ProofpointTapConfig) Validate() error {
@@ -55,6 +76,13 @@ func (c *ProofpointTapConfig) Validate() error {
 }
 
 func NewProofpointTapAdapter(ctx context.Context, conf ProofpointTapConfig) (*ProofpointTapAdapter, chan struct{}, error) {
+	return newProofpointTapAdapter(ctx, conf, nil)
+}
+
+// newProofpointTapAdapter is the implementation behind NewProofpointTapAdapter.
+// When sink is non-nil it is used in place of a real LimaCharlie client -- the
+// seam tests use to capture shipped events.
+func newProofpointTapAdapter(ctx context.Context, conf ProofpointTapConfig, sink uspSink) (*ProofpointTapAdapter, chan struct{}, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, nil, err
 	}
@@ -64,12 +92,24 @@ func NewProofpointTapAdapter(ctx context.Context, conf ProofpointTapConfig) (*Pr
 		doStop:        utils.NewEvent(),
 		messageDedupe: make(map[string]int64),
 		clickDedupe:   make(map[string]int64),
+		apiURL:        conf.URL,
+		pollInterval:  conf.PollInterval,
 	}
-	var err error
+	if a.apiURL == "" {
+		a.apiURL = logsEndpoint
+	}
+	if a.pollInterval <= 0 {
+		a.pollInterval = queryInterval * time.Second
+	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -107,11 +147,11 @@ func (a *ProofpointTapAdapter) Close() error {
 
 func (a *ProofpointTapAdapter) fetchEvents() {
 	defer a.wgSenders.Done()
-	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching of %s events exiting", logsEndpoint))
+	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching of %s events exiting", a.apiURL))
 
 	since := time.Now()
 
-	for !a.doStop.WaitFor(queryInterval * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		items, newSince, _ := a.makeOneRequest(since)
 		since = newSince
 		if items == nil {
@@ -151,9 +191,9 @@ func (a *ProofpointTapAdapter) makeOneRequest(since time.Time) ([]utils.Dict, ti
 	var url string
 
 	if timeDiff > 1*time.Hour {
-		url = fmt.Sprintf("%s?format=json&interval=%s/%s", logsEndpoint, sinceWithOverlapString, sinceWithOverlap.Add(1*time.Hour).Add(-1*time.Minute).Format(time.RFC3339))
+		url = fmt.Sprintf("%s?format=json&interval=%s/%s", a.apiURL, sinceWithOverlapString, sinceWithOverlap.Add(1*time.Hour).Add(-1*time.Minute).Format(time.RFC3339))
 	} else {
-		url = fmt.Sprintf("%s?format=json&interval=%s/%s", logsEndpoint, sinceWithOverlapString, nowTimestamp.Format(time.RFC3339))
+		url = fmt.Sprintf("%s?format=json&interval=%s/%s", a.apiURL, sinceWithOverlapString, nowTimestamp.Format(time.RFC3339))
 	}
 
 	req, err := http.NewRequest("GET", url, nil)

--- a/proofpoint_tap/client_test.go
+++ b/proofpoint_tap/client_test.go
@@ -1,0 +1,89 @@
+package usp_proofpoint_tap
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Run("requires principal", func(t *testing.T) {
+		c := ProofpointTapConfig{ClientOptions: testClientOptions(t), Secret: "s"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires secret", func(t *testing.T) {
+		c := ProofpointTapConfig{ClientOptions: testClientOptions(t), Principal: "p"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		c := ProofpointTapConfig{
+			ClientOptions: testClientOptions(t),
+			Principal:     testPrincipal,
+			Secret:        testSecret,
+		}
+		assert.NoError(t, c.Validate())
+	})
+}
+
+// TestDefaults verifies an empty URL/PollInterval resolve to the real
+// Proofpoint TAP endpoint and the production poll interval.
+func TestDefaults(t *testing.T) {
+	sink := &captureSink{}
+	conf := ProofpointTapConfig{
+		ClientOptions: testClientOptions(t),
+		Principal:     testPrincipal,
+		Secret:        testSecret,
+	}
+	adapter, chStopped, err := newProofpointTapAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	require.NotNil(t, chStopped)
+
+	assert.Equal(t, logsEndpoint, adapter.apiURL)
+	assert.Equal(t, queryInterval*time.Second, adapter.pollInterval)
+
+	// With the default 60s poll interval the fetch goroutine is still idling;
+	// nothing was requested or shipped, and Close unblocks it promptly.
+	require.NoError(t, adapter.Close())
+	assert.Equal(t, 0, sink.count())
+}
+
+// TestURLOverride verifies the config override replaces the endpoint queried.
+func TestURLOverride(t *testing.T) {
+	sink := &captureSink{}
+	conf := ProofpointTapConfig{
+		ClientOptions: testClientOptions(t),
+		Principal:     testPrincipal,
+		Secret:        testSecret,
+		URL:           "https://tap-proxy.example.com/v2/siem/all",
+		PollInterval:  time.Hour, // never polls during the test
+	}
+	adapter, _, err := newProofpointTapAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://tap-proxy.example.com/v2/siem/all", adapter.apiURL)
+	assert.Equal(t, time.Hour, adapter.pollInterval)
+	require.NoError(t, adapter.Close())
+}

--- a/proofpoint_tap/mock_test.go
+++ b/proofpoint_tap/mock_test.go
@@ -1,0 +1,562 @@
+package usp_proofpoint_tap
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock Proofpoint TAP
+// SIEM API (GET /v2/siem/all), capturing the exact messages it ships so their
+// content -- the injected eventType, ingestion timestamp and verbatim payload
+// -- can be asserted.
+//
+// The mock reproduces the API as the adapter uses it: it authenticates the
+// Basic principal/secret pair, requires format=json, parses the
+// interval=<ISO8601>/<ISO8601> window parameter, filters the in-memory event
+// set by that window, and answers with the documented envelope
+// {"queryEndTime": ..., "messagesDelivered": [...], "messagesBlocked": [...],
+// "clicksPermitted": [...], "clicksBlocked": [...]}.
+
+// Clearly fake TAP service credentials.
+const (
+	testPrincipal = "11111111-1111-1111-1111-111111111111"
+	testSecret    = "fake-tap-secret-1111111111111111"
+)
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Proofpoint TAP SIEM API ---------------------------------------------
+
+// TAP SIEM envelope keys; also used as the mock's event categories.
+const (
+	catMessagesDelivered = "messagesDelivered"
+	catMessagesBlocked   = "messagesBlocked"
+	catClicksPermitted   = "clicksPermitted"
+	catClicksBlocked     = "clicksBlocked"
+)
+
+// tapEvent is one record in the mock's dataset: the envelope array it belongs
+// to, the SIEM time used for interval filtering, and the payload served.
+type tapEvent struct {
+	category string
+	ts       time.Time
+	payload  utils.Dict
+}
+
+// mockProofpointTap is an in-memory stand-in for the TAP SIEM /v2/siem/all
+// endpoint.
+type mockProofpointTap struct {
+	mu        sync.Mutex
+	principal string
+	secret    string
+	events    []tapEvent
+
+	requests          int
+	authFailures      int
+	lastFormat        string    // format query param of the last authenticated request
+	lastIntervalStart time.Time // parsed interval start of the last authenticated request
+	lastIntervalEnd   time.Time // parsed interval end of the last authenticated request
+}
+
+func newMockProofpointTap(principal, secret string) *mockProofpointTap {
+	return &mockProofpointTap{principal: principal, secret: secret}
+}
+
+func (m *mockProofpointTap) addEvent(category string, ts time.Time, payload utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, tapEvent{category: category, ts: ts, payload: payload})
+}
+
+func (m *mockProofpointTap) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+func (m *mockProofpointTap) authFailureCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.authFailures
+}
+
+func (m *mockProofpointTap) lastRequest() (string, time.Time, time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastFormat, m.lastIntervalStart, m.lastIntervalEnd
+}
+
+func (m *mockProofpointTap) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		m.requests++
+
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		// TAP authenticates SIEM API calls with HTTP Basic auth carrying the
+		// service principal and secret.
+		principal, secret, ok := r.BasicAuth()
+		if !ok || principal != m.principal || secret != m.secret {
+			m.authFailures++
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("Credentials did not pass authentication"))
+			return
+		}
+
+		q := r.URL.Query()
+		m.lastFormat = q.Get("format")
+		if m.lastFormat != "json" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("The request was missing a mandatory request parameter"))
+			return
+		}
+
+		// interval=<ISO8601 start>/<ISO8601 end>, at most one hour wide.
+		parts := strings.SplitN(q.Get("interval"), "/", 2)
+		if len(parts) != 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("The interval parameter is malformed"))
+			return
+		}
+		start, err := time.Parse(time.RFC3339, parts[0])
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("The interval start is malformed"))
+			return
+		}
+		end, err := time.Parse(time.RFC3339, parts[1])
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("The interval end is malformed"))
+			return
+		}
+		if end.Sub(start) > time.Hour {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("The requested interval is too wide"))
+			return
+		}
+		m.lastIntervalStart, m.lastIntervalEnd = start, end
+
+		// Select the events inside the requested window, per category. The
+		// real service always emits all four arrays for /siem/all.
+		resp := map[string]interface{}{
+			"queryEndTime":       end.UTC().Format(time.RFC3339),
+			catMessagesDelivered: []utils.Dict{},
+			catMessagesBlocked:   []utils.Dict{},
+			catClicksPermitted:   []utils.Dict{},
+			catClicksBlocked:     []utils.Dict{},
+		}
+		for _, e := range m.events {
+			if e.ts.Before(start) || e.ts.After(end) {
+				continue
+			}
+			resp[e.category] = append(resp[e.category].([]utils.Dict), e.payload)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// --- realistic record fixtures ------------------------------------------------
+
+// realisticMessageEvent returns a record shaped like a real TAP SIEM message
+// event (messagesDelivered/messagesBlocked): GUID, RFC3339 messageTime, the
+// nested messageParts and threatsInfoMap arrays, scores, and sender/recipient
+// addressing -- all with clearly fake values.
+func realisticMessageEvent(guid string, messageTime time.Time) utils.Dict {
+	ts := messageTime.UTC().Format(time.RFC3339)
+	return utils.Dict{
+		"GUID":                guid,
+		"QID":                 "r2FNwRHF004109",
+		"ccAddresses":         []interface{}{"finance@example.com"},
+		"clusterId":           "example_hosted",
+		"completelyRewritten": "true",
+		"fromAddress":         "badguy@attacker.example.net",
+		"headerFrom":          "\"A. Badguy\" <badguy@attacker.example.net>",
+		"headerReplyTo":       nil,
+		"impostorScore":       0,
+		"malwareScore":        100,
+		"messageID":           "20260611100000.11111.mail@attacker.example.net",
+		"messageParts": []interface{}{
+			utils.Dict{
+				"contentType":   "application/pdf",
+				"disposition":   "attached",
+				"filename":      "invoice.pdf",
+				"md5":           "11111111111111111111111111111111",
+				"oContentType":  "application/pdf",
+				"sandboxStatus": "threat",
+				"sha256":        "1111111111111111111111111111111111111111111111111111111111111111",
+			},
+		},
+		"messageSize":      18874,
+		"messageTime":      ts,
+		"modulesRun":       []interface{}{"pdr", "sandbox", "spam", "urldefense"},
+		"phishScore":       46,
+		"policyRoutes":     []interface{}{"default_inbound", "executives"},
+		"quarantineFolder": "Attachment Defense",
+		"quarantineRule":   "module.sandbox.threat",
+		"recipient":        []interface{}{"jdoe@example.com"},
+		"replyToAddress":   nil,
+		"sender":           "badguy@attacker.example.net",
+		"senderIP":         "192.0.2.255",
+		"spamScore":        4,
+		"subject":          "Please find a totally legitimate invoice attached",
+		"threatsInfoMap": []interface{}{
+			utils.Dict{
+				"campaignId":     "11111111-1111-1111-1111-111111111111",
+				"classification": "MALWARE",
+				"threat":         "1111111111111111111111111111111111111111111111111111111111111111",
+				"threatId":       "1111111111111111111111111111111111111111111111111111111111111111",
+				"threatStatus":   "active",
+				"threatTime":     ts,
+				"threatType":     "ATTACHMENT",
+				"threatUrl":      "https://threatinsight.proofpoint.com/11111111-1111-1111-1111-111111111111/threat/email/1111",
+			},
+		},
+		"toAddresses": []interface{}{"jdoe@example.com"},
+		"xmailer":     "Spambot v2.5",
+	}
+}
+
+// realisticClickEvent returns a record shaped like a real TAP SIEM click event
+// (clicksPermitted/clicksBlocked): the click-specific id field the adapter
+// dedupes on, RFC3339 clickTime, the clicked URL and threat metadata.
+func realisticClickEvent(id string, clickTime time.Time) utils.Dict {
+	ts := clickTime.UTC().Format(time.RFC3339)
+	return utils.Dict{
+		"GUID":           "click-guid-" + id,
+		"campaignId":     "11111111-1111-1111-1111-111111111111",
+		"classification": "MALWARE",
+		"clickIP":        "192.0.2.10",
+		"clickTime":      ts,
+		"id":             id,
+		"messageID":      "20260611100000.22222.mail@attacker.example.net",
+		"recipient":      "jdoe@example.com",
+		"sender":         "badguy@attacker.example.net",
+		"senderIP":       "192.0.2.255",
+		"threatID":       "2222222222222222222222222222222222222222222222222222222222222222",
+		"threatStatus":   "active",
+		"threatTime":     ts,
+		"threatURL":      "https://threatinsight.proofpoint.com/11111111-1111-1111-1111-111111111111/threat/email/2222",
+		"url":            "http://badsite.example.net/malicious",
+		"userAgent":      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+	}
+}
+
+// withEventType returns a copy of payload with the eventType key the adapter
+// injects before shipping.
+func withEventType(payload utils.Dict, eventType string) utils.Dict {
+	out := utils.Dict{}
+	for k, v := range payload {
+		out[k] = v
+	}
+	out["eventType"] = eventType
+	return out
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// startMockAdapter wires an adapter to the mock server with a fast poll
+// interval and an injected capture sink.
+func startMockAdapter(t *testing.T, serverURL, principal, secret string, sink uspSink) (*ProofpointTapAdapter, chan struct{}) {
+	t.Helper()
+	conf := ProofpointTapConfig{
+		ClientOptions: testClientOptions(t),
+		Principal:     principal,
+		Secret:        secret,
+		URL:           serverURL,
+		PollInterval:  25 * time.Millisecond,
+	}
+	adapter, chStopped, err := newProofpointTapAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	return adapter, chStopped
+}
+
+// --- tests ----------------------------------------------------------------------
+
+// Note on fixture timestamps: the adapter's first poll queries the interval
+// [adapterStart-2min, now], and every later poll [queryEndTime-2min, now], so
+// fixtures stamped "just now" are inside every window of a fast-polling test.
+
+// TestMockAllCategoriesEndToEnd drives the adapter against the mock API and
+// asserts the exact events shipped from each of the four SIEM categories:
+// payload preserved verbatim (nested threatsInfoMap/messageParts included)
+// apart from the injected eventType key, no DataMessage.EventType tagging,
+// ingestion-time TimestampMs, the format/interval/Basic-auth request contract,
+// and that re-polling overlapping windows does not re-ship.
+func TestMockAllCategoriesEndToEnd(t *testing.T) {
+	mock := newMockProofpointTap(testPrincipal, testSecret)
+	now := time.Now()
+
+	delivered1 := realisticMessageEvent("11111111-1111-1111-1111-aaaaaaaaaaaa", now.Add(-30*time.Second))
+	delivered2 := realisticMessageEvent("11111111-1111-1111-1111-bbbbbbbbbbbb", now.Add(-20*time.Second))
+	blockedMsg := realisticMessageEvent("11111111-1111-1111-1111-cccccccccccc", now.Add(-25*time.Second))
+	permittedClick := realisticClickEvent("11111111-1111-1111-1111-dddddddddddd", now.Add(-15*time.Second))
+	blockedClick := realisticClickEvent("11111111-1111-1111-1111-eeeeeeeeeeee", now.Add(-10*time.Second))
+
+	mock.addEvent(catMessagesDelivered, now.Add(-30*time.Second), delivered1)
+	mock.addEvent(catMessagesDelivered, now.Add(-20*time.Second), delivered2)
+	mock.addEvent(catMessagesBlocked, now.Add(-25*time.Second), blockedMsg)
+	mock.addEvent(catClicksPermitted, now.Add(-15*time.Second), permittedClick)
+	mock.addEvent(catClicksBlocked, now.Add(-10*time.Second), blockedClick)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	testStartMs := uint64(time.Now().UnixMilli())
+	adapter, _ := startMockAdapter(t, server.URL, testPrincipal, testSecret, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 5 },
+		8*time.Second, 20*time.Millisecond, "expected all 5 SIEM events to ship")
+
+	// Consecutive polls re-query overlapping windows; the dedupe maps must
+	// prevent any re-shipping: the count stays at 5.
+	require.Never(t, func() bool { return sink.count() != 5 },
+		300*time.Millisecond, 30*time.Millisecond, "records were re-shipped on a later poll")
+
+	doneMs := uint64(time.Now().UnixMilli())
+
+	byKey := map[string]*protocol.DataMessage{}
+	perType := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		// The adapter tags the event category inside the payload (eventType
+		// key), not on DataMessage.EventType.
+		assert.Empty(t, msg.EventType)
+		// The adapter stamps ingestion time, not the record's messageTime.
+		assert.GreaterOrEqual(t, msg.TimestampMs, testStartMs)
+		assert.LessOrEqual(t, msg.TimestampMs, doneMs)
+		require.NotNil(t, msg.JsonPayload)
+
+		et, _ := msg.JsonPayload["eventType"].(string)
+		require.NotEmpty(t, et, "every shipped payload must carry an injected eventType")
+		perType[et]++
+
+		// Messages are keyed by GUID, clicks by id.
+		if strings.HasPrefix(et, "message_") {
+			byKey[msg.JsonPayload["GUID"].(string)] = msg
+		} else {
+			byKey[msg.JsonPayload["id"].(string)] = msg
+		}
+	}
+	assert.Equal(t, map[string]int{
+		"message_delivered": 2,
+		"message_blocked":   1,
+		"click_permitted":   1,
+		"click_blocked":     1,
+	}, perType, "each SIEM category must be tagged with its eventType")
+
+	// The payload is shipped verbatim -- nested messageParts/threatsInfoMap
+	// included -- with only the eventType key added.
+	for _, tc := range []struct {
+		key       string
+		src       utils.Dict
+		eventType string
+	}{
+		{delivered1["GUID"].(string), delivered1, "message_delivered"},
+		{delivered2["GUID"].(string), delivered2, "message_delivered"},
+		{blockedMsg["GUID"].(string), blockedMsg, "message_blocked"},
+		{permittedClick["id"].(string), permittedClick, "click_permitted"},
+		{blockedClick["id"].(string), blockedClick, "click_blocked"},
+	} {
+		msg := byKey[tc.key]
+		require.NotNil(t, msg, "record %s was not shipped", tc.key)
+		assert.JSONEq(t, mustJSON(t, withEventType(tc.src, tc.eventType)), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original TAP record plus eventType")
+	}
+
+	// Request contract: format=json and an interval of two RFC3339 timestamps,
+	// starting 2 minutes before the poll cursor and ending around now.
+	format, start, end := mock.lastRequest()
+	assert.Equal(t, "json", format)
+	assert.False(t, end.Before(start), "interval end must not precede its start")
+	assert.LessOrEqual(t, end.Sub(start), time.Hour, "the adapter must never request more than an hour")
+	assert.WithinDuration(t, time.Now(), end, 5*time.Second, "interval end should be the poll time")
+	assert.WithinDuration(t, time.Now().Add(-2*time.Minute), start, 5*time.Second,
+		"interval start should trail the cursor by the 2 minute overlap")
+}
+
+// TestMockNewEventMidRunShipsOnce verifies an event appearing while the
+// adapter is running is shipped exactly once, and already-shipped events are
+// never re-sent even though every poll re-queries an overlapping window.
+func TestMockNewEventMidRunShipsOnce(t *testing.T) {
+	mock := newMockProofpointTap(testPrincipal, testSecret)
+	now := time.Now()
+	first := realisticMessageEvent("11111111-1111-1111-1111-000000000001", now.Add(-30*time.Second))
+	second := realisticClickEvent("11111111-1111-1111-1111-000000000002", now.Add(-20*time.Second))
+	mock.addEvent(catMessagesDelivered, now.Add(-30*time.Second), first)
+	mock.addEvent(catClicksBlocked, now.Add(-20*time.Second), second)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, testPrincipal, testSecret, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		8*time.Second, 20*time.Millisecond)
+
+	// A new blocked message lands mid-run.
+	third := realisticMessageEvent("11111111-1111-1111-1111-000000000003", time.Now())
+	mock.addEvent(catMessagesBlocked, time.Now(), third)
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		8*time.Second, 20*time.Millisecond, "the new event should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerKey := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		et, _ := msg.JsonPayload["eventType"].(string)
+		if strings.HasPrefix(et, "message_") {
+			shippedPerKey[msg.JsonPayload["GUID"].(string)]++
+		} else {
+			shippedPerKey[msg.JsonPayload["id"].(string)]++
+		}
+	}
+	assert.Equal(t, map[string]int{
+		"11111111-1111-1111-1111-000000000001": 1,
+		"11111111-1111-1111-1111-000000000002": 1,
+		"11111111-1111-1111-1111-000000000003": 1,
+	}, shippedPerKey, "every event must ship exactly once")
+}
+
+// TestMockRejectsBadCredentialsShipsNothing verifies bad credentials ship
+// nothing. The adapter's behavior on a 401 is to report the error and keep
+// polling with an unchanged cursor (it does not stop), so the test also pins
+// that: repeated rejected requests, no shutdown.
+func TestMockRejectsBadCredentialsShipsNothing(t *testing.T) {
+	mock := newMockProofpointTap(testPrincipal, testSecret)
+	mock.addEvent(catMessagesDelivered, time.Now(),
+		realisticMessageEvent("11111111-1111-1111-1111-404040404040", time.Now()))
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	var apiErrors atomic.Int32
+	opts := testClientOptions(t)
+	prevOnError := opts.OnError
+	opts.OnError = func(err error) {
+		apiErrors.Add(1)
+		prevOnError(err)
+	}
+
+	sink := &captureSink{}
+	conf := ProofpointTapConfig{
+		ClientOptions: opts,
+		Principal:     testPrincipal,
+		Secret:        "wrong-secret-00000000000000000000",
+		URL:           server.URL,
+		PollInterval:  25 * time.Millisecond,
+	}
+	adapter, chStopped, err := newProofpointTapAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The adapter keeps polling (and keeps being rejected) rather than stopping.
+	require.Eventually(t, func() bool { return mock.authFailureCount() >= 2 },
+		5*time.Second, 20*time.Millisecond, "the adapter should keep retrying on 401")
+	require.Eventually(t, func() bool { return apiErrors.Load() >= 1 },
+		5*time.Second, 20*time.Millisecond, "the 401 must be surfaced via OnError")
+
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter stopped on a 401; its documented behavior is to keep polling")
+	default:
+	}
+
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	assert.GreaterOrEqual(t, mock.requestCount(), 2)
+}
+
+// TestMockHourCapOnBacklog verifies that when the cursor is far in the past
+// the adapter requests at most a one-hour interval (59 minutes plus the
+// 2-minute overlap trim) and advances its cursor to the returned queryEndTime,
+// rather than asking the API for an over-wide window it would reject.
+func TestMockHourCapOnBacklog(t *testing.T) {
+	mock := newMockProofpointTap(testPrincipal, testSecret)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	conf := ProofpointTapConfig{
+		ClientOptions: testClientOptions(t),
+		Principal:     testPrincipal,
+		Secret:        testSecret,
+		URL:           server.URL,
+		PollInterval:  time.Hour, // the background poller idles for the whole test
+	}
+	adapter, _, err := newProofpointTapAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	since := time.Now().Add(-3 * time.Hour)
+	items, newSince, reqErr := adapter.makeOneRequest(since)
+	require.NoError(t, reqErr)
+	assert.Empty(t, items, "no events exist in the requested backlog window")
+
+	_, start, end := mock.lastRequest()
+	assert.Equal(t, 59*time.Minute, end.Sub(start),
+		"a backlogged cursor must be queried as a capped 59 minute interval")
+	assert.WithinDuration(t, since.Add(-2*time.Minute), start, 2*time.Second,
+		"the capped interval still starts at cursor-2min")
+
+	// The cursor advances to the response's queryEndTime (the interval end),
+	// so the adapter walks the backlog forward an hour at a time.
+	assert.WithinDuration(t, end, newSince, 2*time.Second)
+}

--- a/proofpoint_tap/mock_test.go
+++ b/proofpoint_tap/mock_test.go
@@ -23,9 +23,11 @@ import (
 // -- can be asserted.
 //
 // The mock reproduces the API as the adapter uses it: it authenticates the
-// Basic principal/secret pair, requires format=json, parses the
-// interval=<ISO8601>/<ISO8601> window parameter, filters the in-memory event
-// set by that window, and answers with the documented envelope
+// Basic principal/secret pair, requires the format=json the adapter always
+// sends, parses the interval=<ISO8601>/<ISO8601> window parameter and
+// enforces its documented limits (30s..1h wide, within the 7-day retention),
+// filters the in-memory event set by that window, and answers with the
+// documented envelope
 // {"queryEndTime": ..., "messagesDelivered": [...], "messagesBlocked": [...],
 // "clicksPermitted": [...], "clicksBlocked": [...]}.
 
@@ -151,12 +153,16 @@ func (m *mockProofpointTap) handler() http.HandlerFunc {
 		q := r.URL.Query()
 		m.lastFormat = q.Get("format")
 		if m.lastFormat != "json" {
+			// The real API defaults format to syslog; the mock only speaks
+			// JSON, which is what the adapter must always request.
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte("The request was missing a mandatory request parameter"))
+			_, _ = w.Write([]byte("mock only supports format=json"))
 			return
 		}
 
-		// interval=<ISO8601 start>/<ISO8601 end>, at most one hour wide.
+		// interval=<ISO8601 start>/<ISO8601 end>. Documented limits: at least
+		// 30 seconds wide, at most one hour wide, and no further than 7 days
+		// into the past.
 		parts := strings.SplitN(q.Get("interval"), "/", 2)
 		if len(parts) != 2 {
 			w.WriteHeader(http.StatusBadRequest)
@@ -178,6 +184,16 @@ func (m *mockProofpointTap) handler() http.HandlerFunc {
 		if end.Sub(start) > time.Hour {
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte("The requested interval is too wide"))
+			return
+		}
+		if end.Sub(start) < 30*time.Second {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("The requested interval is too narrow"))
+			return
+		}
+		if time.Since(start) > 7*24*time.Hour {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("The requested interval is too far into the past"))
 			return
 		}
 		m.lastIntervalStart, m.lastIntervalEnd = start, end
@@ -524,8 +540,9 @@ func TestMockRejectsBadCredentialsShipsNothing(t *testing.T) {
 }
 
 // TestMockHourCapOnBacklog verifies that when the cursor is far in the past
-// the adapter requests at most a one-hour interval (59 minutes plus the
-// 2-minute overlap trim) and advances its cursor to the returned queryEndTime,
+// the adapter requests at most a one-hour interval (it asks for the 1-hour
+// cap minus a 1-minute trim, i.e. a 59-minute window starting at the
+// cursor-2min overlap) and advances its cursor to the returned queryEndTime,
 // rather than asking the API for an over-wide window it would reject.
 func TestMockHourCapOnBacklog(t *testing.T) {
 	mock := newMockProofpointTap(testPrincipal, testSecret)

--- a/slack/client.go
+++ b/slack/client.go
@@ -18,13 +18,26 @@ import (
 )
 
 const (
-	apiURL = "https://api.slack.com/audit/v1/logs"
+	defaultApiURL       = "https://api.slack.com/audit/v1/logs"
+	defaultPollInterval = 5 * time.Second
 )
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
 
 type SlackAdapter struct {
 	conf       SlackConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
+
+	apiURL       string
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -43,6 +56,15 @@ type slackResponse struct {
 type SlackConfig struct {
 	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 	Token         string                  `json:"token" yaml:"token"`
+
+	// ApiURL overrides the Slack Audit Logs API endpoint. Empty means the
+	// public endpoint: https://api.slack.com/audit/v1/logs
+	ApiURL string `json:"api_url" yaml:"api_url"`
+
+	// PollInterval overrides the wait between polls of the audit logs
+	// endpoint (default 5s). It is not settable through a config file; it
+	// exists as a seam for tests.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *SlackConfig) Validate() error {
@@ -56,16 +78,36 @@ func (c *SlackConfig) Validate() error {
 }
 
 func NewSlackAdapter(ctx context.Context, conf SlackConfig) (*SlackAdapter, chan struct{}, error) {
-	var err error
+	return newSlackAdapter(ctx, conf, nil)
+}
+
+// newSlackAdapter is the implementation behind NewSlackAdapter. When sink is
+// nil a real LimaCharlie client is created from the config; tests pass an
+// in-memory sink instead.
+func newSlackAdapter(ctx context.Context, conf SlackConfig, sink uspSink) (*SlackAdapter, chan struct{}, error) {
 	a := &SlackAdapter{
 		conf:   conf,
 		ctx:    context.Background(),
 		doStop: utils.NewEvent(),
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	a.apiURL = conf.ApiURL
+	if a.apiURL == "" {
+		a.apiURL = defaultApiURL
+	}
+	a.pollInterval = conf.PollInterval
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -109,7 +151,7 @@ func (a *SlackAdapter) fetchEvents() {
 	// Initianlize the search parameters
 	lastTime := time.Now().Unix()
 
-	for !a.doStop.WaitFor(5 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		isItemsProcessed := false
 
 		// Do a non-paged fetch based on time.
@@ -180,7 +222,7 @@ func (a *SlackAdapter) shipEntries(entries []utils.Dict) (int64, error) {
 
 func (a *SlackAdapter) makeOneContentRequest(lastTime int64, page string) ([]utils.Dict, string, error) {
 	// Prepare the request.
-	req, err := http.NewRequest("GET", apiURL, &bytes.Buffer{})
+	req, err := http.NewRequest("GET", a.apiURL, &bytes.Buffer{})
 	if err != nil {
 		a.doStop.Set()
 		a.conf.ClientOptions.OnError(fmt.Errorf("http.NewRequest(): %v", err))

--- a/slack/client_test.go
+++ b/slack/client_test.go
@@ -1,0 +1,81 @@
+package usp_slack
+
+import (
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("requires token", func(t *testing.T) {
+		c := SlackConfig{ClientOptions: testClientOptions(t)}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires valid client options", func(t *testing.T) {
+		c := SlackConfig{Token: "xoxp-1111111111-fake-test-token"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("accepts a complete config", func(t *testing.T) {
+		c := SlackConfig{
+			ClientOptions: testClientOptions(t),
+			Token:         "xoxp-1111111111-fake-test-token",
+		}
+		assert.NoError(t, c.Validate())
+	})
+}
+
+// TestDefaults verifies an empty ApiURL/PollInterval fall back to the public
+// Slack endpoint and the production poll interval, and that overrides stick.
+func TestDefaults(t *testing.T) {
+	t.Run("defaults applied", func(t *testing.T) {
+		sink := &captureSink{}
+		a, _, err := newSlackAdapter(t.Context(), SlackConfig{
+			ClientOptions: testClientOptions(t),
+			Token:         "xoxp-1111111111-fake-test-token",
+		}, sink)
+		require.NoError(t, err)
+		// Close before the first poll interval elapses: no request is ever
+		// made to the (real) default endpoint.
+		defer a.Close()
+
+		assert.Equal(t, "https://api.slack.com/audit/v1/logs", a.apiURL)
+		assert.Equal(t, 5*time.Second, a.pollInterval)
+	})
+
+	t.Run("overrides applied", func(t *testing.T) {
+		sink := &captureSink{}
+		a, _, err := newSlackAdapter(t.Context(), SlackConfig{
+			ClientOptions: testClientOptions(t),
+			Token:         "xoxp-1111111111-fake-test-token",
+			ApiURL:        "https://slack.example.com/audit/v1/logs",
+			PollInterval:  123 * time.Millisecond,
+		}, sink)
+		require.NoError(t, err)
+		defer a.Close()
+
+		assert.Equal(t, "https://slack.example.com/audit/v1/logs", a.apiURL)
+		assert.Equal(t, 123*time.Millisecond, a.pollInterval)
+	})
+}

--- a/slack/mock_test.go
+++ b/slack/mock_test.go
@@ -21,6 +21,11 @@ import (
 // Logs API (https://api.slack.com/audit/v1/logs), capturing the exact messages
 // it ships so their content -- event type, timestamp and verbatim payload --
 // can be asserted without live Slack credentials.
+//
+// The API contract mocked here is taken from the official documentation:
+//   - https://docs.slack.dev/admins/audit-logs-api/ (auth, entry anatomy)
+//   - https://docs.slack.dev/reference/audit-logs-api/methods-actions-reference/
+//     (endpoint, query parameters, ordering, action names, error codes)
 
 // --- in-memory USP sink -----------------------------------------------------
 
@@ -64,11 +69,22 @@ func (s *captureSink) snapshot() []*protocol.DataMessage {
 // documented by Slack, and cursors are opaque continuation tokens over a
 // snapshot of the filtered result set -- supplying a cursor resumes that
 // snapshot regardless of the other parameters, as with the real API.
+//
+// Ordering: the real API returns entries newest-first ("the default ordering
+// being descending (most to least recent)" per the methods reference). The
+// mock defaults to serving oldest-first -- the ordering under which the
+// adapter's "oldest" watermark never re-ships across pages -- and offers
+// newestFirst to reproduce the documented ordering; see
+// TestNewestFirstPaginationReships for the behavior difference that causes.
 type mockSlack struct {
 	mu       sync.Mutex
 	token    string
 	pageSize int
 	entries  []utils.Dict // ascending by date_create
+
+	// newestFirst serves fresh queries in the real API's documented order
+	// (descending date_create) instead of the default ascending order.
+	newestFirst bool
 
 	cursors   map[string][]utils.Dict // continuation token -> remaining entries
 	cursorSeq int
@@ -93,8 +109,8 @@ func newMockSlack(token string, pageSize int) *mockSlack {
 }
 
 // addEntry appends an audit log entry to the dataset. Entries must be added in
-// ascending date_create order (the order the adapter's incremental "oldest"
-// tracking requires to not re-ship).
+// ascending date_create order; serving order is then controlled by
+// newestFirst (the real API serves newest-first).
 func (m *mockSlack) addEntry(e utils.Dict) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -151,9 +167,15 @@ func (m *mockSlack) handler() http.HandlerFunc {
 			return
 		}
 		if r.Header.Get("Authorization") != "Bearer "+m.token {
+			// The live endpoint answers an invalid bearer token with a bare
+			// 401 and an empty body (Content-Type: application/json,
+			// Content-Length: 0); the documented error codes for this API
+			// are invalid_authentication / missing_authentication, but no
+			// body envelope is documented or observed. The adapter only
+			// looks at the status code.
 			m.authFailures++
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			w.WriteHeader(http.StatusUnauthorized)
-			_, _ = w.Write([]byte(`{"ok":false,"error":"not_authed"}`))
 			return
 		}
 
@@ -167,8 +189,9 @@ func (m *mockSlack) handler() http.HandlerFunc {
 			m.pagedRequests++
 			remaining, ok := m.cursors[cur]
 			if !ok {
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_cursor"}`))
+				// Mock-internal guard: the adapter should only ever echo
+				// back a cursor this mock handed out.
+				http.Error(w, "mock: unknown cursor", http.StatusBadRequest)
 				return
 			}
 			page, remaining = splitPage(remaining, m.pageSize)
@@ -189,6 +212,11 @@ func (m *mockSlack) handler() http.HandlerFunc {
 				ts, _ := e.GetInt("date_create")
 				if int64(ts) >= oldest {
 					matched = append(matched, e)
+				}
+			}
+			if m.newestFirst {
+				for i, j := 0, len(matched)-1; i < j; i, j = i+1, j-1 {
+					matched[i], matched[j] = matched[j], matched[i]
 				}
 			}
 			var remaining []utils.Dict
@@ -222,8 +250,10 @@ func splitPage(entries []utils.Dict, n int) ([]utils.Dict, []utils.Dict) {
 // --- fixtures ----------------------------------------------------------------
 
 // auditEntry builds a realistic Slack audit log entry, shaped like the real
-// API's payloads: a UUID id, an epoch date_create, an action, and nested
-// actor/entity/context objects.
+// API's payloads: a UUID id, an epoch-seconds date_create, an action, and
+// nested actor/entity/context objects, following the documented anatomy
+// (https://docs.slack.dev/admins/audit-logs-api/). All identifiers are
+// obviously-fake placeholders.
 func auditEntry(id string, dateCreate int64, action string) utils.Dict {
 	return utils.Dict{
 		"id":          id,
@@ -255,12 +285,11 @@ func auditEntry(id string, dateCreate int64, action string) utils.Dict {
 			},
 			"ua":         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ExampleAgent/1.0",
 			"ip_address": "198.51.100.1",
-			"session_id": 1111111111,
+			"session_id": "1111111111",
 		},
 		"details": utils.Dict{
 			"is_internal_integration": false,
 			"app_owner_id":            "W111AA111",
-			"md5":                     "11111111111111111111111111111111",
 		},
 	}
 }
@@ -438,7 +467,11 @@ func TestMidRunEntryShipsExactlyOnce(t *testing.T) {
 
 // TestMultiPagePaginationFullyConsumed verifies the adapter exhausts the
 // next_cursor chain: a dataset spanning several pages is fully shipped, each
-// entry exactly once, and stays shipped-once across later polls.
+// entry exactly once, and stays shipped-once across later polls. The mock
+// serves pages oldest-first here, the ordering under which the adapter's
+// last-page watermark is exact; see TestNewestFirstPaginationReships for the
+// documented (descending) ordering, where multi-page delivery degrades to
+// at-least-once.
 func TestMultiPagePaginationFullyConsumed(t *testing.T) {
 	const token = "xoxp-1111111111-fake-test-token"
 	base := time.Now().Unix() + 5
@@ -474,6 +507,65 @@ func TestMultiPagePaginationFullyConsumed(t *testing.T) {
 	require.Eventually(t, func() bool { return mock.requestCount() >= reqs+3 },
 		5*time.Second, 10*time.Millisecond)
 	assert.Equal(t, len(fixtures), sink.count())
+}
+
+// TestNewestFirstPaginationReships pins the adapter's behavior against the
+// documented Slack ordering: the real API returns entries newest-first
+// ("descending (most to least recent)" per
+// https://docs.slack.dev/reference/audit-logs-api/methods-actions-reference/).
+// Because the adapter's "oldest" watermark is the max date_create of the LAST
+// page it processed (+1 per cycle), a multi-page newest-first response leaves
+// the watermark anchored at the oldest chunk, so the newer pages re-ship on
+// subsequent polls until the watermark converges. With 5 entries (date_create
+// base..base+4) and a page size of 2 this is fully deterministic:
+//
+//	poll 1 (oldest<=base):  ships e5,e4 | e3,e2 | e1  -> watermark base+1
+//	poll 2 (oldest=base+1): ships e5,e4 | e3,e2       -> watermark base+3
+//	poll 3 (oldest=base+3): ships e5,e4               -> watermark base+5
+//	poll 4+ : nothing
+//
+// for a total of 11 ships: e1 once, e2/e3 twice, e4/e5 three times. Every
+// entry is eventually delivered (no loss), but multi-page responses are
+// at-least-once, not exactly-once.
+func TestNewestFirstPaginationReships(t *testing.T) {
+	const token = "xoxp-1111111111-fake-test-token"
+	base := time.Now().Unix() + 5
+
+	mock := newMockSlack(token, 2)
+	mock.newestFirst = true
+	for i := 0; i < 5; i++ {
+		mock.addEntry(auditEntry(fixtureID(i+1), base+int64(i), "user_login"))
+	}
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _, err := newSlackAdapter(t.Context(), testConf(t, server.URL, token), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The ship count converges to exactly 11 (see trace above)...
+	require.Eventually(t, func() bool { return sink.count() >= 11 },
+		5*time.Second, 10*time.Millisecond, "expected the watermark to converge after re-ships")
+	// ... and stays there once the watermark has passed the newest entry.
+	reqs := mock.requestCount()
+	require.Eventually(t, func() bool { return mock.requestCount() >= reqs+3 },
+		5*time.Second, 10*time.Millisecond)
+	assert.Equal(t, 11, sink.count(), "ships must stop once the watermark converges")
+
+	shipsPerID := map[string]int{}
+	for _, m := range sink.snapshot() {
+		id, _ := m.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		shipsPerID[id]++
+	}
+	assert.Equal(t, map[string]int{
+		fixtureID(1): 1,
+		fixtureID(2): 2,
+		fixtureID(3): 2,
+		fixtureID(4): 3,
+		fixtureID(5): 3,
+	}, shipsPerID, "newest-first pagination re-ships newer pages until the watermark converges")
 }
 
 // TestBadTokenShipsNothing pins the adapter's actual behavior on auth failure:

--- a/slack/mock_test.go
+++ b/slack/mock_test.go
@@ -1,0 +1,539 @@
+package usp_slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock of the Slack Audit
+// Logs API (https://api.slack.com/audit/v1/logs), capturing the exact messages
+// it ships so their content -- event type, timestamp and verbatim payload --
+// can be asserted without live Slack credentials.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Slack Audit Logs API ----------------------------------------------
+
+// mockSlack is an in-memory stand-in for the Slack Audit Logs API. It honours
+// the contract the adapter relies on: a GET with a "Bearer <token>"
+// Authorization header and "oldest"/"cursor" query parameters, answered with
+// the {"entries": [...], "response_metadata": {"next_cursor": "..."}}
+// envelope. The "oldest" filter is inclusive (date_create >= oldest), as
+// documented by Slack, and cursors are opaque continuation tokens over a
+// snapshot of the filtered result set -- supplying a cursor resumes that
+// snapshot regardless of the other parameters, as with the real API.
+type mockSlack struct {
+	mu       sync.Mutex
+	token    string
+	pageSize int
+	entries  []utils.Dict // ascending by date_create
+
+	cursors   map[string][]utils.Dict // continuation token -> remaining entries
+	cursorSeq int
+
+	requests      int
+	pagedRequests int
+	authFailures  int
+	oldestSeen    []int64
+
+	// First-request capture, for asserting the request shape.
+	gotMethod string
+	gotPath   string
+	gotAuth   string
+}
+
+func newMockSlack(token string, pageSize int) *mockSlack {
+	return &mockSlack{
+		token:    token,
+		pageSize: pageSize,
+		cursors:  map[string][]utils.Dict{},
+	}
+}
+
+// addEntry appends an audit log entry to the dataset. Entries must be added in
+// ascending date_create order (the order the adapter's incremental "oldest"
+// tracking requires to not re-ship).
+func (m *mockSlack) addEntry(e utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = append(m.entries, e)
+}
+
+func (m *mockSlack) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+func (m *mockSlack) pagedRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pagedRequests
+}
+
+func (m *mockSlack) authFailureCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.authFailures
+}
+
+func (m *mockSlack) firstRequest() (method, path, auth string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.gotMethod, m.gotPath, m.gotAuth
+}
+
+func (m *mockSlack) firstOldest() (int64, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.oldestSeen) == 0 {
+		return 0, false
+	}
+	return m.oldestSeen[0], true
+}
+
+func (m *mockSlack) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		m.requests++
+		if m.gotMethod == "" {
+			m.gotMethod = r.Method
+			m.gotPath = r.URL.Path
+			m.gotAuth = r.Header.Get("Authorization")
+		}
+
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer "+m.token {
+			m.authFailures++
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"ok":false,"error":"not_authed"}`))
+			return
+		}
+
+		q := r.URL.Query()
+		var page []utils.Dict
+		next := ""
+
+		if cur := q.Get("cursor"); cur != "" {
+			// Continuation of a previous snapshot; the cursor is opaque and
+			// self-contained, the other parameters do not re-filter it.
+			m.pagedRequests++
+			remaining, ok := m.cursors[cur]
+			if !ok {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_cursor"}`))
+				return
+			}
+			page, remaining = splitPage(remaining, m.pageSize)
+			if len(remaining) > 0 {
+				m.cursors[cur] = remaining
+				next = cur
+			} else {
+				delete(m.cursors, cur)
+			}
+		} else {
+			// Fresh query: filter by oldest (inclusive) and snapshot the rest
+			// behind a new cursor when it does not fit in one page.
+			oldest, _ := strconv.ParseInt(q.Get("oldest"), 10, 64)
+			m.oldestSeen = append(m.oldestSeen, oldest)
+
+			var matched []utils.Dict
+			for _, e := range m.entries {
+				ts, _ := e.GetInt("date_create")
+				if int64(ts) >= oldest {
+					matched = append(matched, e)
+				}
+			}
+			var remaining []utils.Dict
+			page, remaining = splitPage(matched, m.pageSize)
+			if len(remaining) > 0 {
+				m.cursorSeq++
+				tok := fmt.Sprintf("dXNlcjpVMEc5V0Z%d=", m.cursorSeq)
+				m.cursors[tok] = remaining
+				next = tok
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]interface{}{
+			"entries": page,
+			"response_metadata": map[string]interface{}{
+				"next_cursor": next,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func splitPage(entries []utils.Dict, n int) ([]utils.Dict, []utils.Dict) {
+	if n <= 0 || len(entries) <= n {
+		return entries, nil
+	}
+	return entries[:n], entries[n:]
+}
+
+// --- fixtures ----------------------------------------------------------------
+
+// auditEntry builds a realistic Slack audit log entry, shaped like the real
+// API's payloads: a UUID id, an epoch date_create, an action, and nested
+// actor/entity/context objects.
+func auditEntry(id string, dateCreate int64, action string) utils.Dict {
+	return utils.Dict{
+		"id":          id,
+		"date_create": dateCreate,
+		"action":      action,
+		"actor": utils.Dict{
+			"type": "user",
+			"user": utils.Dict{
+				"id":    "W111AA111",
+				"name":  "John Doe",
+				"email": "jdoe@example.com",
+				"team":  "T111AA111",
+			},
+		},
+		"entity": utils.Dict{
+			"type": "workspace",
+			"workspace": utils.Dict{
+				"id":     "T111AA111",
+				"name":   "Example Workspace",
+				"domain": "example",
+			},
+		},
+		"context": utils.Dict{
+			"location": utils.Dict{
+				"type":   "enterprise",
+				"id":     "E111AA111",
+				"name":   "Example Enterprise",
+				"domain": "example",
+			},
+			"ua":         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ExampleAgent/1.0",
+			"ip_address": "198.51.100.1",
+			"session_id": 1111111111,
+		},
+		"details": utils.Dict{
+			"is_internal_integration": false,
+			"app_owner_id":            "W111AA111",
+			"md5":                     "11111111111111111111111111111111",
+		},
+	}
+}
+
+// fixtureID returns the all-1s UUID with the given 2-digit suffix.
+func fixtureID(n int) string {
+	return fmt.Sprintf("11111111-1111-1111-1111-1111111111%02d", n)
+}
+
+// testConf wires a SlackConfig at the mock server with a fast poll interval.
+func testConf(t *testing.T, serverURL string, token string) SlackConfig {
+	t.Helper()
+	return SlackConfig{
+		ClientOptions: testClientOptions(t),
+		Token:         token,
+		ApiURL:        serverURL + "/audit/v1/logs",
+		PollInterval:  50 * time.Millisecond,
+	}
+}
+
+// shippedByID indexes shipped messages by the payload "id" field, failing the
+// test if an id ships more than once.
+func shippedByID(t *testing.T, msgs []*protocol.DataMessage) map[string]*protocol.DataMessage {
+	t.Helper()
+	out := map[string]*protocol.DataMessage{}
+	for _, m := range msgs {
+		id, _ := m.JsonPayload["id"].(string)
+		require.NotEmpty(t, id, "shipped payload has no id: %#v", m.JsonPayload)
+		require.NotContains(t, out, id, "entry %q shipped more than once", id)
+		out[id] = m
+	}
+	return out
+}
+
+// --- end-to-end tests ---------------------------------------------------------
+
+// TestAllEntriesShipVerbatim verifies every available audit log entry is
+// shipped with the verbatim Slack payload, a ship-time TimestampMs and the
+// (empty) EventType the adapter actually sets, and that the request the
+// adapter sends has the right shape: GET, Bearer token, and an "oldest"
+// parameter anchored at adapter start time.
+func TestAllEntriesShipVerbatim(t *testing.T) {
+	const token = "xoxp-1111111111-fake-test-token"
+
+	beforeStart := time.Now()
+	base := beforeStart.Unix() + 5
+	fixtures := []utils.Dict{
+		auditEntry(fixtureID(1), base, "user_login"),
+		auditEntry(fixtureID(2), base+1, "file_downloaded"),
+		auditEntry(fixtureID(3), base+2, "user_logout"),
+	}
+
+	mock := newMockSlack(token, 100)
+	for _, f := range fixtures {
+		mock.addEntry(f)
+	}
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, chStopped, err := newSlackAdapter(t.Context(), testConf(t, server.URL, token), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == len(fixtures) },
+		5*time.Second, 10*time.Millisecond, "expected all %d entries to ship", len(fixtures))
+	afterShip := time.Now()
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped unexpectedly")
+	default:
+	}
+
+	// Request shape.
+	method, path, auth := mock.firstRequest()
+	assert.Equal(t, http.MethodGet, method)
+	assert.Equal(t, "/audit/v1/logs", path)
+	assert.Equal(t, "Bearer "+token, auth)
+	oldest, ok := mock.firstOldest()
+	require.True(t, ok, "first request must carry an oldest parameter")
+	assert.GreaterOrEqual(t, oldest, beforeStart.Unix(), "oldest anchors at adapter start")
+	assert.LessOrEqual(t, oldest, afterShip.Unix())
+
+	// Shipped content.
+	byID := shippedByID(t, sink.snapshot())
+	require.Len(t, byID, len(fixtures))
+	for _, f := range fixtures {
+		id := f["id"].(string)
+		msg, ok := byID[id]
+		require.True(t, ok, "entry %q never shipped", id)
+
+		// Verbatim payload: exactly the JSON the API returned, unreshaped.
+		want, err := json.Marshal(f)
+		require.NoError(t, err)
+		got, err := json.Marshal(msg.JsonPayload)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(want), string(got), "payload for %q must ship verbatim", id)
+
+		// The adapter stamps ship time (not date_create) and no event type.
+		assert.Equal(t, "", msg.EventType, "adapter does not set an EventType")
+		assert.GreaterOrEqual(t, msg.TimestampMs, uint64(beforeStart.UnixMilli()))
+		assert.LessOrEqual(t, msg.TimestampMs, uint64(afterShip.UnixMilli()))
+	}
+}
+
+// TestRepollDoesNotReship verifies that once entries have shipped, subsequent
+// polls (which carry an advanced "oldest") do not ship them again.
+func TestRepollDoesNotReship(t *testing.T) {
+	const token = "xoxp-1111111111-fake-test-token"
+	base := time.Now().Unix() + 5
+
+	mock := newMockSlack(token, 100)
+	mock.addEntry(auditEntry(fixtureID(1), base, "user_login"))
+	mock.addEntry(auditEntry(fixtureID(2), base+1, "user_login"))
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _, err := newSlackAdapter(t.Context(), testConf(t, server.URL, token), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 10*time.Millisecond)
+
+	// Let at least three more polls happen, then confirm nothing re-shipped.
+	reqs := mock.requestCount()
+	require.Eventually(t, func() bool { return mock.requestCount() >= reqs+3 },
+		5*time.Second, 10*time.Millisecond, "adapter should keep polling")
+	assert.Equal(t, 2, sink.count(), "re-polls must not re-ship already-shipped entries")
+	shippedByID(t, sink.snapshot()) // each id exactly once
+}
+
+// TestMidRunEntryShipsExactlyOnce verifies an entry that appears while the
+// adapter is already polling is picked up and shipped exactly once.
+func TestMidRunEntryShipsExactlyOnce(t *testing.T) {
+	const token = "xoxp-1111111111-fake-test-token"
+	base := time.Now().Unix() + 5
+
+	mock := newMockSlack(token, 100)
+	mock.addEntry(auditEntry(fixtureID(1), base, "user_login"))
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _, err := newSlackAdapter(t.Context(), testConf(t, server.URL, token), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 10*time.Millisecond, "initial entry should ship")
+
+	// A new audit event occurs mid-run, strictly newer than what shipped.
+	late := auditEntry(fixtureID(2), base+10, "user_channel_join")
+	mock.addEntry(late)
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 10*time.Millisecond, "mid-run entry should ship")
+
+	// Several polls later it still shipped only once.
+	reqs := mock.requestCount()
+	require.Eventually(t, func() bool { return mock.requestCount() >= reqs+3 },
+		5*time.Second, 10*time.Millisecond)
+	assert.Equal(t, 2, sink.count(), "mid-run entry must ship exactly once")
+	byID := shippedByID(t, sink.snapshot())
+	require.Contains(t, byID, fixtureID(2))
+
+	want, err := json.Marshal(late)
+	require.NoError(t, err)
+	got, err := json.Marshal(byID[fixtureID(2)].JsonPayload)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(want), string(got))
+}
+
+// TestMultiPagePaginationFullyConsumed verifies the adapter exhausts the
+// next_cursor chain: a dataset spanning several pages is fully shipped, each
+// entry exactly once, and stays shipped-once across later polls.
+func TestMultiPagePaginationFullyConsumed(t *testing.T) {
+	const token = "xoxp-1111111111-fake-test-token"
+	base := time.Now().Unix() + 5
+
+	// 5 entries with a page size of 2 -> 3 pages (two of them cursor-driven).
+	mock := newMockSlack(token, 2)
+	fixtures := make([]utils.Dict, 0, 5)
+	for i := 0; i < 5; i++ {
+		f := auditEntry(fixtureID(i+1), base+int64(i), "user_login")
+		fixtures = append(fixtures, f)
+		mock.addEntry(f)
+	}
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _, err := newSlackAdapter(t.Context(), testConf(t, server.URL, token), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == len(fixtures) },
+		5*time.Second, 10*time.Millisecond, "all pages should be consumed")
+	assert.GreaterOrEqual(t, mock.pagedRequestCount(), 2,
+		"the dataset spans 3 pages, so at least 2 cursor requests were required")
+
+	byID := shippedByID(t, sink.snapshot())
+	for _, f := range fixtures {
+		assert.Contains(t, byID, f["id"].(string))
+	}
+
+	// Later polls must not re-ship any page.
+	reqs := mock.requestCount()
+	require.Eventually(t, func() bool { return mock.requestCount() >= reqs+3 },
+		5*time.Second, 10*time.Millisecond)
+	assert.Equal(t, len(fixtures), sink.count())
+}
+
+// TestBadTokenShipsNothing pins the adapter's actual behavior on auth failure:
+// the Audit Logs API answers 401, the adapter reports the error and ships
+// nothing -- but it does NOT stop; it keeps polling (a non-200 is reported via
+// OnError and surfaced as a nil-error empty result to the poll loop).
+func TestBadTokenShipsNothing(t *testing.T) {
+	const token = "xoxp-1111111111-fake-test-token"
+	base := time.Now().Unix() + 5
+
+	mock := newMockSlack(token, 100)
+	mock.addEntry(auditEntry(fixtureID(1), base, "user_login"))
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	var apiErrors atomic.Int32
+	conf := testConf(t, server.URL, "xoxp-2222222222-wrong-token")
+	conf.ClientOptions.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		apiErrors.Add(1)
+	}
+
+	sink := &captureSink{}
+	adapter, chStopped, err := newSlackAdapter(t.Context(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// Let several polls fail authentication.
+	require.Eventually(t, func() bool { return mock.authFailureCount() >= 3 },
+		5*time.Second, 10*time.Millisecond, "adapter keeps polling despite 401s")
+
+	assert.Equal(t, 0, sink.count(), "nothing may ship with a bad token")
+	assert.GreaterOrEqual(t, apiErrors.Load(), int32(1), "401s must be reported via OnError")
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped on 401; current behavior is to keep polling")
+	default:
+	}
+}
+
+// TestUnreachableAPIStopsAdapter pins the adapter's behavior on transport
+// errors: a failed HTTP request terminates the polling loop (chStopped closes)
+// and nothing ships.
+func TestUnreachableAPIStopsAdapter(t *testing.T) {
+	// Grab a URL that refuses connections.
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := server.URL
+	server.Close()
+
+	sink := &captureSink{}
+	adapter, chStopped, err := newSlackAdapter(t.Context(),
+		testConf(t, deadURL, "xoxp-1111111111-fake-test-token"), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	select {
+	case <-chStopped:
+		// Expected: a transport error terminates the fetch loop.
+	case <-time.After(5 * time.Second):
+		t.Fatal("adapter should stop when the API is unreachable")
+	}
+	assert.Equal(t, 0, sink.count())
+}

--- a/sophos/client.go
+++ b/sophos/client.go
@@ -20,7 +20,24 @@ import (
 
 const (
 	eventsURL = "/siem/v1/events"
+
+	// defaultAuthURL is the Sophos Central OAuth2 token endpoint used when the
+	// config does not override it.
+	defaultAuthURL = "https://id.sophos.com/api/v2/oauth2/token"
+
+	// defaultPollInterval is how long fetchEvents idles between polls of the
+	// SIEM events endpoint.
+	defaultPollInterval = 30 * time.Second
 )
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
 
 type opRequest struct {
 	Limit     int    `json:"page[size],omitempty"`
@@ -30,8 +47,11 @@ type opRequest struct {
 
 type SophosAdapter struct {
 	conf       SophosConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
+
+	authURL      string
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -46,6 +66,15 @@ type SophosConfig struct {
 	ClientSecret  string                  `json:"clientsecret" yaml:"clientsecret"`
 	TenantId      string                  `json:"tenantid" yaml:"tenantid"`
 	URL           string                  `json:"url" yaml:"url"`
+
+	// AuthURL overrides the Sophos Central OAuth2 token endpoint. Defaults to
+	// https://id.sophos.com/api/v2/oauth2/token when empty.
+	AuthURL string `json:"auth_url" yaml:"auth_url"`
+
+	// PollInterval overrides the wait between polls of the SIEM events
+	// endpoint (default 30s). It is not settable through a config file; it
+	// exists as a seam for tests.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *SophosConfig) Validate() error {
@@ -68,16 +97,36 @@ func (c *SophosConfig) Validate() error {
 }
 
 func NewSophosAdapter(ctx context.Context, conf SophosConfig) (*SophosAdapter, chan struct{}, error) {
-	var err error
+	return newSophosAdapter(ctx, conf, nil)
+}
+
+// newSophosAdapter is the implementation behind NewSophosAdapter. When sink is
+// non-nil it is used in place of a real LimaCharlie client -- the seam tests
+// use to capture shipped events.
+func newSophosAdapter(ctx context.Context, conf SophosConfig, sink uspSink) (*SophosAdapter, chan struct{}, error) {
 	a := &SophosAdapter{
 		conf:   conf,
 		ctx:    context.Background(),
 		doStop: utils.NewEvent(),
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	a.authURL = conf.AuthURL
+	if a.authURL == "" {
+		a.authURL = defaultAuthURL
+	}
+	a.pollInterval = conf.PollInterval
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -123,7 +172,7 @@ func (a *SophosAdapter) fetchEvents(url string) {
 
 	lastCursor := ""
 	has_more := "false"
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// The makeOneRequest function handles error
 		// handling and fatal error handling.
 		items, newCursor, has_more_resp := a.makeOneRequest(url, lastCursor, has_more)
@@ -156,7 +205,7 @@ func (a *SophosAdapter) fetchEvents(url string) {
 
 func (a *SophosAdapter) getJwt() string {
 
-	auth_url := "https://id.sophos.com/api/v2/oauth2/token"
+	auth_url := a.authURL
 	method := "POST"
 
 	payload := strings.NewReader(fmt.Sprintf("grant_type=client_credentials&scope=token&client_id=%s&client_secret=%s", a.conf.ClientId, a.conf.ClientSecret))

--- a/sophos/client_test.go
+++ b/sophos/client_test.go
@@ -1,0 +1,99 @@
+package usp_sophos
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// testConfig returns a complete valid config pointed at nothing in particular;
+// tests override URL/AuthURL to aim it at their mock server.
+func testConfig(t *testing.T) SophosConfig {
+	t.Helper()
+	return SophosConfig{
+		ClientOptions: testClientOptions(t),
+		ClientId:      "11111111-2222-3333-4444-555555555555",
+		ClientSecret:  "fake-client-secret-for-tests",
+		TenantId:      "11111111-1111-1111-1111-aaaaaaaaaaaa",
+		URL:           "https://api-us03.central.example.com",
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Run("complete config passes", func(t *testing.T) {
+		c := testConfig(t)
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("requires url", func(t *testing.T) {
+		c := testConfig(t)
+		c.URL = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires client id", func(t *testing.T) {
+		c := testConfig(t)
+		c.ClientId = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires client secret", func(t *testing.T) {
+		c := testConfig(t)
+		c.ClientSecret = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires tenant id", func(t *testing.T) {
+		c := testConfig(t)
+		c.TenantId = ""
+		assert.Error(t, c.Validate())
+	})
+}
+
+// TestSeamDefaults verifies the test seams default to production values when
+// unset, and apply overrides when set.
+func TestSeamDefaults(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		conf := testConfig(t)
+		adapter, _, err := newSophosAdapter(context.Background(), conf, &captureSink{})
+		require.NoError(t, err)
+		defer adapter.Close()
+
+		assert.Equal(t, defaultAuthURL, adapter.authURL,
+			"empty auth_url must fall back to the real Sophos OAuth endpoint")
+		assert.Equal(t, defaultPollInterval, adapter.pollInterval)
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		conf := testConfig(t)
+		conf.AuthURL = "https://auth.example.com/api/v2/oauth2/token"
+		conf.PollInterval = 1 * time.Hour
+		adapter, _, err := newSophosAdapter(context.Background(), conf, &captureSink{})
+		require.NoError(t, err)
+		defer adapter.Close()
+
+		assert.Equal(t, "https://auth.example.com/api/v2/oauth2/token", adapter.authURL)
+		assert.Equal(t, 1*time.Hour, adapter.pollInterval)
+	})
+}

--- a/sophos/mock_test.go
+++ b/sophos/mock_test.go
@@ -1,0 +1,570 @@
+package usp_sophos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock of the Sophos
+// Central SIEM API (OAuth2 token endpoint + /siem/v1/events), capturing the
+// exact messages it ships so their content -- timestamp and verbatim payload --
+// can be asserted.
+
+const (
+	mockTokenPath = "/api/v2/oauth2/token"
+	mockCursorFmt = "cur-%d"
+)
+
+// --- in-memory USP sink -------------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Sophos Central ------------------------------------------------------
+
+// mockSophosCentral is an in-memory stand-in for Sophos Central. It serves:
+//
+//   - POST /api/v2/oauth2/token -- the OAuth2 client-credentials exchange
+//     (grant_type=client_credentials&scope=token&client_id&client_secret as a
+//     form body), returning {"access_token": ..., "token_type": "bearer", ...}.
+//   - GET /siem/v1/events -- the SIEM events endpoint. It authenticates the
+//     Bearer token and the X-Tenant-ID header, honours either ?from_date=<epoch>
+//     (first poll) or ?cursor=<opaque> (subsequent polls), and answers with the
+//     real envelope {"items": [...], "has_more": <bool>, "next_cursor": <string>}.
+//
+// Events are kept oldest-first; a cursor is an opaque "cur-<index>" marking the
+// next event to serve, so a repeated poll at the tail returns no items and the
+// same cursor -- exactly how the real API lets a client tail the event stream.
+type mockSophosCentral struct {
+	t *testing.T
+
+	clientID     string
+	clientSecret string
+	tenantID     string
+
+	mu          sync.Mutex
+	events      []utils.Dict
+	pageSize    int // server-side page cap; 0 means honor the request's limit
+	validTokens map[string]bool
+	tokenSeq    int
+
+	tokenRequests     int
+	fromDateRequests  int
+	cursorRequests    int
+	rejectedEventReqs int
+	lastFromDate      string
+	lastTokenForm     map[string]string
+	lastEventsAuth    string
+	lastEventsTenant  string
+}
+
+func newMockSophosCentral(t *testing.T, clientID, clientSecret, tenantID string) *mockSophosCentral {
+	return &mockSophosCentral{
+		t:            t,
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		tenantID:     tenantID,
+		validTokens:  map[string]bool{},
+	}
+}
+
+func (m *mockSophosCentral) setEvents(events []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = events
+}
+
+// appendEvent adds a new event at the tail of the stream, as Sophos Central
+// does when new telemetry arrives.
+func (m *mockSophosCentral) appendEvent(event utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, event)
+}
+
+func (m *mockSophosCentral) counts() (token, fromDate, cursor, rejected int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests, m.fromDateRequests, m.cursorRequests, m.rejectedEventReqs
+}
+
+func (m *mockSophosCentral) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(mockTokenPath, m.handleToken)
+	mux.HandleFunc(eventsURL, m.handleEvents)
+	return mux
+}
+
+func (m *mockSophosCentral) handleToken(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.tokenRequests++
+	m.mu.Unlock()
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/x-www-form-urlencoded") {
+		writeJSON(w, http.StatusBadRequest, utils.Dict{"error": "invalid_request", "message": "expected form body"})
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, utils.Dict{"error": "invalid_request"})
+		return
+	}
+
+	m.mu.Lock()
+	m.lastTokenForm = map[string]string{
+		"grant_type":    r.PostFormValue("grant_type"),
+		"scope":         r.PostFormValue("scope"),
+		"client_id":     r.PostFormValue("client_id"),
+		"client_secret": r.PostFormValue("client_secret"),
+	}
+	m.mu.Unlock()
+
+	if r.PostFormValue("grant_type") != "client_credentials" ||
+		r.PostFormValue("scope") != "token" {
+		writeJSON(w, http.StatusBadRequest, utils.Dict{
+			"error": "unsupported_grant_type", "message": "grant_type must be client_credentials with scope token",
+		})
+		return
+	}
+	if r.PostFormValue("client_id") != m.clientID || r.PostFormValue("client_secret") != m.clientSecret {
+		writeJSON(w, http.StatusUnauthorized, utils.Dict{
+			"errorCode": "oauth.invalid_client_secret",
+			"message":   "Invalid client id or secret",
+		})
+		return
+	}
+
+	m.mu.Lock()
+	m.tokenSeq++
+	token := fmt.Sprintf("sophos-jwt-%d", m.tokenSeq)
+	m.validTokens[token] = true
+	m.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, utils.Dict{
+		"access_token": token,
+		"token_type":   "bearer",
+		"expires_in":   3600,
+		"message":      "OK",
+		"errorCode":    "success",
+	})
+}
+
+func (m *mockSophosCentral) handleEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	auth := r.Header.Get("Authorization")
+	tenant := r.Header.Get("X-Tenant-ID")
+	token := strings.TrimPrefix(auth, "Bearer ")
+
+	m.mu.Lock()
+	m.lastEventsAuth = auth
+	m.lastEventsTenant = tenant
+	authOK := strings.HasPrefix(auth, "Bearer ") && m.validTokens[token] && tenant == m.tenantID
+	if !authOK {
+		m.rejectedEventReqs++
+		m.mu.Unlock()
+		writeJSON(w, http.StatusUnauthorized, utils.Dict{"error": "Unauthorized", "message": "invalid token or tenant"})
+		return
+	}
+
+	defer m.mu.Unlock()
+
+	// Resolve the starting index from either the cursor or from_date.
+	start := 0
+	if cur := r.URL.Query().Get("cursor"); cur != "" {
+		m.cursorRequests++
+		idx, err := strconv.Atoi(strings.TrimPrefix(cur, "cur-"))
+		if err != nil || !strings.HasPrefix(cur, "cur-") || idx < 0 {
+			writeJSON(w, http.StatusBadRequest, utils.Dict{"error": "Bad Request", "message": "invalid cursor"})
+			return
+		}
+		start = idx
+	} else {
+		fromDate := r.URL.Query().Get("from_date")
+		m.fromDateRequests++
+		m.lastFromDate = fromDate
+		epoch, err := strconv.ParseInt(fromDate, 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, utils.Dict{"error": "Bad Request", "message": "invalid from_date"})
+			return
+		}
+		// Skip events created before from_date.
+		for start < len(m.events) {
+			created, perr := time.Parse(time.RFC3339, m.events[start].FindOneString("created_at"))
+			if perr == nil && !created.Before(time.Unix(epoch, 0)) {
+				break
+			}
+			start++
+		}
+	}
+	if start > len(m.events) {
+		start = len(m.events)
+	}
+
+	// Page the result set: the server caps how many items one response carries.
+	limit := 200
+	if l, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && l > 0 {
+		limit = l
+	}
+	if m.pageSize > 0 && m.pageSize < limit {
+		limit = m.pageSize
+	}
+	end := start + limit
+	if end > len(m.events) {
+		end = len(m.events)
+	}
+
+	items := make([]utils.Dict, 0, end-start)
+	items = append(items, m.events[start:end]...)
+
+	writeJSON(w, http.StatusOK, utils.Dict{
+		"items":       items,
+		"has_more":    end < len(m.events),
+		"next_cursor": fmt.Sprintf(mockCursorFmt, end),
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body utils.Dict) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// --- realistic event fixtures ---------------------------------------------------
+
+// sophosTime renders a timestamp the way Sophos Central does: RFC 3339 UTC with
+// millisecond precision.
+func sophosTime(ts time.Time) string {
+	return ts.UTC().Format("2006-01-02T15:04:05.000Z")
+}
+
+// realisticThreatEvent returns an event shaped like a real Sophos Central SIEM
+// endpoint threat detection.
+func realisticThreatEvent(id string, createdAt time.Time) utils.Dict {
+	when := sophosTime(createdAt)
+	return utils.Dict{
+		"id":            id,
+		"created_at":    when,
+		"when":          when,
+		"severity":      "high",
+		"type":          "Event::Endpoint::Threat::Detected",
+		"name":          `Malware detected: 'EICAR-AV-Test' at 'C:\Users\jdoe\Downloads\eicar.com'`,
+		"group":         "MALWARE",
+		"datastream":    "event",
+		"endpoint_id":   "11111111-1111-1111-1111-111111111111",
+		"endpoint_type": "computer",
+		"customer_id":   "11111111-1111-1111-1111-222222222222",
+		"user_id":       "11111111-1111-1111-1111-333333333333",
+		"source":        `EXAMPLE\jdoe`,
+		"suser":         `EXAMPLE\jdoe`,
+		"location":      "WIN-EXAMPLE-01",
+		"dhost":         "WIN-EXAMPLE-01",
+		"threat":        "EICAR-AV-Test",
+		"source_info":   utils.Dict{"ip": "10.1.2.3"},
+	}
+}
+
+// realisticWebEvent returns an event shaped like a Sophos Central SIEM web
+// control event.
+func realisticWebEvent(id string, createdAt time.Time) utils.Dict {
+	when := sophosTime(createdAt)
+	return utils.Dict{
+		"id":            id,
+		"created_at":    when,
+		"when":          when,
+		"severity":      "medium",
+		"type":          "Event::Endpoint::WebFilteringBlocked",
+		"name":          "Access to 'blocked.example.com' was blocked by policy",
+		"group":         "WEB",
+		"datastream":    "event",
+		"endpoint_id":   "11111111-1111-1111-1111-111111111111",
+		"endpoint_type": "computer",
+		"customer_id":   "11111111-1111-1111-1111-222222222222",
+		"user_id":       "11111111-1111-1111-1111-333333333333",
+		"source":        `EXAMPLE\jdoe`,
+		"suser":         `EXAMPLE\jdoe`,
+		"location":      "WIN-EXAMPLE-01",
+		"dhost":         "WIN-EXAMPLE-01",
+		"source_info":   utils.Dict{"ip": "10.1.2.3"},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// startMockAdapter wires a config at the mock server and starts the adapter
+// with a capture sink and a fast poll interval.
+func startMockAdapter(t *testing.T, server *httptest.Server, conf SophosConfig) (*SophosAdapter, chan struct{}, *captureSink) {
+	t.Helper()
+	conf.URL = server.URL
+	conf.AuthURL = server.URL + mockTokenPath
+	if conf.PollInterval == 0 {
+		conf.PollInterval = 30 * time.Millisecond
+	}
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+	adapter, chStopped, err := newSophosAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adapter.Close() })
+	return adapter, chStopped, sink
+}
+
+// --- tests ---------------------------------------------------------------------
+
+// TestMockEventsEndToEnd drives the adapter against the mock Sophos Central API
+// and asserts the exact events shipped: ingestion-time timestamps and payloads
+// preserved verbatim, with the OAuth exchange, Bearer token, tenant header and
+// from_date/cursor query parameters all validated by the mock. It also asserts
+// that re-polling advances to cursor mode and never re-ships an event.
+func TestMockEventsEndToEnd(t *testing.T) {
+	conf := testConfig(t)
+	mock := newMockSophosCentral(t, conf.ClientId, conf.ClientSecret, conf.TenantId)
+
+	now := time.Now()
+	want := []utils.Dict{
+		realisticThreatEvent("11111111-0000-0000-0000-000000000001", now.Add(-20*time.Second)),
+		realisticWebEvent("11111111-0000-0000-0000-000000000002", now.Add(-15*time.Second)),
+		realisticThreatEvent("11111111-0000-0000-0000-000000000003", now.Add(-10*time.Second)),
+	}
+	mock.setEvents(want)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	startMs := uint64(time.Now().UnixMilli())
+	_, chStopped, sink := startMockAdapter(t, server, conf)
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 events to ship")
+
+	// Re-polling: wait for several cursor polls past the tail, then verify
+	// nothing was re-shipped.
+	require.Eventually(t, func() bool { _, _, cursor, _ := mock.counts(); return cursor >= 3 },
+		5*time.Second, 20*time.Millisecond, "adapter should keep polling with the cursor")
+	assert.Equal(t, 3, sink.count(), "re-polling must not re-ship events")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped unexpectedly")
+	default:
+	}
+
+	// The OAuth exchange carried the client-credentials form.
+	mock.mu.Lock()
+	tokenForm := mock.lastTokenForm
+	eventsAuth := mock.lastEventsAuth
+	eventsTenant := mock.lastEventsTenant
+	lastFromDate := mock.lastFromDate
+	mock.mu.Unlock()
+	require.NotNil(t, tokenForm, "the token endpoint was never called")
+	assert.Equal(t, "client_credentials", tokenForm["grant_type"])
+	assert.Equal(t, "token", tokenForm["scope"])
+	assert.Equal(t, conf.ClientId, tokenForm["client_id"])
+	assert.Equal(t, conf.ClientSecret, tokenForm["client_secret"])
+
+	// The events requests carried the issued Bearer token and the tenant header.
+	assert.True(t, strings.HasPrefix(eventsAuth, "Bearer sophos-jwt-"),
+		"events request must carry the issued bearer token, got %q", eventsAuth)
+	assert.Equal(t, conf.TenantId, eventsTenant)
+
+	// The first poll used from_date = now-30s (epoch seconds); later polls use
+	// the cursor.
+	tokenN, fromDateN, _, rejectedN := mock.counts()
+	assert.GreaterOrEqual(t, tokenN, 2, "a JWT is fetched on every poll")
+	assert.Equal(t, 1, fromDateN, "only the first poll uses from_date")
+	assert.Equal(t, 0, rejectedN, "no request should have failed authentication")
+	fd, err := strconv.ParseInt(lastFromDate, 10, 64)
+	require.NoError(t, err, "from_date must be epoch seconds, got %q", lastFromDate)
+	assert.GreaterOrEqual(t, fd, now.Unix()-31, "from_date should be ~30s before the poll")
+	assert.LessOrEqual(t, fd, time.Now().Unix()-29, "from_date should be ~30s before the poll")
+
+	// Each shipped message preserves the event verbatim and is stamped with
+	// ingestion time (the adapter does not parse event timestamps).
+	endMs := uint64(time.Now().UnixMilli())
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		assert.Equal(t, "", msg.EventType, "the adapter does not tag an event type")
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+		assert.GreaterOrEqual(t, msg.TimestampMs, startMs)
+		assert.LessOrEqual(t, msg.TimestampMs, endMs)
+	}
+	require.Len(t, byID, 3)
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "event %s was not shipped", id)
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Sophos event verbatim")
+	}
+}
+
+// TestMockMidRunEventShipsOnce verifies an event arriving after the adapter has
+// caught up is picked up via the cursor and shipped exactly once.
+func TestMockMidRunEventShipsOnce(t *testing.T) {
+	conf := testConfig(t)
+	mock := newMockSophosCentral(t, conf.ClientId, conf.ClientSecret, conf.TenantId)
+
+	now := time.Now()
+	mock.setEvents([]utils.Dict{
+		realisticThreatEvent("11111111-0000-0000-0000-00000000000a", now.Add(-12*time.Second)),
+		realisticThreatEvent("11111111-0000-0000-0000-00000000000b", now.Add(-6*time.Second)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	_, _, sink := startMockAdapter(t, server, conf)
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new event arrives in Sophos Central mid-run.
+	mock.appendEvent(realisticThreatEvent("11111111-0000-0000-0000-00000000000c", time.Now()))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new event should ship")
+
+	// Let a few more cursor polls happen, then check nothing re-shipped.
+	_, _, cursorBase, _ := mock.counts()
+	require.Eventually(t, func() bool { _, _, cursor, _ := mock.counts(); return cursor >= cursorBase+3 },
+		5*time.Second, 20*time.Millisecond)
+	require.Equal(t, 3, sink.count(), "no event may ship more than once")
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{
+		"11111111-0000-0000-0000-00000000000a": 1,
+		"11111111-0000-0000-0000-00000000000b": 1,
+		"11111111-0000-0000-0000-00000000000c": 1,
+	}, shippedPerID, "every event must ship exactly once")
+}
+
+// TestMockMultiPagePagination verifies a dataset spanning several has_more pages
+// is fully consumed (one page per poll tick, following next_cursor) and every
+// event ships exactly once.
+func TestMockMultiPagePagination(t *testing.T) {
+	conf := testConfig(t)
+	mock := newMockSophosCentral(t, conf.ClientId, conf.ClientSecret, conf.TenantId)
+	mock.pageSize = 2 // server-side cap: 5 events => 3 pages
+
+	now := time.Now()
+	const total = 5
+	events := make([]utils.Dict, total)
+	for i := 0; i < total; i++ {
+		events[i] = realisticThreatEvent(
+			fmt.Sprintf("11111111-0000-0000-0000-0000000000%02d", i),
+			now.Add(time.Duration(i-25)*time.Second))
+	}
+	mock.setEvents(events)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	_, _, sink := startMockAdapter(t, server, conf)
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 20*time.Millisecond, "the whole multi-page dataset should ship")
+
+	_, fromDateN, cursorN, _ := mock.counts()
+	assert.Equal(t, 1, fromDateN, "only the first request uses from_date")
+	assert.GreaterOrEqual(t, cursorN, 2, "the remaining pages are walked via next_cursor")
+
+	// A few more polls past the tail must not re-ship anything.
+	require.Eventually(t, func() bool { _, _, cursor, _ := mock.counts(); return cursor >= 5 },
+		5*time.Second, 20*time.Millisecond)
+	assert.Equal(t, total, sink.count())
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["id"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct event should ship exactly once")
+}
+
+// TestMockBadCredentialsShipNothing pins the adapter's behavior on a failed
+// OAuth exchange: it ships nothing and keeps retrying (it does not stop). Each
+// poll fails to obtain a JWT, falls through to the events endpoint with an
+// empty bearer token and is rejected there too.
+func TestMockBadCredentialsShipNothing(t *testing.T) {
+	conf := testConfig(t)
+	mock := newMockSophosCentral(t, conf.ClientId, "the-real-secret", conf.TenantId)
+	mock.setEvents([]utils.Dict{
+		realisticThreatEvent("11111111-0000-0000-0000-000000000001", time.Now().Add(-5*time.Second)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	// conf.ClientSecret does not match the mock's secret.
+	_, chStopped, sink := startMockAdapter(t, server, conf)
+
+	// Wait for several failed polls.
+	require.Eventually(t, func() bool {
+		token, _, _, rejected := mock.counts()
+		return token >= 2 && rejected >= 2
+	}, 5*time.Second, 20*time.Millisecond, "the adapter should keep retrying the exchange")
+
+	assert.Equal(t, 0, sink.count(), "nothing may ship when authentication fails")
+
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter does not stop on auth failure; it retries every poll")
+	default:
+	}
+}

--- a/sophos/mock_test.go
+++ b/sophos/mock_test.go
@@ -285,52 +285,51 @@ func sophosTime(ts time.Time) string {
 }
 
 // realisticThreatEvent returns an event shaped like a real Sophos Central SIEM
-// endpoint threat detection.
+// endpoint threat detection. Field names follow the raw /siem/v1/events schema
+// (id, created_at, when, severity, type, name, group, endpoint_id,
+// endpoint_type, customer_id, user_id, source, location, threat, origin,
+// source_info.ip); "when" is when the event occurred on the endpoint and
+// "created_at" is when Sophos Central ingested it, so created_at trails when.
 func realisticThreatEvent(id string, createdAt time.Time) utils.Dict {
-	when := sophosTime(createdAt)
 	return utils.Dict{
 		"id":            id,
-		"created_at":    when,
-		"when":          when,
+		"created_at":    sophosTime(createdAt),
+		"when":          sophosTime(createdAt.Add(-90 * time.Second)),
 		"severity":      "high",
 		"type":          "Event::Endpoint::Threat::Detected",
 		"name":          `Malware detected: 'EICAR-AV-Test' at 'C:\Users\jdoe\Downloads\eicar.com'`,
 		"group":         "MALWARE",
-		"datastream":    "event",
 		"endpoint_id":   "11111111-1111-1111-1111-111111111111",
 		"endpoint_type": "computer",
 		"customer_id":   "11111111-1111-1111-1111-222222222222",
-		"user_id":       "11111111-1111-1111-1111-333333333333",
-		"source":        `EXAMPLE\jdoe`,
-		"suser":         `EXAMPLE\jdoe`,
+		"user_id":       "111111111111111111111111",
+		"source":        "Jane Doe",
 		"location":      "WIN-EXAMPLE-01",
-		"dhost":         "WIN-EXAMPLE-01",
 		"threat":        "EICAR-AV-Test",
+		"origin":        nil,
 		"source_info":   utils.Dict{"ip": "10.1.2.3"},
 	}
 }
 
 // realisticWebEvent returns an event shaped like a Sophos Central SIEM web
-// control event.
+// filtering event (same raw schema as above; web events carry a null threat).
 func realisticWebEvent(id string, createdAt time.Time) utils.Dict {
-	when := sophosTime(createdAt)
 	return utils.Dict{
 		"id":            id,
-		"created_at":    when,
-		"when":          when,
-		"severity":      "medium",
+		"created_at":    sophosTime(createdAt),
+		"when":          sophosTime(createdAt.Add(-90 * time.Second)),
+		"severity":      "low",
 		"type":          "Event::Endpoint::WebFilteringBlocked",
-		"name":          "Access to 'blocked.example.com' was blocked by policy",
+		"name":          "'https://blocked.example.com' blocked due to category 'Personals and Dating'",
 		"group":         "WEB",
-		"datastream":    "event",
 		"endpoint_id":   "11111111-1111-1111-1111-111111111111",
 		"endpoint_type": "computer",
 		"customer_id":   "11111111-1111-1111-1111-222222222222",
-		"user_id":       "11111111-1111-1111-1111-333333333333",
-		"source":        `EXAMPLE\jdoe`,
-		"suser":         `EXAMPLE\jdoe`,
+		"user_id":       "111111111111111111111111",
+		"source":        "Jane Doe",
 		"location":      "WIN-EXAMPLE-01",
-		"dhost":         "WIN-EXAMPLE-01",
+		"threat":        nil,
+		"origin":        nil,
 		"source_info":   utils.Dict{"ip": "10.1.2.3"},
 	}
 }

--- a/sublime/client.go
+++ b/sublime/client.go
@@ -17,15 +17,25 @@ import (
 )
 
 const (
-	defaultBaseURL = "https://platform.sublime.security"
-	logsPath       = "/v0/audit-log/events"
-	overlapPeriod  = 30 * time.Second
-	pageLimit      = 500
+	defaultBaseURL      = "https://platform.sublime.security"
+	logsPath            = "/v0/audit-log/events"
+	overlapPeriod       = 30 * time.Second
+	pageLimit           = 500
+	defaultPollInterval = 30 * time.Second
 )
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
 
 type SublimeAdapter struct {
 	conf       SublimeConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
 
 	chStopped chan struct{}
@@ -40,6 +50,11 @@ type SublimeConfig struct {
 	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 	ApiKey        string                  `json:"api_key" yaml:"api_key"`
 	BaseURL       string                  `json:"base_url" yaml:"base_url"`
+
+	// PollInterval overrides the fixed wait between polls of the audit log
+	// API. It is not settable through a config file; it exists as a seam for
+	// tests (the production interval stays the historical 30 seconds).
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *SublimeConfig) Validate() error {
@@ -52,11 +67,20 @@ func (c *SublimeConfig) Validate() error {
 	if c.BaseURL == "" {
 		c.BaseURL = defaultBaseURL
 	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
 	return nil
 }
 
 func NewSublimeAdapter(ctx context.Context, conf SublimeConfig) (*SublimeAdapter, chan struct{}, error) {
-	var err error
+	return newSublimeAdapter(ctx, conf, nil)
+}
+
+// newSublimeAdapter is the implementation behind NewSublimeAdapter. When sink
+// is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newSublimeAdapter(ctx context.Context, conf SublimeConfig, sink uspSink) (*SublimeAdapter, chan struct{}, error) {
 	a := &SublimeAdapter{
 		conf:   conf,
 		ctx:    context.Background(),
@@ -64,9 +88,21 @@ func NewSublimeAdapter(ctx context.Context, conf SublimeConfig) (*SublimeAdapter
 		dedupe: make(map[string]int64),
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	// The general adapter runner constructs the adapter without calling
+	// Validate(), so backfill the poll interval default here as well --
+	// otherwise the poll loop would spin on WaitFor(0).
+	if a.conf.PollInterval <= 0 {
+		a.conf.PollInterval = defaultPollInterval
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -108,7 +144,7 @@ func (a *SublimeAdapter) fetchEvents() {
 
 	since := time.Now()
 
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.conf.PollInterval) {
 		items, newSince, _ := a.makeOneRequest(since)
 		since = newSince
 		if items == nil {

--- a/sublime/client_test.go
+++ b/sublime/client_test.go
@@ -1,0 +1,171 @@
+package usp_sublime
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// newDirectAdapter builds an adapter wired to a base URL without starting any
+// goroutines -- for unit testing makeOneRequest in isolation.
+func newDirectAdapter(t *testing.T, baseURL string) *SublimeAdapter {
+	t.Helper()
+	return &SublimeAdapter{
+		conf: SublimeConfig{
+			ClientOptions: testClientOptions(t),
+			ApiKey:        "test-api-key",
+			BaseURL:       baseURL,
+		},
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		doStop:     utils.NewEvent(),
+		dedupe:     map[string]int64{},
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("requires api_key", func(t *testing.T) {
+		c := SublimeConfig{ClientOptions: testClientOptions(t)}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("applies defaults", func(t *testing.T) {
+		c := SublimeConfig{ClientOptions: testClientOptions(t), ApiKey: "k"}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, defaultBaseURL, c.BaseURL)
+		assert.Equal(t, defaultPollInterval, c.PollInterval)
+	})
+
+	t.Run("keeps explicit values", func(t *testing.T) {
+		c := SublimeConfig{
+			ClientOptions: testClientOptions(t),
+			ApiKey:        "k",
+			BaseURL:       "https://sublime.example.com",
+			PollInterval:  5 * time.Second,
+		}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, "https://sublime.example.com", c.BaseURL)
+		assert.Equal(t, 5*time.Second, c.PollInterval)
+	})
+}
+
+// TestMakeOneRequestFiltersAndAdvancesSince verifies one poll: events at or
+// before `since` are dropped, events with a missing or unparseable created_at
+// are skipped, and the returned watermark advances to the newest created_at.
+func TestMakeOneRequestFiltersAndAdvancesSince(t *testing.T) {
+	now := time.Now().UTC()
+	newest := now.Add(10 * time.Minute)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"events": [
+			{"id": "old", "created_at": "` + now.Add(-time.Hour).Format(time.RFC3339Nano) + `"},
+			{"id": "no-ts"},
+			{"id": "bad-ts", "created_at": "not a timestamp"},
+			{"id": "new-1", "created_at": "` + now.Add(5*time.Minute).Format(time.RFC3339Nano) + `"},
+			{"id": "new-2", "created_at": "` + newest.Format(time.RFC3339Nano) + `"}
+		], "count": 5}`))
+	}))
+	defer server.Close()
+
+	a := newDirectAdapter(t, server.URL)
+	items, newSince, err := a.makeOneRequest(now)
+	require.NoError(t, err)
+
+	ids := []string{}
+	for _, item := range items {
+		id, _ := item["id"].(string)
+		ids = append(ids, id)
+	}
+	assert.ElementsMatch(t, []string{"new-1", "new-2"}, ids,
+		"only events newer than since with a valid created_at are returned")
+	assert.True(t, newSince.Equal(newest), "since must advance to the newest created_at, got %v want %v", newSince, newest)
+}
+
+// TestMakeOneRequestDedupes verifies an event id already seen in a previous
+// poll is not returned again even when its created_at is inside the window.
+func TestMakeOneRequestDedupes(t *testing.T) {
+	now := time.Now().UTC()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"events": [
+			{"id": "evt-1", "created_at": "` + now.Add(5*time.Minute).Format(time.RFC3339Nano) + `"}
+		], "count": 1}`))
+	}))
+	defer server.Close()
+
+	a := newDirectAdapter(t, server.URL)
+
+	items, _, err := a.makeOneRequest(now)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	// Same window re-polled: the id is in the dedupe map, nothing returns.
+	items, _, err = a.makeOneRequest(now)
+	require.NoError(t, err)
+	assert.Empty(t, items, "an already-seen event id must not be returned twice")
+}
+
+// TestMakeOneRequestInvalidJSON verifies a non-JSON body surfaces an error and
+// returns no items, with the watermark unchanged.
+func TestMakeOneRequestInvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer server.Close()
+
+	a := newDirectAdapter(t, server.URL)
+	since := time.Now()
+	items, newSince, err := a.makeOneRequest(since)
+	assert.Error(t, err)
+	assert.Nil(t, items)
+	assert.True(t, newSince.Equal(since), "since must not advance on a bad response")
+}
+
+// TestMakeOneRequestNon200 pins the adapter's behavior on a non-200: no items,
+// the watermark is preserved, and (a long-standing quirk) no error is returned
+// -- the failure is only reported through OnError.
+func TestMakeOneRequestNon200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	}))
+	defer server.Close()
+
+	errs := 0
+	a := newDirectAdapter(t, server.URL)
+	a.conf.ClientOptions.OnError = func(err error) { errs++; t.Logf("ERR: %v", err) }
+
+	since := time.Now()
+	items, newSince, err := a.makeOneRequest(since)
+	assert.Nil(t, items)
+	assert.True(t, newSince.Equal(since), "since must not advance on an error response")
+	assert.Equal(t, 1, errs, "a non-200 must be reported via OnError")
+	// Pin the current behavior: the non-200 path returns a nil error (the
+	// error variable it returns belongs to the preceding, successful, Do call).
+	assert.NoError(t, err)
+}

--- a/sublime/client_test.go
+++ b/sublime/client_test.go
@@ -86,7 +86,7 @@ func TestMakeOneRequestFiltersAndAdvancesSince(t *testing.T) {
 			{"id": "bad-ts", "created_at": "not a timestamp"},
 			{"id": "new-1", "created_at": "` + now.Add(5*time.Minute).Format(time.RFC3339Nano) + `"},
 			{"id": "new-2", "created_at": "` + newest.Format(time.RFC3339Nano) + `"}
-		], "count": 5}`))
+		], "count": 5, "total": 5}`))
 	}))
 	defer server.Close()
 
@@ -113,7 +113,7 @@ func TestMakeOneRequestDedupes(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"events": [
 			{"id": "evt-1", "created_at": "` + now.Add(5*time.Minute).Format(time.RFC3339Nano) + `"}
-		], "count": 1}`))
+		], "count": 1, "total": 1}`))
 	}))
 	defer server.Close()
 

--- a/sublime/mock_test.go
+++ b/sublime/mock_test.go
@@ -1,0 +1,474 @@
+package usp_sublime
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock of the Sublime
+// Security platform API (GET /v0/audit-log/events), capturing the exact
+// messages it ships so their content -- timestamp, event type and verbatim
+// payload -- can be asserted.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Sublime platform API -----------------------------------------------
+
+// mockSublime is an in-memory stand-in for the Sublime Security platform API's
+// audit log listing. It honours the contract the adapter relies on: a GET on
+// /v0/audit-log/events authenticated with a Bearer API key, offset/limit query
+// pagination (limit capped at 500 by the real API), and an object envelope
+// {"events": [...], "count": N} around the page.
+type mockSublime struct {
+	mu     sync.Mutex
+	apiKey string
+	events []utils.Dict
+
+	requests      int
+	authFailures  int
+	maxOffsetSeen int
+	lastMethod    string
+	lastPath      string
+	lastAccept    string
+	lastLimit     int
+}
+
+func newMockSublime(apiKey string) *mockSublime {
+	return &mockSublime{apiKey: apiKey}
+}
+
+func (m *mockSublime) setEvents(events []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = events
+}
+
+// appendEvent adds a newly-occurred event to the audit log.
+func (m *mockSublime) appendEvent(event utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, event)
+}
+
+func (m *mockSublime) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+func (m *mockSublime) authFailureCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.authFailures
+}
+
+func (m *mockSublime) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		m.requests++
+		m.lastMethod = r.Method
+		m.lastPath = r.URL.Path
+		m.lastAccept = r.Header.Get("Accept")
+
+		if r.Method != http.MethodGet {
+			http.Error(w, `{"message":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != logsPath {
+			http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+			return
+		}
+		// The platform API authenticates with a Bearer API key.
+		if r.Header.Get("Authorization") != "Bearer "+m.apiKey {
+			m.authFailures++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"invalid or missing API key"}`))
+			return
+		}
+
+		limit := pageLimit
+		if v, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && v > 0 {
+			limit = v
+		}
+		offset := 0
+		if v, err := strconv.Atoi(r.URL.Query().Get("offset")); err == nil && v >= 0 {
+			offset = v
+		}
+		m.lastLimit = limit
+		if offset > m.maxOffsetSeen {
+			m.maxOffsetSeen = offset
+		}
+
+		page := []utils.Dict{}
+		if offset < len(m.events) {
+			end := offset + limit
+			if end > len(m.events) {
+				end = len(m.events)
+			}
+			page = m.events[offset:end]
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"events": page,
+			"count":  len(page),
+		})
+	}
+}
+
+// --- realistic event fixtures -------------------------------------------------
+
+// realisticAuditEvent returns an event shaped like a real Sublime Security
+// audit log entry: id/type/created_at plus the created_by user object and the
+// data.request details of the action recorded. All identifiers are fake.
+func realisticAuditEvent(id, eventType, createdAt string) utils.Dict {
+	return utils.Dict{
+		"id":         id,
+		"type":       eventType,
+		"created_at": createdAt,
+		"created_by": utils.Dict{
+			"id":                      "11111111-1111-1111-1111-111111111111",
+			"email_address":           "analyst@example.com",
+			"first_name":              "Alex",
+			"last_name":               "Analyst",
+			"role":                    "admin",
+			"active":                  true,
+			"google_oauth_user_id":    "",
+			"microsoft_oauth_user_id": "",
+			"created_at":              "2026-01-01T00:00:00Z",
+			"updated_at":              "2026-01-02T00:00:00Z",
+		},
+		"data": utils.Dict{
+			"request": utils.Dict{
+				"id":                    "22222222-2222-2222-2222-222222222222",
+				"method":                "POST",
+				"path":                  "/v0/message-groups/33333333-3333-3333-3333-333333333333/review",
+				"user_agent":            "Mozilla/5.0 (X11; Linux x86_64) Example/1.0",
+				"ip":                    "203.0.113.10",
+				"authentication_method": "user_session",
+				"query":                 utils.Dict{},
+				"body":                  nil,
+			},
+			"message": utils.Dict{
+				"id":          "44444444-4444-4444-4444-444444444444",
+				"external_id": "55555555-5555-5555-5555-555555555555",
+			},
+		},
+	}
+}
+
+// futureTS returns an RFC3339Nano timestamp d into the future. The adapter
+// starts its polling window at time.Now(), so only events whose created_at is
+// after adapter start are shipped; fixtures use future timestamps to land
+// inside the window deterministically.
+func futureTS(d time.Duration) string {
+	return time.Now().Add(d).UTC().Format(time.RFC3339Nano)
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func shippedIDs(msgs []*protocol.DataMessage) map[string]int {
+	out := map[string]int{}
+	for _, m := range msgs {
+		id, _ := m.JsonPayload["id"].(string)
+		out[id]++
+	}
+	return out
+}
+
+// startMockAdapter wires the adapter to the mock server with the capture sink
+// and a fast poll interval.
+func startMockAdapter(t *testing.T, serverURL, apiKey string, sink uspSink) (*SublimeAdapter, chan struct{}) {
+	t.Helper()
+	conf := SublimeConfig{
+		ClientOptions: testClientOptions(t),
+		ApiKey:        apiKey,
+		BaseURL:       serverURL,
+		PollInterval:  25 * time.Millisecond,
+	}
+	adapter, chStopped, err := newSublimeAdapter(t.Context(), conf, sink)
+	require.NoError(t, err)
+	return adapter, chStopped
+}
+
+// --- tests --------------------------------------------------------------------
+
+// TestMockAuditLogEndToEnd drives the adapter against the mock API and asserts
+// the exact messages shipped: ingestion-time TimestampMs, empty EventType (the
+// adapter does not tag audit events), and the payload preserved verbatim. It
+// also pins the request contract: GET on /v0/audit-log/events with the Bearer
+// API key, Accept: application/json and limit=500.
+func TestMockAuditLogEndToEnd(t *testing.T) {
+	const apiKey = "sublime-test-api-key-000000000000"
+
+	mock := newMockSublime(apiKey)
+	want := []utils.Dict{
+		realisticAuditEvent("aaaaaaaa-1111-1111-1111-111111111111", "message_group.review", futureTS(1*time.Hour)),
+		realisticAuditEvent("aaaaaaaa-2222-2222-2222-222222222222", "message.view_contents", futureTS(1*time.Hour+1*time.Minute)),
+		realisticAuditEvent("aaaaaaaa-3333-3333-3333-333333333333", "user.session.create", futureTS(1*time.Hour+2*time.Minute)),
+	}
+	mock.setEvents(want)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	before := uint64(time.Now().UnixMilli())
+	adapter, _ := startMockAdapter(t, server.URL, apiKey, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond, "expected all 3 audit events to ship")
+	after := uint64(time.Now().UnixMilli())
+
+	// Wait for at least one more full poll, then verify nothing re-ships.
+	polled := mock.requestCount()
+	require.Eventually(t, func() bool { return mock.requestCount() >= polled+2 },
+		5*time.Second, 10*time.Millisecond, "expected further polls to happen")
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 25*time.Millisecond, "events were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		// The adapter ships audit events without an EventType tag.
+		assert.Equal(t, "", msg.EventType)
+		// The adapter stamps ingestion time, not the event's created_at.
+		assert.GreaterOrEqual(t, msg.TimestampMs, before, "TimestampMs should be ingestion time")
+		assert.LessOrEqual(t, msg.TimestampMs, after, "TimestampMs should be ingestion time")
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "event %s was not shipped", id)
+		// The payload is shipped verbatim -- nested objects included.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Sublime audit event")
+	}
+
+	// Request contract.
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	assert.Equal(t, http.MethodGet, mock.lastMethod)
+	assert.Equal(t, logsPath, mock.lastPath)
+	assert.Equal(t, "application/json", mock.lastAccept)
+	assert.Equal(t, pageLimit, mock.lastLimit, "the adapter should request the full page limit")
+	assert.Zero(t, mock.authFailures, "the Bearer API key must be sent on every request")
+}
+
+// TestMockNewEventMidRunShipsOnce verifies an audit event that appears while
+// the adapter is running ships exactly once, and already-shipped events are
+// never re-sent.
+func TestMockNewEventMidRunShipsOnce(t *testing.T) {
+	const apiKey = "sublime-test-api-key-000000000000"
+
+	mock := newMockSublime(apiKey)
+	mock.setEvents([]utils.Dict{
+		realisticAuditEvent("bbbbbbbb-1111-1111-1111-111111111111", "message_group.review", futureTS(1*time.Hour)),
+		realisticAuditEvent("bbbbbbbb-2222-2222-2222-222222222222", "rule.update", futureTS(1*time.Hour+1*time.Minute)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, apiKey, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 10*time.Millisecond)
+
+	// A new event occurs mid-run, later than everything already seen.
+	mock.appendEvent(realisticAuditEvent(
+		"bbbbbbbb-3333-3333-3333-333333333333", "user.session.create", futureTS(2*time.Hour)))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 10*time.Millisecond, "the new event should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 25*time.Millisecond)
+
+	assert.Equal(t, map[string]int{
+		"bbbbbbbb-1111-1111-1111-111111111111": 1,
+		"bbbbbbbb-2222-2222-2222-222222222222": 1,
+		"bbbbbbbb-3333-3333-3333-333333333333": 1,
+	}, shippedIDs(sink.snapshot()), "every event must ship exactly once")
+}
+
+// TestMockPaginationFullDataset verifies a dataset larger than one page
+// (pageLimit=500) is walked completely via offset pagination and every event
+// ships exactly once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const apiKey = "sublime-test-api-key-000000000000"
+	const total = 750 // 500 + 250 => two pages
+
+	mock := newMockSublime(apiKey)
+	events := make([]utils.Dict, total)
+	for i := 0; i < total; i++ {
+		events[i] = realisticAuditEvent(
+			fmt.Sprintf("cccccccc-0000-0000-0000-%012d", i),
+			"message.view_contents",
+			futureTS(time.Hour+time.Duration(i)*time.Millisecond))
+	}
+	mock.setEvents(events)
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, apiKey, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 25*time.Millisecond, "all paginated events should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 25*time.Millisecond)
+
+	ids := shippedIDs(sink.snapshot())
+	assert.Len(t, ids, total, "every distinct event should ship")
+	for id, n := range ids {
+		assert.Equalf(t, 1, n, "event %s shipped %d times", id, n)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	assert.GreaterOrEqual(t, mock.maxOffsetSeen, pageLimit,
+		"the adapter should have requested the second page (offset=%d)", pageLimit)
+}
+
+// TestMockEventsBeforeStartDoNotShip pins the adapter's startup window: it only
+// ships audit events whose created_at is after the adapter started; the
+// pre-existing backlog is not replayed.
+func TestMockEventsBeforeStartDoNotShip(t *testing.T) {
+	const apiKey = "sublime-test-api-key-000000000000"
+
+	mock := newMockSublime(apiKey)
+	mock.setEvents([]utils.Dict{
+		realisticAuditEvent("dddddddd-1111-1111-1111-111111111111", "rule.create", time.Now().Add(-2*time.Hour).UTC().Format(time.RFC3339Nano)),
+		realisticAuditEvent("dddddddd-2222-2222-2222-222222222222", "rule.update", time.Now().Add(-1*time.Hour).UTC().Format(time.RFC3339Nano)),
+		realisticAuditEvent("dddddddd-3333-3333-3333-333333333333", "message_group.review", futureTS(1*time.Hour)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, apiKey, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 10*time.Millisecond, "the post-start event should ship")
+	// Let several more polls happen; the historical events must stay unshipped.
+	polled := mock.requestCount()
+	require.Eventually(t, func() bool { return mock.requestCount() >= polled+2 },
+		5*time.Second, 10*time.Millisecond)
+	require.Never(t, func() bool { return sink.count() != 1 },
+		300*time.Millisecond, 25*time.Millisecond, "historical events must not be replayed")
+
+	assert.Equal(t, map[string]int{"dddddddd-3333-3333-3333-333333333333": 1},
+		shippedIDs(sink.snapshot()))
+}
+
+// TestMockBadAPIKeyShipsNothing pins the adapter's behavior on auth failure:
+// a 401 from the API is reported via OnError and nothing ships, but the
+// adapter does not stop -- it keeps polling on its interval.
+func TestMockBadAPIKeyShipsNothing(t *testing.T) {
+	mock := newMockSublime("the-correct-api-key")
+	mock.setEvents([]utils.Dict{
+		realisticAuditEvent("eeeeeeee-1111-1111-1111-111111111111", "rule.create", futureTS(1*time.Hour)),
+	})
+
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	var mu sync.Mutex
+	errorCount := 0
+	opts := testClientOptions(t)
+	opts.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		mu.Lock()
+		errorCount++
+		mu.Unlock()
+	}
+
+	sink := &captureSink{}
+	conf := SublimeConfig{
+		ClientOptions: opts,
+		ApiKey:        "the-wrong-api-key",
+		BaseURL:       server.URL,
+		PollInterval:  25 * time.Millisecond,
+	}
+	adapter, chStopped, err := newSublimeAdapter(t.Context(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The adapter keeps polling despite the 401s (it does not treat auth
+	// failure as fatal) ...
+	require.Eventually(t, func() bool { return mock.authFailureCount() >= 3 },
+		5*time.Second, 10*time.Millisecond, "the adapter should keep polling on auth failure")
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter is not expected to stop on auth failure")
+	default:
+	}
+
+	// ... reports the failures, and ships nothing.
+	mu.Lock()
+	assert.GreaterOrEqual(t, errorCount, 1, "auth failures must be reported via OnError")
+	mu.Unlock()
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+}

--- a/sublime/mock_test.go
+++ b/sublime/mock_test.go
@@ -56,10 +56,12 @@ func (s *captureSink) snapshot() []*protocol.DataMessage {
 // --- mock Sublime platform API -----------------------------------------------
 
 // mockSublime is an in-memory stand-in for the Sublime Security platform API's
-// audit log listing. It honours the contract the adapter relies on: a GET on
-// /v0/audit-log/events authenticated with a Bearer API key, offset/limit query
-// pagination (limit capped at 500 by the real API), and an object envelope
-// {"events": [...], "count": N} around the page.
+// audit log listing (https://docs.sublime.security/reference/listeventsinauditlog).
+// It honours the contract the adapter relies on: a GET on /v0/audit-log/events
+// authenticated with a Bearer API key, offset/limit query pagination (limit
+// capped at 500 by the real API), and an object envelope
+// {"events": [...], "count": N, "total": M} around the page (count is the
+// number of results on the current page, total the number available).
 type mockSublime struct {
 	mu     sync.Mutex
 	apiKey string
@@ -157,6 +159,7 @@ func (m *mockSublime) handler() http.HandlerFunc {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"events": page,
 			"count":  len(page),
+			"total":  len(m.events),
 		})
 	}
 }
@@ -164,8 +167,10 @@ func (m *mockSublime) handler() http.HandlerFunc {
 // --- realistic event fixtures -------------------------------------------------
 
 // realisticAuditEvent returns an event shaped like a real Sublime Security
-// audit log entry: id/type/created_at plus the created_by user object and the
-// data.request details of the action recorded. All identifiers are fake.
+// audit log entry (per the example in
+// https://docs.sublime.security/docs/export-audit-logs-and-message-events):
+// id/type/created_at plus the created_by user object and the data.request
+// details of the action recorded. All identifiers are fake.
 func realisticAuditEvent(id, eventType, createdAt string) utils.Dict {
 	return utils.Dict{
 		"id":         id,
@@ -187,12 +192,12 @@ func realisticAuditEvent(id, eventType, createdAt string) utils.Dict {
 			"request": utils.Dict{
 				"id":                    "22222222-2222-2222-2222-222222222222",
 				"method":                "POST",
-				"path":                  "/v0/message-groups/33333333-3333-3333-3333-333333333333/review",
+				"path":                  "/v1/messages/groups/33333333-3333-3333-3333-333333333333/trash",
 				"user_agent":            "Mozilla/5.0 (X11; Linux x86_64) Example/1.0",
-				"ip":                    "203.0.113.10",
+				"ip":                    "203.0.113.10/32",
 				"authentication_method": "user_session",
 				"query":                 utils.Dict{},
-				"body":                  nil,
+				"body":                  "",
 			},
 			"message": utils.Dict{
 				"id":          "44444444-4444-4444-4444-444444444444",
@@ -253,9 +258,9 @@ func TestMockAuditLogEndToEnd(t *testing.T) {
 
 	mock := newMockSublime(apiKey)
 	want := []utils.Dict{
-		realisticAuditEvent("aaaaaaaa-1111-1111-1111-111111111111", "message_group.review", futureTS(1*time.Hour)),
+		realisticAuditEvent("aaaaaaaa-1111-1111-1111-111111111111", "message_group.quarantine", futureTS(1*time.Hour)),
 		realisticAuditEvent("aaaaaaaa-2222-2222-2222-222222222222", "message.view_contents", futureTS(1*time.Hour+1*time.Minute)),
-		realisticAuditEvent("aaaaaaaa-3333-3333-3333-333333333333", "user.session.create", futureTS(1*time.Hour+2*time.Minute)),
+		realisticAuditEvent("aaaaaaaa-3333-3333-3333-333333333333", "message.access_justification", futureTS(1*time.Hour+2*time.Minute)),
 	}
 	mock.setEvents(want)
 
@@ -319,8 +324,8 @@ func TestMockNewEventMidRunShipsOnce(t *testing.T) {
 
 	mock := newMockSublime(apiKey)
 	mock.setEvents([]utils.Dict{
-		realisticAuditEvent("bbbbbbbb-1111-1111-1111-111111111111", "message_group.review", futureTS(1*time.Hour)),
-		realisticAuditEvent("bbbbbbbb-2222-2222-2222-222222222222", "rule.update", futureTS(1*time.Hour+1*time.Minute)),
+		realisticAuditEvent("bbbbbbbb-1111-1111-1111-111111111111", "message_group.trash", futureTS(1*time.Hour)),
+		realisticAuditEvent("bbbbbbbb-2222-2222-2222-222222222222", "message.flagged", futureTS(1*time.Hour+1*time.Minute)),
 	})
 
 	server := httptest.NewServer(mock.handler())
@@ -335,7 +340,7 @@ func TestMockNewEventMidRunShipsOnce(t *testing.T) {
 
 	// A new event occurs mid-run, later than everything already seen.
 	mock.appendEvent(realisticAuditEvent(
-		"bbbbbbbb-3333-3333-3333-333333333333", "user.session.create", futureTS(2*time.Hour)))
+		"bbbbbbbb-3333-3333-3333-333333333333", "message_group.quarantine", futureTS(2*time.Hour)))
 
 	require.Eventually(t, func() bool { return sink.count() == 3 },
 		5*time.Second, 10*time.Millisecond, "the new event should ship")
@@ -398,9 +403,9 @@ func TestMockEventsBeforeStartDoNotShip(t *testing.T) {
 
 	mock := newMockSublime(apiKey)
 	mock.setEvents([]utils.Dict{
-		realisticAuditEvent("dddddddd-1111-1111-1111-111111111111", "rule.create", time.Now().Add(-2*time.Hour).UTC().Format(time.RFC3339Nano)),
-		realisticAuditEvent("dddddddd-2222-2222-2222-222222222222", "rule.update", time.Now().Add(-1*time.Hour).UTC().Format(time.RFC3339Nano)),
-		realisticAuditEvent("dddddddd-3333-3333-3333-333333333333", "message_group.review", futureTS(1*time.Hour)),
+		realisticAuditEvent("dddddddd-1111-1111-1111-111111111111", "message.view_contents", time.Now().Add(-2*time.Hour).UTC().Format(time.RFC3339Nano)),
+		realisticAuditEvent("dddddddd-2222-2222-2222-222222222222", "message_group.trash", time.Now().Add(-1*time.Hour).UTC().Format(time.RFC3339Nano)),
+		realisticAuditEvent("dddddddd-3333-3333-3333-333333333333", "message_group.quarantine", futureTS(1*time.Hour)),
 	})
 
 	server := httptest.NewServer(mock.handler())
@@ -429,7 +434,7 @@ func TestMockEventsBeforeStartDoNotShip(t *testing.T) {
 func TestMockBadAPIKeyShipsNothing(t *testing.T) {
 	mock := newMockSublime("the-correct-api-key")
 	mock.setEvents([]utils.Dict{
-		realisticAuditEvent("eeeeeeee-1111-1111-1111-111111111111", "rule.create", futureTS(1*time.Hour)),
+		realisticAuditEvent("eeeeeeee-1111-1111-1111-111111111111", "message.flagged", futureTS(1*time.Hour)),
 	})
 
 	server := httptest.NewServer(mock.handler())

--- a/syslog/client.go
+++ b/syslog/client.go
@@ -23,6 +23,15 @@ const (
 	udpBufferSize       = 64 * 1024
 )
 
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type SyslogAdapter struct {
 	conf         SyslogConfig
 	listener     net.Listener
@@ -30,7 +39,7 @@ type SyslogAdapter struct {
 	connMutex    sync.Mutex
 	wg           sync.WaitGroup
 	isRunning    uint32
-	uspClient    *uspclient.Client
+	uspClient    uspSink
 	writeTimeout time.Duration
 }
 
@@ -56,6 +65,13 @@ func (c *SyslogConfig) Validate() error {
 }
 
 func NewSyslogAdapter(ctx context.Context, conf SyslogConfig) (*SyslogAdapter, chan struct{}, error) {
+	return newSyslogAdapter(ctx, conf, nil)
+}
+
+// newSyslogAdapter is the implementation behind NewSyslogAdapter. When sink is
+// non-nil it is used in place of a real LimaCharlie client -- the seam tests
+// use to capture shipped events.
+func newSyslogAdapter(ctx context.Context, conf SyslogConfig, sink uspSink) (*SyslogAdapter, chan struct{}, error) {
 	a := &SyslogAdapter{
 		conf:      conf,
 		isRunning: 1,
@@ -113,14 +129,20 @@ func NewSyslogAdapter(ctx context.Context, conf SyslogConfig) (*SyslogAdapter, c
 		return nil, nil, err
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		if l != nil {
-			l.Close()
-		} else {
-			ul.Close()
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		var uspClient *uspclient.Client
+		uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			if l != nil {
+				l.Close()
+			} else {
+				ul.Close()
+			}
+			return nil, nil, err
 		}
-		return nil, nil, err
+		a.uspClient = uspClient
 	}
 
 	a.listener = l

--- a/syslog/client_test.go
+++ b/syslog/client_test.go
@@ -1,0 +1,586 @@
+package usp_syslog
+
+// End-to-end tests for the syslog adapter. The adapter is a listener, so the
+// tests play the role of the syslog sender: they start the adapter on an
+// ephemeral loopback port, connect to it over TCP/UDP/TLS, send realistic
+// RFC3164/RFC5424 lines and assert the exact messages the adapter ships,
+// using an in-memory uspSink in place of a real LimaCharlie client.
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	eventuallyTimeout = 5 * time.Second
+	eventuallyTick    = 10 * time.Millisecond
+)
+
+// Realistic (but clearly fake) syslog samples.
+const (
+	sampleRFC3164 = "<34>Oct 11 22:14:15 host1.example.com su[1024]: 'su root' failed for alice on /dev/pts/8"
+	sampleRFC5424 = `<165>1 2026-06-11T22:14:15.003Z host2.example.com evntslog 1234 ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] An application event log entry`
+)
+
+// --- test logging -------------------------------------------------------------
+
+// testLogger funnels adapter callbacks to t.Logf, but goes quiet once the test
+// is over: the adapter's Close does not wait for per-connection goroutines, so
+// a handler can emit a DebugLog/OnWarning after the test body returns, and
+// calling t.Logf then would panic the test binary.
+type testLogger struct {
+	mu   sync.Mutex
+	t    *testing.T
+	done bool
+}
+
+func (l *testLogger) logf(format string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.done {
+		return
+	}
+	l.t.Logf(format, args...)
+}
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	l := &testLogger{t: t}
+	t.Cleanup(func() {
+		l.mu.Lock()
+		l.done = true
+		l.mu.Unlock()
+	})
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "text",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { l.logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { l.logf("WRN: %s", msg) },
+		OnError:      func(err error) { l.logf("ERR: %v", err) },
+	}
+}
+
+// --- in-memory USP sink -------------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+func (s *captureSink) textPayloads() []string {
+	msgs := s.snapshot()
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, m.TextPayload)
+	}
+	return out
+}
+
+// --- adapter bring-up ----------------------------------------------------------
+
+// startSyslogAdapter starts the adapter on an ephemeral loopback port and
+// returns it with its stop channel and the address clients should dial. The
+// real bound port is read off the adapter's listener (the package-internal
+// view), so tests never race over a probed free port.
+func startSyslogAdapter(t *testing.T, sink uspSink, mutate func(*SyslogConfig)) (*SyslogAdapter, chan struct{}, string) {
+	t.Helper()
+	conf := SyslogConfig{
+		ClientOptions: testClientOptions(t),
+		Port:          0, // ephemeral; the OS picks a free port
+		Interface:     "127.0.0.1",
+	}
+	if mutate != nil {
+		mutate(&conf)
+	}
+	a, chStopped, err := newSyslogAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+
+	var addr string
+	if conf.IsUDP {
+		addr = a.udpListener.LocalAddr().String()
+	} else {
+		addr = a.listener.Addr().String()
+	}
+	return a, chStopped, addr
+}
+
+// --- test PKI ------------------------------------------------------------------
+
+// testPKI is a certificate + key generated for a test, with their PEM forms.
+type testPKI struct {
+	certPEM []byte
+	keyPEM  []byte
+	cert    *x509.Certificate
+	key     *ecdsa.PrivateKey
+}
+
+// newTestCert generates a certificate. With parent == nil it is self-signed
+// (and may be a CA); otherwise it is signed by the parent.
+func newTestCert(t *testing.T, cn string, isCA bool, eku []x509.ExtKeyUsage, parent *testPKI) testPKI {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serial, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn, Organization: []string{"Example Test Org"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           eku,
+		BasicConstraintsValid: true,
+		DNSNames:              []string{cn, "localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	if isCA {
+		tmpl.IsCA = true
+		tmpl.KeyUsage |= x509.KeyUsageCertSign
+	}
+
+	parentCert, parentKey := tmpl, key
+	if parent != nil {
+		parentCert, parentKey = parent.cert, parent.key
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parentCert, &key.PublicKey, parentKey)
+	require.NoError(t, err)
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	return testPKI{
+		certPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		keyPEM:  pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+		cert:    parsed,
+		key:     key,
+	}
+}
+
+func writeTempFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, data, 0o600))
+	return p
+}
+
+// --- tests ----------------------------------------------------------------------
+
+// TestTCPShipsSyslogLinesVerbatim sends an RFC3164 and an RFC5424 line (plus a
+// blank line) over TCP and asserts each non-empty line ships exactly once, as
+// a verbatim TextPayload, with a "now" timestamp and no JSON payload.
+func TestTCPShipsSyslogLinesVerbatim(t *testing.T) {
+	t.Parallel()
+	sink := &captureSink{}
+	_, _, addr := startSyslogAdapter(t, sink, nil)
+
+	conn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	before := uint64(time.Now().UnixMilli())
+	_, err = conn.Write([]byte(sampleRFC3164 + "\n" + sampleRFC5424 + "\n\n"))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return sink.count() == 2 }, eventuallyTimeout, eventuallyTick)
+	after := uint64(time.Now().UnixMilli())
+
+	msgs := sink.snapshot()
+	require.Len(t, msgs, 2)
+	require.Equal(t, sampleRFC3164, msgs[0].TextPayload)
+	require.Equal(t, sampleRFC5424, msgs[1].TextPayload)
+	for _, m := range msgs {
+		require.Nil(t, m.JsonPayload, "syslog ships raw text, never JSON")
+		require.Empty(t, m.EventType)
+		require.GreaterOrEqual(t, m.TimestampMs, before)
+		require.LessOrEqual(t, m.TimestampMs, after)
+	}
+}
+
+// TestTCPFramingPartialAndCoalescedWrites exercises the newline framing: a
+// line split across two TCP writes is reassembled, several lines in a single
+// segment are split apart, and a line far larger than the 16KiB read buffer
+// (spanning several reads) ships intact.
+func TestTCPFramingPartialAndCoalescedWrites(t *testing.T) {
+	t.Parallel()
+	sink := &captureSink{}
+	_, _, addr := startSyslogAdapter(t, sink, nil)
+
+	conn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	line1 := "<34>Oct 11 22:14:15 host1.example.com sshd[2001]: Accepted publickey for bob from 192.0.2.10 port 51514 ssh2"
+	line2 := "<13>Jun 11 09:00:01 host2.example.com cron[7]: (root) CMD (/usr/local/bin/example-job)"
+	line3 := "<13>Jun 11 09:00:02 host3.example.com cron[8]: (root) CMD (/usr/local/bin/other-job)"
+
+	// First half of line1, no newline: nothing may ship yet.
+	split := len(line1) / 2
+	_, err = conn.Write([]byte(line1[:split]))
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond) // let the adapter read the partial segment
+	require.Equal(t, 0, sink.count(), "a partial line must not ship")
+
+	// Rest of line1 plus two full lines, all in one segment.
+	_, err = conn.Write([]byte(line1[split:] + "\n" + line2 + "\n" + line3 + "\n"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return sink.count() == 3 }, eventuallyTimeout, eventuallyTick)
+	require.Equal(t, []string{line1, line2, line3}, sink.textPayloads())
+
+	// A line much larger than the adapter's 16KiB read buffer.
+	bigLine := "<134>1 2026-06-11T00:00:00Z host1.example.com bigapp 99 - - " + strings.Repeat("A", 48*1024)
+	_, err = conn.Write([]byte(bigLine + "\n"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return sink.count() == 4 }, eventuallyTimeout, eventuallyTick)
+	require.Equal(t, bigLine, sink.snapshot()[3].TextPayload)
+}
+
+// TestTCPConcurrentConnections runs several simultaneous TCP senders and
+// asserts every line from every connection ships exactly once.
+func TestTCPConcurrentConnections(t *testing.T) {
+	t.Parallel()
+	sink := &captureSink{}
+	_, _, addr := startSyslogAdapter(t, sink, nil)
+
+	const nConns = 5
+	const nLines = 20
+
+	expected := make([]string, 0, nConns*nLines)
+	for c := 0; c < nConns; c++ {
+		for i := 0; i < nLines; i++ {
+			expected = append(expected, fmt.Sprintf(
+				"<13>Jun 11 09:%02d:%02d host%d.example.com app[%d]: concurrent test line %d-%d",
+				c, i, c+1, 100+c, c, i))
+		}
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, nConns)
+	for c := 0; c < nConns; c++ {
+		wg.Add(1)
+		go func(c int) {
+			defer wg.Done()
+			conn, err := net.Dial("tcp", addr)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer conn.Close()
+			var b strings.Builder
+			for i := 0; i < nLines; i++ {
+				b.WriteString(expected[c*nLines+i])
+				b.WriteByte('\n')
+			}
+			if _, err := conn.Write([]byte(b.String())); err != nil {
+				errs <- err
+			}
+		}(c)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Eventually(t, func() bool { return sink.count() == nConns*nLines }, eventuallyTimeout, eventuallyTick)
+	require.ElementsMatch(t, expected, sink.textPayloads())
+}
+
+// TestUDPShipsDatagramPerRecord covers UDP mode: each datagram is one record,
+// shipped verbatim with no newline tokenization -- a datagram containing an
+// embedded newline ships as a single message (pinned production behavior).
+func TestUDPShipsDatagramPerRecord(t *testing.T) {
+	t.Parallel()
+	sink := &captureSink{}
+	_, _, addr := startSyslogAdapter(t, sink, func(c *SyslogConfig) { c.IsUDP = true })
+
+	conn, err := net.Dial("udp", addr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(sampleRFC3164))
+	require.NoError(t, err)
+	_, err = conn.Write([]byte(sampleRFC5424))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return sink.count() == 2 }, eventuallyTimeout, eventuallyTick)
+	require.ElementsMatch(t, []string{sampleRFC3164, sampleRFC5424}, sink.textPayloads())
+
+	// Datagrams are never split on newlines: this ships as ONE message.
+	multi := "<13>first line from host1.example.com\n<13>second line from host1.example.com"
+	_, err = conn.Write([]byte(multi))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return sink.count() == 3 }, eventuallyTimeout, eventuallyTick)
+	require.Equal(t, multi, sink.snapshot()[2].TextPayload)
+}
+
+// TestTLSShipsLines runs the adapter with a self-signed server certificate and
+// asserts a verifying TLS client can deliver lines.
+func TestTLSShipsLines(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	server := newTestCert(t, "host1.example.com", false, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, nil)
+	certPath := writeTempFile(t, dir, "server.crt", server.certPEM)
+	keyPath := writeTempFile(t, dir, "server.key", server.keyPEM)
+
+	sink := &captureSink{}
+	_, _, addr := startSyslogAdapter(t, sink, func(c *SyslogConfig) {
+		c.SslCertPath = certPath
+		c.SslKeyPath = keyPath
+	})
+
+	roots := x509.NewCertPool()
+	require.True(t, roots.AppendCertsFromPEM(server.certPEM))
+	conn, err := tls.Dial("tcp", addr, &tls.Config{
+		RootCAs:    roots,
+		ServerName: "host1.example.com",
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(sampleRFC3164 + "\n" + sampleRFC5424 + "\n"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return sink.count() == 2 }, eventuallyTimeout, eventuallyTick)
+	require.Equal(t, []string{sampleRFC3164, sampleRFC5424}, sink.textPayloads())
+}
+
+// TestMutualTLS runs the adapter with client-certificate verification enabled:
+// a client presenting a certificate signed by the configured CA delivers its
+// line; a client with no certificate is rejected and its line never ships.
+func TestMutualTLS(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ca := newTestCert(t, "Example Test CA", true, nil, nil)
+	server := newTestCert(t, "host1.example.com", false, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, nil)
+	clientCert := newTestCert(t, "sender1.example.com", false, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, &ca)
+
+	sink := &captureSink{}
+	_, _, addr := startSyslogAdapter(t, sink, func(c *SyslogConfig) {
+		c.SslCertPath = writeTempFile(t, dir, "server.crt", server.certPEM)
+		c.SslKeyPath = writeTempFile(t, dir, "server.key", server.keyPEM)
+		c.MutualTlsCertPath = writeTempFile(t, dir, "ca.crt", ca.certPEM)
+	})
+
+	roots := x509.NewCertPool()
+	require.True(t, roots.AppendCertsFromPEM(server.certPEM))
+
+	// A client with NO certificate must be rejected. Depending on the TLS
+	// version the failure surfaces at Dial (TLS 1.2) or on the first Read
+	// after the handshake (TLS 1.3) -- either way its line must never ship.
+	badLine := "<13>Jun 11 09:00:00 intruder.example.com app[666]: should never ship"
+	badConn, err := tls.Dial("tcp", addr, &tls.Config{
+		RootCAs:    roots,
+		ServerName: "host1.example.com",
+	})
+	if err == nil {
+		_, _ = badConn.Write([]byte(badLine + "\n"))
+		require.NoError(t, badConn.SetReadDeadline(time.Now().Add(2*time.Second)))
+		_, rerr := badConn.Read(make([]byte, 1))
+		require.Error(t, rerr, "server must reject a client without a certificate")
+		badConn.Close()
+	}
+
+	// A client presenting a CA-signed certificate succeeds.
+	pair, err := tls.X509KeyPair(clientCert.certPEM, clientCert.keyPEM)
+	require.NoError(t, err)
+	goodConn, err := tls.Dial("tcp", addr, &tls.Config{
+		RootCAs:      roots,
+		ServerName:   "host1.example.com",
+		Certificates: []tls.Certificate{pair},
+	})
+	require.NoError(t, err)
+	defer goodConn.Close()
+
+	goodLine := "<13>Jun 11 09:00:01 sender1.example.com app[42]: authenticated client line"
+	_, err = goodConn.Write([]byte(goodLine + "\n"))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return sink.count() == 1 }, eventuallyTimeout, eventuallyTick)
+	require.Equal(t, []string{goodLine}, sink.textPayloads(),
+		"only the authenticated client's line may ship")
+}
+
+// TestUDPWithTLSConfigRejected pins the config guard: TLS options cannot be
+// combined with UDP mode.
+func TestUDPWithTLSConfigRejected(t *testing.T) {
+	t.Parallel()
+	conf := SyslogConfig{
+		ClientOptions: testClientOptions(t),
+		Port:          0,
+		Interface:     "127.0.0.1",
+		IsUDP:         true,
+		SslCertPath:   "/nonexistent/server.crt",
+		SslKeyPath:    "/nonexistent/server.key",
+	}
+	a, ch, err := newSyslogAdapter(context.Background(), conf, &captureSink{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ssl cannot be enabled for udp")
+	require.Nil(t, a)
+	require.Nil(t, ch)
+}
+
+// TestConfigValidateRequiresPort pins Validate(): a zero port is rejected (the
+// general runner calls Validate before constructing the adapter).
+func TestConfigValidateRequiresPort(t *testing.T) {
+	t.Parallel()
+	conf := SyslogConfig{
+		ClientOptions: testClientOptions(t),
+		Port:          0,
+	}
+	err := conf.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing port")
+}
+
+// TestTCPCloseWhileClientConnected covers shutdown with a live TCP client:
+// Close() returns promptly, the stop channel closes, the server tears the
+// client connection down, and -- aside from at most one line already in flight
+// in the handler's blocking Read (pinned production behavior: Close() does not
+// close accepted connections, so a read in progress can still complete and
+// ship) -- nothing sent after Close is shipped.
+func TestTCPCloseWhileClientConnected(t *testing.T) {
+	t.Parallel()
+	sink := &captureSink{}
+	a, chStopped, addr := startSyslogAdapter(t, sink, nil)
+
+	conn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Prove the connection handler is up before closing.
+	preLine := "<13>Jun 11 08:59:59 host1.example.com app[1]: before close"
+	_, err = conn.Write([]byte(preLine + "\n"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return sink.count() == 1 }, eventuallyTimeout, eventuallyTick)
+
+	// Close must return promptly with a client still connected...
+	require.NoError(t, a.Close())
+	// ...and the adapter's stop channel must close.
+	require.Eventually(t, func() bool {
+		select {
+		case <-chStopped:
+			return true
+		default:
+			return false
+		}
+	}, eventuallyTimeout, eventuallyTick, "chStopped must close after Close()")
+
+	// One line written after Close may still be consumed by the handler's
+	// in-flight Read; it must be the last thing that can ever ship.
+	lateLine := "<13>Jun 11 09:00:05 host1.example.com app[1]: after close"
+	_, _ = conn.Write([]byte(lateLine + "\n"))
+
+	// The handler must tear the connection down (the client observes EOF/reset,
+	// not just read timeouts).
+	require.Eventually(t, func() bool {
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(20*time.Millisecond)))
+		_, rerr := conn.Read(make([]byte, 1))
+		if rerr == nil {
+			return false
+		}
+		var ne net.Error
+		if errors.As(rerr, &ne) && ne.Timeout() {
+			return false
+		}
+		return true
+	}, eventuallyTimeout, eventuallyTick, "server must close the client connection after Close()")
+
+	// The handler has exited (it closed the connection on its way out), so the
+	// sink is final: the pre-close line, plus at most the one in-flight line.
+	got := sink.textPayloads()
+	require.GreaterOrEqual(t, len(got), 1)
+	require.LessOrEqual(t, len(got), 2)
+	require.Equal(t, preLine, got[0])
+	if len(got) == 2 {
+		require.Equal(t, lateLine, got[1])
+	}
+}
+
+// TestUDPCloseStopsShipping covers UDP shutdown: Close() closes the socket, so
+// datagrams sent after Close are deterministically never shipped.
+func TestUDPCloseStopsShipping(t *testing.T) {
+	t.Parallel()
+	sink := &captureSink{}
+	a, chStopped, addr := startSyslogAdapter(t, sink, func(c *SyslogConfig) { c.IsUDP = true })
+
+	conn, err := net.Dial("udp", addr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	preLine := "<13>Jun 11 08:59:59 host1.example.com app[1]: udp before close"
+	_, err = conn.Write([]byte(preLine))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return sink.count() == 1 }, eventuallyTimeout, eventuallyTick)
+
+	require.NoError(t, a.Close())
+	require.Eventually(t, func() bool {
+		select {
+		case <-chStopped:
+			return true
+		default:
+			return false
+		}
+	}, eventuallyTimeout, eventuallyTick, "chStopped must close after Close()")
+
+	// The socket is closed: these can never be delivered or shipped. Writes may
+	// error (ICMP port unreachable) -- that is fine, only shipping matters.
+	for i := 0; i < 3; i++ {
+		_, _ = conn.Write([]byte(fmt.Sprintf("<13>Jun 11 09:00:0%d host1.example.com app[1]: udp after close", i)))
+	}
+	require.Never(t, func() bool { return sink.count() > 1 }, 250*time.Millisecond, 20*time.Millisecond,
+		"nothing sent after Close may ship")
+	require.Equal(t, []string{preLine}, sink.textPayloads())
+}

--- a/syslog/client_test.go
+++ b/syslog/client_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/refractionPOINT/go-uspclient"
 	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -472,8 +473,9 @@ func TestUDPWithTLSConfigRejected(t *testing.T) {
 	require.Nil(t, ch)
 }
 
-// TestConfigValidateRequiresPort pins Validate(): a zero port is rejected (the
-// general runner calls Validate before constructing the adapter).
+// TestConfigValidateRequiresPort pins Validate(): a zero port is rejected.
+// Note that NewSyslogAdapter does not call Validate itself (nothing in this
+// repo does), which is why the other tests can bind Port 0 directly.
 func TestConfigValidateRequiresPort(t *testing.T) {
 	t.Parallel()
 	conf := SyslogConfig{
@@ -547,6 +549,40 @@ func TestTCPCloseWhileClientConnected(t *testing.T) {
 	if len(got) == 2 {
 		require.Equal(t, lateLine, got[1])
 	}
+}
+
+// TestStreamTokenizerSingleCharLineQuirk pins a known quirk of the tokenizer
+// the TCP path feeds every read into (utils/stream_tokenizer.go): the
+// `i-1 > dataStart` guard in Add skips segments of exactly one byte, so a
+// one-character line whose byte and newline arrive in the SAME Add call comes
+// back as an empty chunk -- handleLine then drops it, so the line never ships.
+// The same line split across two Adds (byte in one read, newline in the next)
+// survives via the end-of-buffer branch. The tokenizer here is configured
+// exactly as handleConnection configures it (Token 0x0a).
+func TestStreamTokenizerSingleCharLineQuirk(t *testing.T) {
+	t.Parallel()
+
+	// Byte and newline in one Add: the 1-byte line is lost (empty chunk),
+	// surrounding lines are unaffected.
+	st := utils.StreamTokenizer{ExpectedSize: 1024 * 32, Token: 0x0a}
+	chunks, err := st.Add([]byte("<13>first line\nX\n<13>second line\n"))
+	require.NoError(t, err)
+	got := make([]string, 0, len(chunks))
+	for _, c := range chunks {
+		got = append(got, string(c))
+	}
+	require.Equal(t, []string{"<13>first line", "", "<13>second line"}, got,
+		"a 1-character line in a single read degrades to an empty chunk (dropped by handleLine)")
+
+	// The same 1-byte line split across two Adds is preserved.
+	st = utils.StreamTokenizer{ExpectedSize: 1024 * 32, Token: 0x0a}
+	chunks, err = st.Add([]byte("X"))
+	require.NoError(t, err)
+	require.Empty(t, chunks)
+	chunks, err = st.Add([]byte("\n"))
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+	require.Equal(t, "X", string(chunks[0]))
 }
 
 // TestUDPCloseStopsShipping covers UDP shutdown: Close() closes the socket, so

--- a/trendmicro/client.go
+++ b/trendmicro/client.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,6 +17,10 @@ import (
 	"github.com/refractionPOINT/go-uspclient/protocol"
 	"github.com/refractionPOINT/usp-adapters/utils"
 )
+
+// defaultPollInterval is the historical fixed wait between polls of the
+// Vision One Workbench alerts endpoint.
+const defaultPollInterval = 60 * time.Second
 
 var regionalDomains = map[string]string{
 	"us": "https://api.xdr.trendmicro.com",
@@ -30,6 +35,16 @@ type TrendMicroConfig struct {
 	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 	APIToken      string                  `json:"api_token" yaml:"api_token"`
 	Region        string                  `json:"region" yaml:"region"` // "us", "eu", "sg", "jp", "in", "au" - defaults to "us"
+
+	// URL optionally overrides the regional Vision One API root (e.g.
+	// "https://api.xdr.trendmicro.com"). When empty, the root is derived from
+	// Region as before.
+	URL string `json:"url" yaml:"url"`
+
+	// PollInterval overrides the fixed wait between polls of the alerts
+	// endpoint. It is not settable through a config file; it exists as a seam
+	// for tests (the production interval stays the historical 60 seconds).
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *TrendMicroConfig) Validate() error {
@@ -46,12 +61,24 @@ func (c *TrendMicroConfig) Validate() error {
 	if _, ok := regionalDomains[c.Region]; !ok {
 		return fmt.Errorf("invalid region: %s (must be one of: us, eu, sg, jp, in, au)", c.Region)
 	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
 	return nil
+}
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
 }
 
 type TrendMicroAdapter struct {
 	conf       TrendMicroConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
 	chStopped  chan struct{}
 	wgSenders  sync.WaitGroup
@@ -62,11 +89,17 @@ type TrendMicroAdapter struct {
 }
 
 func NewTrendMicroAdapter(ctx context.Context, conf TrendMicroConfig) (*TrendMicroAdapter, chan struct{}, error) {
+	return newTrendMicroAdapter(ctx, conf, nil)
+}
+
+// newTrendMicroAdapter is the implementation behind NewTrendMicroAdapter. When
+// sink is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newTrendMicroAdapter(ctx context.Context, conf TrendMicroConfig, sink uspSink) (*TrendMicroAdapter, chan struct{}, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, nil, err
 	}
 
-	var err error
 	a := &TrendMicroAdapter{
 		conf:      conf,
 		ctx:       context.Background(),
@@ -75,12 +108,20 @@ func NewTrendMicroAdapter(ctx context.Context, conf TrendMicroConfig) (*TrendMic
 		lastFetch: time.Now().Add(-24 * time.Hour), // Start by fetching last 24 hours
 	}
 
-	// Set regional base URL
+	// Set regional base URL, unless explicitly overridden.
 	a.baseURL = regionalDomains[conf.Region]
+	if conf.URL != "" {
+		a.baseURL = strings.TrimRight(conf.URL, "/")
+	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -121,7 +162,7 @@ func (a *TrendMicroAdapter) fetchAlerts() {
 	defer a.wgSenders.Done()
 	defer a.conf.ClientOptions.DebugLog("Trend Micro alert collection stopping")
 
-	for !a.doStop.WaitFor(60 * time.Second) {
+	for !a.doStop.WaitFor(a.conf.PollInterval) {
 		items, err := a.fetchAllPages()
 		if err != nil {
 			a.conf.ClientOptions.OnError(fmt.Errorf("failed to fetch alerts: %v", err))

--- a/trendmicro/client_test.go
+++ b/trendmicro/client_test.go
@@ -68,7 +68,9 @@ func TestValidate(t *testing.T) {
 		assert.Equal(t, "us", c.Region, "region still defaults even when url is overridden")
 	})
 
-	t.Run("every documented region maps to a Trend Micro domain", func(t *testing.T) {
+	// Trend Micro's v3.0 spec lists more regions (e.g. mea, uk, ca); the
+	// adapter supports these six, and the URL override covers the rest.
+	t.Run("every supported region maps to a Trend Micro domain", func(t *testing.T) {
 		for _, region := range []string{"us", "eu", "sg", "jp", "in", "au"} {
 			c := TrendMicroConfig{ClientOptions: testClientOptions(t), APIToken: "k", Region: region}
 			require.NoError(t, c.Validate(), "region %s", region)

--- a/trendmicro/client_test.go
+++ b/trendmicro/client_test.go
@@ -1,0 +1,78 @@
+package usp_trendmicro
+
+import (
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("requires api_token", func(t *testing.T) {
+		c := TrendMicroConfig{ClientOptions: testClientOptions(t)}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("rejects an unknown region", func(t *testing.T) {
+		c := TrendMicroConfig{ClientOptions: testClientOptions(t), APIToken: "k", Region: "mars"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("applies defaults", func(t *testing.T) {
+		c := TrendMicroConfig{ClientOptions: testClientOptions(t), APIToken: "k"}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, "us", c.Region, "region must default to us")
+		assert.Equal(t, defaultPollInterval, c.PollInterval,
+			"poll interval must default to the historical 60s")
+	})
+
+	t.Run("keeps explicit values", func(t *testing.T) {
+		c := TrendMicroConfig{
+			ClientOptions: testClientOptions(t),
+			APIToken:      "k",
+			Region:        "eu",
+			PollInterval:  5 * time.Second,
+		}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, "eu", c.Region)
+		assert.Equal(t, 5*time.Second, c.PollInterval)
+	})
+
+	t.Run("accepts a url override", func(t *testing.T) {
+		c := TrendMicroConfig{
+			ClientOptions: testClientOptions(t),
+			APIToken:      "k",
+			URL:           "https://visionone.example.com",
+		}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, "https://visionone.example.com", c.URL)
+		assert.Equal(t, "us", c.Region, "region still defaults even when url is overridden")
+	})
+
+	t.Run("every documented region maps to a Trend Micro domain", func(t *testing.T) {
+		for _, region := range []string{"us", "eu", "sg", "jp", "in", "au"} {
+			c := TrendMicroConfig{ClientOptions: testClientOptions(t), APIToken: "k", Region: region}
+			require.NoError(t, c.Validate(), "region %s", region)
+			assert.NotEmpty(t, regionalDomains[region], "region %s", region)
+		}
+	})
+}

--- a/trendmicro/mock_test.go
+++ b/trendmicro/mock_test.go
@@ -1,0 +1,578 @@
+package usp_trendmicro
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock Trend Micro Vision
+// One API, capturing the exact messages it ships so their content -- event
+// type, timestamp and verbatim payload -- can be asserted.
+
+const alertsPath = "/v3.0/workbench/alerts"
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// countByID returns how many shipped messages carry the given Workbench alert
+// id.
+func (s *captureSink) countByID(id string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, m := range s.messages {
+		if v, _ := m.JsonPayload["id"].(string); v == id {
+			n++
+		}
+	}
+	return n
+}
+
+// --- mock Vision One API ----------------------------------------------------
+
+// recordedRequest captures one request the adapter made, for assertions on the
+// wire shape (method, path, auth header, query params).
+type recordedRequest struct {
+	method string
+	path   string
+	auth   string
+	query  url.Values
+}
+
+// mockVisionOne is an in-memory stand-in for the Vision One Workbench alerts
+// API as the adapter consumes it: a GET on /v3.0/workbench/alerts authenticated
+// with "Authorization: Bearer <token>", filtered by the startDateTime /
+// endDateTime query params (compared against each alert's createdDateTime,
+// boundaries inclusive, like the real API's default dateTimeTarget), returning
+// an {"items": [...], "count": N, "totalCount": M} envelope with a full
+// "nextLink" URL when more pages remain (continuation via a skipToken query
+// param, which the adapter follows verbatim).
+type mockVisionOne struct {
+	mu        sync.Mutex
+	token     string
+	pageSize  int
+	serverURL string
+	alerts    []utils.Dict
+	requests  []recordedRequest
+}
+
+func newMockVisionOne(token string, pageSize int) *mockVisionOne {
+	return &mockVisionOne{token: token, pageSize: pageSize}
+}
+
+func (m *mockVisionOne) addAlert(a utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.alerts = append(m.alerts, a)
+}
+
+func (m *mockVisionOne) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.requests)
+}
+
+func (m *mockVisionOne) recordedRequests() []recordedRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]recordedRequest, len(m.requests))
+	copy(out, m.requests)
+	return out
+}
+
+// writeVisionOneError renders the Vision One error envelope.
+func writeVisionOneError(w http.ResponseWriter, status int, code, message string) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": map[string]interface{}{"code": code, "message": message},
+	})
+}
+
+// handler implements the mock API. It runs on httptest server goroutines, so
+// it reports failures with assert (require's FailNow is only valid on the test
+// goroutine).
+func (m *mockVisionOne) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.requests = append(m.requests, recordedRequest{
+			method: r.Method,
+			path:   r.URL.Path,
+			auth:   r.Header.Get("Authorization"),
+			query:  r.URL.Query(),
+		})
+		alerts := make([]utils.Dict, len(m.alerts))
+		copy(alerts, m.alerts)
+		pageSize := m.pageSize
+		serverURL := m.serverURL
+		m.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path != alertsPath {
+			writeVisionOneError(w, http.StatusNotFound, "NotFound", "The requested resource was not found.")
+			return
+		}
+		if r.Method != http.MethodGet {
+			writeVisionOneError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "The HTTP method is not supported.")
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer "+m.token {
+			writeVisionOneError(w, http.StatusUnauthorized, "Unauthorized", "The provided authentication token is invalid.")
+			return
+		}
+
+		q := r.URL.Query()
+		start, errStart := time.Parse(time.RFC3339, q.Get("startDateTime"))
+		end, errEnd := time.Parse(time.RFC3339, q.Get("endDateTime"))
+		if !assert.NoError(t, errStart, "startDateTime must be ISO 8601") ||
+			!assert.NoError(t, errEnd, "endDateTime must be ISO 8601") {
+			writeVisionOneError(w, http.StatusBadRequest, "BadRequest", "startDateTime/endDateTime must be in ISO 8601 format.")
+			return
+		}
+		skip := 0
+		if s := q.Get("skipToken"); s != "" {
+			v, err := strconv.Atoi(s)
+			if !assert.NoError(t, err, "skipToken must be the token the mock issued") {
+				writeVisionOneError(w, http.StatusBadRequest, "BadRequest", "invalid skipToken")
+				return
+			}
+			skip = v
+		}
+
+		// Filter on createdDateTime within [startDateTime, endDateTime], both
+		// boundaries inclusive (the real API's documented default target is
+		// the alert creation time).
+		filtered := []utils.Dict{}
+		for _, a := range alerts {
+			cs, _ := a["createdDateTime"].(string)
+			c, err := time.Parse(time.RFC3339, cs)
+			if !assert.NoError(t, err, "mock fixture has a bad createdDateTime") {
+				continue
+			}
+			if !c.Before(start) && !c.After(end) {
+				filtered = append(filtered, a)
+			}
+		}
+
+		if skip > len(filtered) {
+			skip = len(filtered)
+		}
+		pageEnd := skip + pageSize
+		if pageEnd > len(filtered) {
+			pageEnd = len(filtered)
+		}
+		page := filtered[skip:pageEnd]
+
+		resp := map[string]interface{}{
+			"totalCount": len(filtered),
+			"count":      len(page),
+			"items":      page,
+		}
+		if pageEnd < len(filtered) {
+			next := url.Values{}
+			next.Set("startDateTime", q.Get("startDateTime"))
+			next.Set("endDateTime", q.Get("endDateTime"))
+			next.Set("skipToken", strconv.Itoa(pageEnd))
+			resp["nextLink"] = fmt.Sprintf("%s%s?%s", serverURL, alertsPath, next.Encode())
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// startMockVisionOne starts the httptest server and wires its URL back into
+// the mock so nextLink can point at it.
+func startMockVisionOne(t *testing.T, m *mockVisionOne) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(m.handler(t))
+	t.Cleanup(server.Close)
+	m.mu.Lock()
+	m.serverURL = server.URL
+	m.mu.Unlock()
+	return server
+}
+
+// --- realistic record fixtures ------------------------------------------------
+
+// visionOneAlert returns a record shaped like a real Vision One Workbench
+// alert (GET /v3.0/workbench/alerts item): the documented top-level fields plus
+// the nested impactScope/indicators/matchedRules structures with mixed scalar
+// types, arrays and nested objects. All identifiers are clearly fake.
+func visionOneAlert(id string, created time.Time) utils.Dict {
+	ts := created.UTC().Format(time.RFC3339)
+	return utils.Dict{
+		"schemaVersion":       "1.12",
+		"id":                  id,
+		"investigationStatus": "New",
+		"status":              "Open",
+		"investigationResult": "No Findings",
+		"workbenchLink":       "https://portal.xdr.trendmicro.com/index.html#/workbench/alerts/" + id,
+		"alertProvider":       "SAE",
+		"model":               "Possible Credential Dumping via Known Tool",
+		"modelId":             "11111111-1111-1111-1111-111111111111",
+		"modelType":           "preset",
+		"score":               64,
+		"severity":            "high",
+		"createdDateTime":     ts,
+		"updatedDateTime":     ts,
+		"description":         "A high-privilege process accessed credential storage on an endpoint.",
+		"impactScope": utils.Dict{
+			"desktopCount":      1,
+			"serverCount":       0,
+			"accountCount":      1,
+			"emailAddressCount": 0,
+			"entities": []interface{}{
+				utils.Dict{
+					"entityType":          "account",
+					"entityValue":         `EXAMPLE\jdoe`,
+					"entityId":            `EXAMPLE\jdoe`,
+					"relatedEntities":     []interface{}{"22222222-2222-2222-2222-222222222222"},
+					"relatedIndicatorIds": []interface{}{1},
+					"provenance":          []interface{}{"Alert"},
+				},
+				utils.Dict{
+					"entityType": "host",
+					"entityValue": utils.Dict{
+						"guid": "22222222-2222-2222-2222-222222222222",
+						"name": "workstation-01.example.com",
+						"ips":  []interface{}{"203.0.113.10"},
+					},
+					"entityId":            "22222222-2222-2222-2222-222222222222",
+					"relatedEntities":     []interface{}{},
+					"relatedIndicatorIds": []interface{}{1},
+					"provenance":          []interface{}{"Alert"},
+				},
+			},
+		},
+		"indicators": []interface{}{
+			utils.Dict{
+				"id":              1,
+				"type":            "command_line",
+				"field":           "processCmd",
+				"value":           "powershell.exe -nop -w hidden -encodedcommand SQBFAFgA",
+				"relatedEntities": []interface{}{"22222222-2222-2222-2222-222222222222"},
+				"filterIds":       []interface{}{"33333333-3333-3333-3333-333333333333"},
+				"provenance":      []interface{}{"Alert"},
+			},
+		},
+		"matchedRules": []interface{}{
+			utils.Dict{
+				"id":   "44444444-4444-4444-4444-444444444444",
+				"name": "Potential Credential Dumping",
+				"matchedFilters": []interface{}{
+					utils.Dict{
+						"id":                "33333333-3333-3333-3333-333333333333",
+						"name":              "Credential Dumping via Memory Access",
+						"matchedDateTime":   ts,
+						"mitreTechniqueIds": []interface{}{"V9013.T1003.001"},
+						"matchedEvents": []interface{}{
+							utils.Dict{
+								"uuid":            "55555555-5555-5555-5555-555555555555",
+								"matchedDateTime": ts,
+								"type":            "TELEMETRY_PROCESS",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// --- tests --------------------------------------------------------------------
+
+// TestMockAlertsEndToEnd drives the adapter against the mock API and asserts
+// the exact events shipped -- verbatim payloads, the adapter's (empty)
+// EventType, a ship-time TimestampMs -- plus the wire shape of the first
+// request (GET, bearer token, a 24h initial startDateTime/endDateTime window).
+// It also verifies re-polling does not re-ship: the window advances past
+// already-fetched alerts.
+func TestMockAlertsEndToEnd(t *testing.T) {
+	const token = "tmv1-fake-token-0000000000000000"
+
+	mock := newMockVisionOne(token, 100)
+	now := time.Now().UTC()
+	want := []utils.Dict{
+		visionOneAlert("WB-9002-20260611-00001", now.Add(-3*time.Hour)),
+		visionOneAlert("WB-9002-20260611-00002", now.Add(-2*time.Hour)),
+		visionOneAlert("WB-9002-20260611-00003", now.Add(-1*time.Hour)),
+	}
+	for _, a := range want {
+		mock.addAlert(a)
+	}
+	server := startMockVisionOne(t, mock)
+
+	sink := &captureSink{}
+	beforeMs := uint64(time.Now().UnixMilli())
+	conf := TrendMicroConfig{
+		ClientOptions: testClientOptions(t),
+		APIToken:      token,
+		URL:           server.URL,
+		PollInterval:  100 * time.Millisecond,
+	}
+	adapter, _, err := newTrendMicroAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 alerts to ship")
+
+	// Re-polling must not re-ship: the time window advances past the alerts'
+	// createdDateTime, so the count stays at 3 across several more polls.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		500*time.Millisecond, 25*time.Millisecond, "alerts were re-shipped on a later poll")
+	afterMs := uint64(time.Now().UnixMilli())
+
+	// Wire shape of the first request.
+	reqs := mock.recordedRequests()
+	require.NotEmpty(t, reqs)
+	first := reqs[0]
+	assert.Equal(t, http.MethodGet, first.method)
+	assert.Equal(t, alertsPath, first.path)
+	assert.Equal(t, "Bearer "+token, first.auth)
+	assert.Empty(t, first.query.Get("skipToken"), "the first request must not carry a continuation token")
+	start, perr := time.Parse(time.RFC3339, first.query.Get("startDateTime"))
+	require.NoError(t, perr, "startDateTime must be RFC3339")
+	end, perr := time.Parse(time.RFC3339, first.query.Get("endDateTime"))
+	require.NoError(t, perr, "endDateTime must be RFC3339")
+	assert.WithinDuration(t, now.Add(-24*time.Hour), start, 2*time.Minute,
+		"the initial window must start 24h in the past")
+	assert.WithinDuration(t, now, end, 2*time.Minute, "the window must end at poll time")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		// The adapter does not tag an event type; LimaCharlie's platform
+		// setting drives parsing. Pin that behavior.
+		assert.Empty(t, msg.EventType)
+		// The adapter stamps events with the ship time, not the alert's
+		// createdDateTime. Pin that behavior.
+		assert.GreaterOrEqual(t, msg.TimestampMs, beforeMs)
+		assert.LessOrEqual(t, msg.TimestampMs, afterMs)
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "alert %s was not shipped", id)
+		// The payload is shipped verbatim -- nested objects and arrays included.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Vision One alert")
+	}
+}
+
+// TestMockNewAlertMidRun verifies an alert created while the adapter is
+// running is picked up by a subsequent poll, and that the advancing time
+// window then stops it from being shipped over and over.
+//
+// The adapter has no deduplication: its only re-ship protection is the
+// server-side startDateTime/endDateTime window, whose boundaries the real API
+// treats inclusively at one-second granularity. An alert whose createdDateTime
+// second coincides with a window boundary can therefore legitimately ship
+// twice (against the real API too). The poll interval here is kept above one
+// second so window starts strictly advance each poll, bounding the new alert
+// at one possible boundary duplicate; the test pins "at least once, at most
+// twice, then never again".
+func TestMockNewAlertMidRun(t *testing.T) {
+	const token = "tmv1-fake-token-0000000000000000"
+	const newID = "WB-9002-20260611-00099"
+
+	mock := newMockVisionOne(token, 100)
+	now := time.Now().UTC()
+	mock.addAlert(visionOneAlert("WB-9002-20260611-00010", now.Add(-2*time.Hour)))
+	mock.addAlert(visionOneAlert("WB-9002-20260611-00011", now.Add(-1*time.Hour)))
+	server := startMockVisionOne(t, mock)
+
+	sink := &captureSink{}
+	conf := TrendMicroConfig{
+		ClientOptions: testClientOptions(t),
+		APIToken:      token,
+		URL:           server.URL,
+		PollInterval:  1 * time.Second,
+	}
+	adapter, _, err := newTrendMicroAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "the two pre-existing alerts should ship")
+
+	// A new alert is raised while the adapter runs.
+	newAlert := visionOneAlert(newID, time.Now().UTC())
+	mock.addAlert(newAlert)
+	created, err := time.Parse(time.RFC3339, newAlert["createdDateTime"].(string))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return sink.countByID(newID) >= 1 },
+		5*time.Second, 25*time.Millisecond, "the new alert should ship on a later poll")
+
+	// Wait for the polling window to move strictly past the new alert's
+	// creation time; from then on no poll can return it again.
+	require.Eventually(t, func() bool {
+		for _, r := range mock.recordedRequests() {
+			if s, perr := time.Parse(time.RFC3339, r.query.Get("startDateTime")); perr == nil && s.After(created) {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 50*time.Millisecond, "the poll window should advance past the new alert")
+
+	stable := sink.count()
+	require.Never(t, func() bool { return sink.count() != stable },
+		1500*time.Millisecond, 50*time.Millisecond, "no alert may ship once the window has passed it")
+
+	assert.Equal(t, 1, sink.countByID("WB-9002-20260611-00010"))
+	assert.Equal(t, 1, sink.countByID("WB-9002-20260611-00011"))
+	n := sink.countByID(newID)
+	assert.GreaterOrEqual(t, n, 1, "the new alert must ship")
+	assert.LessOrEqual(t, n, 2,
+		"the new alert may ship at most twice (inclusive window boundary, no dedup in the adapter)")
+}
+
+// TestMockPaginationFullDataset verifies a result set larger than one page is
+// fully consumed by following nextLink, with every alert shipped exactly once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const token = "tmv1-fake-token-0000000000000000"
+	const total = 25
+
+	mock := newMockVisionOne(token, 10) // 25 alerts => pages of 10, 10, 5
+	now := time.Now().UTC()
+	for i := 0; i < total; i++ {
+		mock.addAlert(visionOneAlert(
+			fmt.Sprintf("WB-9002-20260611-%05d", i),
+			now.Add(-2*time.Hour).Add(time.Duration(i)*time.Second)))
+	}
+	server := startMockVisionOne(t, mock)
+
+	sink := &captureSink{}
+	conf := TrendMicroConfig{
+		ClientOptions: testClientOptions(t),
+		APIToken:      token,
+		URL:           server.URL,
+		PollInterval:  100 * time.Millisecond,
+	}
+	adapter, _, err := newTrendMicroAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		5*time.Second, 25*time.Millisecond, "all paginated alerts should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		500*time.Millisecond, 25*time.Millisecond, "no alert may ship twice")
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["id"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct alert should ship exactly once")
+
+	// The adapter must have followed the mock's nextLink continuations.
+	skipTokens := map[string]bool{}
+	for _, r := range mock.recordedRequests() {
+		if s := r.query.Get("skipToken"); s != "" {
+			skipTokens[s] = true
+		}
+	}
+	assert.True(t, skipTokens["10"], "the second page should be fetched via nextLink (skipToken=10)")
+	assert.True(t, skipTokens["20"], "the third page should be fetched via nextLink (skipToken=20)")
+}
+
+// TestMockBadTokenShipsNothing pins the adapter's behavior on authentication
+// failure: nothing ships, the error is surfaced through OnError, and the
+// adapter does NOT stop -- it keeps polling on its interval (a 401 is handled
+// like any other poll error).
+func TestMockBadTokenShipsNothing(t *testing.T) {
+	mock := newMockVisionOne("correct-token", 100)
+	mock.addAlert(visionOneAlert("WB-9002-20260611-00001", time.Now().UTC().Add(-1*time.Hour)))
+	server := startMockVisionOne(t, mock)
+
+	var authErrs atomic.Int32
+	opts := testClientOptions(t)
+	opts.OnError = func(err error) {
+		t.Logf("ERR: %v", err)
+		if strings.Contains(err.Error(), "authentication failed (401)") {
+			authErrs.Add(1)
+		}
+	}
+
+	sink := &captureSink{}
+	conf := TrendMicroConfig{
+		ClientOptions: opts,
+		APIToken:      "wrong-token",
+		URL:           server.URL,
+		PollInterval:  100 * time.Millisecond,
+	}
+	adapter, chStopped, err := newTrendMicroAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The adapter keeps retrying across poll cycles and reports the 401.
+	require.Eventually(t, func() bool { return mock.requestCount() >= 3 },
+		5*time.Second, 20*time.Millisecond, "the adapter should keep polling after a 401")
+	require.Eventually(t, func() bool { return authErrs.Load() >= 1 },
+		5*time.Second, 20*time.Millisecond, "the 401 should be reported through OnError")
+
+	select {
+	case <-chStopped:
+		t.Fatal("the adapter stopped on a 401; its current behavior is to keep polling")
+	default:
+	}
+
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+}

--- a/trendmicro/mock_test.go
+++ b/trendmicro/mock_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -86,11 +87,19 @@ type recordedRequest struct {
 // mockVisionOne is an in-memory stand-in for the Vision One Workbench alerts
 // API as the adapter consumes it: a GET on /v3.0/workbench/alerts authenticated
 // with "Authorization: Bearer <token>", filtered by the startDateTime /
-// endDateTime query params (compared against each alert's createdDateTime,
-// boundaries inclusive, like the real API's default dateTimeTarget), returning
-// an {"items": [...], "count": N, "totalCount": M} envelope with a full
+// endDateTime query params (compared against each alert's createdDateTime, the
+// documented default dateTimeTarget), returning an
+// {"items": [...], "count": N, "totalCount": M} envelope with a full
 // "nextLink" URL when more pages remain (continuation via a skipToken query
-// param, which the adapter follows verbatim).
+// param embedded in nextLink, which the adapter follows verbatim -- the real
+// token is opaque). Items are returned newest-first, the documented default
+// orderBy ("createdDateTime desc").
+//
+// The official docs do not state whether the window boundaries are inclusive;
+// the mock treats both as inclusive, the conservative assumption for duplicate
+// delivery. Note the real endpoint has no "top" parameter and serves at most
+// 10 entries per page; pageSize here is a knob so tests can choose between
+// exercising pagination and keeping a single page.
 type mockVisionOne struct {
 	mu        sync.Mutex
 	token     string
@@ -183,10 +192,15 @@ func (m *mockVisionOne) handler(t *testing.T) http.HandlerFunc {
 			skip = v
 		}
 
-		// Filter on createdDateTime within [startDateTime, endDateTime], both
-		// boundaries inclusive (the real API's documented default target is
-		// the alert creation time).
-		filtered := []utils.Dict{}
+		// Filter on createdDateTime within [startDateTime, endDateTime] (the
+		// documented default dateTimeTarget is createdDateTime; boundary
+		// inclusivity is not documented, so the mock takes the inclusive,
+		// duplicate-prone reading).
+		type datedAlert struct {
+			created time.Time
+			alert   utils.Dict
+		}
+		dated := []datedAlert{}
 		for _, a := range alerts {
 			cs, _ := a["createdDateTime"].(string)
 			c, err := time.Parse(time.RFC3339, cs)
@@ -194,8 +208,14 @@ func (m *mockVisionOne) handler(t *testing.T) http.HandlerFunc {
 				continue
 			}
 			if !c.Before(start) && !c.After(end) {
-				filtered = append(filtered, a)
+				dated = append(dated, datedAlert{created: c, alert: a})
 			}
+		}
+		// Newest first: the documented default orderBy is "createdDateTime desc".
+		sort.SliceStable(dated, func(i, j int) bool { return dated[i].created.After(dated[j].created) })
+		filtered := make([]utils.Dict, 0, len(dated))
+		for _, d := range dated {
+			filtered = append(filtered, d.alert)
 		}
 
 		if skip > len(filtered) {
@@ -262,10 +282,13 @@ func visionOneAlert(id string, created time.Time) utils.Dict {
 		"updatedDateTime":     ts,
 		"description":         "A high-privilege process accessed credential storage on an endpoint.",
 		"impactScope": utils.Dict{
-			"desktopCount":      1,
-			"serverCount":       0,
-			"accountCount":      1,
-			"emailAddressCount": 0,
+			"desktopCount":       1,
+			"serverCount":        0,
+			"accountCount":       1,
+			"emailAddressCount":  0,
+			"containerCount":     0,
+			"cloudIdentityCount": 0,
+			"cloudWorkloadCount": 0,
 			"entities": []interface{}{
 				utils.Dict{
 					"entityType":          "account",
@@ -309,7 +332,7 @@ func visionOneAlert(id string, created time.Time) utils.Dict {
 						"id":                "33333333-3333-3333-3333-333333333333",
 						"name":              "Credential Dumping via Memory Access",
 						"matchedDateTime":   ts,
-						"mitreTechniqueIds": []interface{}{"V9013.T1003.001"},
+						"mitreTechniqueIds": []interface{}{"T1003.001"},
 						"matchedEvents": []interface{}{
 							utils.Dict{
 								"uuid":            "55555555-5555-5555-5555-555555555555",
@@ -422,13 +445,15 @@ func TestMockAlertsEndToEnd(t *testing.T) {
 // window then stops it from being shipped over and over.
 //
 // The adapter has no deduplication: its only re-ship protection is the
-// server-side startDateTime/endDateTime window, whose boundaries the real API
-// treats inclusively at one-second granularity. An alert whose createdDateTime
-// second coincides with a window boundary can therefore legitimately ship
-// twice (against the real API too). The poll interval here is kept above one
-// second so window starts strictly advance each poll, bounding the new alert
-// at one possible boundary duplicate; the test pins "at least once, at most
-// twice, then never again".
+// server-side startDateTime/endDateTime window. The API's timestamps have
+// one-second granularity (documented format yyyy-MM-ddThh:mm:ssZ) and the
+// official docs do not say whether the boundaries are inclusive; the mock
+// assumes inclusive, the worst case for duplicates. Under that reading an
+// alert whose createdDateTime second coincides with a window boundary can
+// legitimately ship twice. The poll interval here is kept above one second so
+// window starts strictly advance each poll, bounding the new alert at one
+// possible boundary duplicate; the test pins "at least once, at most twice,
+// then never again".
 func TestMockNewAlertMidRun(t *testing.T) {
 	const token = "tmv1-fake-token-0000000000000000"
 	const newID = "WB-9002-20260611-00099"

--- a/wiz/client.go
+++ b/wiz/client.go
@@ -17,9 +17,28 @@ import (
 	"github.com/refractionPOINT/usp-adapters/utils"
 )
 
+const (
+	// defaultTokenURL is the Wiz commercial-cloud OAuth token endpoint used
+	// when the config does not override it.
+	defaultTokenURL = "https://auth.app.wiz.io/oauth/token"
+
+	// defaultPollInterval is the historical fixed wait between polls of the
+	// Wiz GraphQL API.
+	defaultPollInterval = 30 * time.Second
+)
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type WizAdapter struct {
 	conf       WizConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
 
 	chStopped chan struct{}
@@ -41,6 +60,15 @@ type WizConfig struct {
 	TimeField     string                  `json:"time_field" yaml:"time_field"` // e.g., "createdAt", "updatedAt"
 	DataPath      []string                `json:"data_path" yaml:"data_path"`   // e.g., ["data", "securityIssues", "issues"]
 	IDField       string                  `json:"id_field" yaml:"id_field"`     // e.g., "id"
+
+	// TokenURL overrides the OAuth token endpoint. Empty means the Wiz
+	// commercial cloud endpoint (https://auth.app.wiz.io/oauth/token).
+	TokenURL string `json:"token_url" yaml:"token_url"`
+
+	// PollInterval overrides the fixed wait between polls of the Wiz GraphQL
+	// API. It is not settable through a config file; it exists as a seam for
+	// tests (the production interval stays the historical 30 seconds).
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *WizConfig) Validate() error {
@@ -72,16 +100,36 @@ func (c *WizConfig) Validate() error {
 }
 
 func NewWizAdapter(ctx context.Context, conf WizConfig) (*WizAdapter, chan struct{}, error) {
-	var err error
+	return newWizAdapter(ctx, conf, nil)
+}
+
+// newWizAdapter is the implementation behind NewWizAdapter. When sink is
+// non-nil it is used in place of a real LimaCharlie client -- the seam tests
+// use to capture shipped events.
+func newWizAdapter(ctx context.Context, conf WizConfig, sink uspSink) (*WizAdapter, chan struct{}, error) {
 	a := &WizAdapter{
 		conf:   conf,
 		ctx:    context.Background(),
 		doStop: utils.NewEvent(),
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	// The runner may construct the adapter without calling Validate(), so
+	// defaults are applied here rather than relying on Validate().
+	if a.conf.TokenURL == "" {
+		a.conf.TokenURL = defaultTokenURL
+	}
+	if a.conf.PollInterval <= 0 {
+		a.conf.PollInterval = defaultPollInterval
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -131,7 +179,7 @@ func (a *WizAdapter) fetchToken() (string, error) {
 
 	a.conf.ClientOptions.DebugLog("fetching token")
 
-	url := "https://auth.app.wiz.io/oauth/token"
+	url := a.conf.TokenURL
 	payload := fmt.Sprintf("grant_type=client_credentials&client_id=%s&client_secret=%s&audience=wiz-api",
 		a.conf.ClientID,
 		a.conf.ClientSecret)
@@ -178,7 +226,7 @@ func (a *WizAdapter) fetchEvents() {
 	lastEventId := ""
 	since := time.Now().Add(-24 * time.Hour).Format(time.RFC3339)
 
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.conf.PollInterval) {
 		items, newSince, eventId, err := a.makeOneGraphQLRequest(since, lastEventId)
 		if err != nil {
 			a.conf.ClientOptions.OnError(fmt.Errorf("error making GraphQL request: %v", err))

--- a/wiz/client_test.go
+++ b/wiz/client_test.go
@@ -1,0 +1,102 @@
+package usp_wiz
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// validTestConfig returns a config that passes Validate(). The URLs point at a
+// reserved example domain; nothing in these unit tests performs network I/O.
+func validTestConfig(t *testing.T) WizConfig {
+	t.Helper()
+	return WizConfig{
+		ClientOptions: testClientOptions(t),
+		ClientID:      "test-client-id",
+		ClientSecret:  "test-client-secret",
+		URL:           "https://api.wiz.example.com/graphql",
+		Query:         testIssuesQuery,
+		TimeField:     "createdAt",
+		DataPath:      []string{"data", "issues", "nodes"},
+		IDField:       "id",
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("valid config passes", func(t *testing.T) {
+		c := validTestConfig(t)
+		assert.NoError(t, c.Validate())
+	})
+
+	mutations := map[string]func(*WizConfig){
+		"missing client_id":     func(c *WizConfig) { c.ClientID = "" },
+		"missing client_secret": func(c *WizConfig) { c.ClientSecret = "" },
+		"missing url":           func(c *WizConfig) { c.URL = "" },
+		"missing query":         func(c *WizConfig) { c.Query = "" },
+		"missing time_field":    func(c *WizConfig) { c.TimeField = "" },
+		"missing data_path":     func(c *WizConfig) { c.DataPath = nil },
+		"missing id_field":      func(c *WizConfig) { c.IDField = "" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			c := validTestConfig(t)
+			mutate(&c)
+			assert.Error(t, c.Validate())
+		})
+	}
+}
+
+// TestConstructorDefaults verifies the constructor fills the token URL and
+// poll interval defaults (production values) when the config leaves them
+// empty, and that explicit values are respected.
+func TestConstructorDefaults(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	t.Run("defaults applied", func(t *testing.T) {
+		sink := &captureSink{}
+		// The default 30s poll interval means no request is made before Close.
+		adapter, _, err := newWizAdapter(ctx, validTestConfig(t), sink)
+		require.NoError(t, err)
+		defer adapter.Close()
+
+		assert.Equal(t, "https://auth.app.wiz.io/oauth/token", adapter.conf.TokenURL,
+			"an empty token_url must default to the Wiz commercial cloud endpoint")
+		assert.Equal(t, 30*time.Second, adapter.conf.PollInterval,
+			"the default poll interval must stay the historical 30 seconds")
+	})
+
+	t.Run("overrides respected", func(t *testing.T) {
+		sink := &captureSink{}
+		conf := validTestConfig(t)
+		conf.TokenURL = "https://auth.gov.wiz.example.com/oauth/token"
+		conf.PollInterval = 42 * time.Minute
+		adapter, _, err := newWizAdapter(ctx, conf, sink)
+		require.NoError(t, err)
+		defer adapter.Close()
+
+		assert.Equal(t, conf.TokenURL, adapter.conf.TokenURL)
+		assert.Equal(t, 42*time.Minute, adapter.conf.PollInterval)
+	})
+}

--- a/wiz/mock_test.go
+++ b/wiz/mock_test.go
@@ -63,10 +63,15 @@ func (s *captureSink) snapshot() []*protocol.DataMessage {
 //     auth.app.wiz.io/oauth/token performs (form-encoded, audience=wiz-api),
 //     returning a bearer token.
 //   - POST /graphql: the GraphQL endpoint (api.<region>.app.wiz.io/graphql in
-//     production). It validates the bearer token, parses the query/variables
-//     the adapter sends, and answers from an in-memory issue set, honoring
-//     the filterBy.<timeField>.after time filter the way the real API filters
-//     issues (strictly newer than "after", newest first).
+//     production, where <region> is the tenant's region such as us1 or eu1).
+//     It validates the bearer token, parses the query/variables the adapter
+//     sends, and answers from an in-memory issue set, applying the
+//     filterBy.<timeField>.after filter as strictly exclusive and returning
+//     nodes newest first. Wiz's full filter/ordering reference sits behind its
+//     auth-gated docs, so those two semantics are best-effort: they are what
+//     the adapter's watermark logic requires for exactly-once delivery (a real
+//     deployment must request a descending time order via the query's
+//     $orderBy/IssueOrder variables), so the mock pins them.
 type mockWiz struct {
 	mu sync.Mutex
 
@@ -308,9 +313,14 @@ func extractAfter(variables map[string]interface{}) string {
 
 // --- realistic fixtures -------------------------------------------------------
 
-// testIssuesQuery is shaped like the issues query Wiz documents for pulling
-// Issues over GraphQL. The adapter treats the query as an opaque string; the
-// mock captures it so tests can assert it is sent verbatim.
+// testIssuesQuery is shaped like the IssuesTable query Wiz publishes for
+// pulling Issues over GraphQL (the same issuesV2 alias, $filterBy/$first/
+// $after/$orderBy signature, node fields and pageInfo{hasNextPage endCursor}
+// appear in Wiz-maintained integrations). In the real schema sourceRule is an
+// interface queried via inline fragments; the flat {id name} selection here
+// is the simplified form some Wiz-published examples use. The adapter treats
+// the query as an opaque string; the mock captures it so tests can assert it
+// is sent verbatim.
 const testIssuesQuery = `query IssuesTable($filterBy: IssueFilters, $first: Int, $after: String, $orderBy: IssueOrder) {
   issues: issuesV2(filterBy: $filterBy, first: $first, after: $after, orderBy: $orderBy) {
     nodes {

--- a/wiz/mock_test.go
+++ b/wiz/mock_test.go
@@ -1,0 +1,672 @@
+package usp_wiz
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock of the Wiz API:
+// the OAuth client-credentials token endpoint (auth.app.wiz.io/oauth/token in
+// production) and the GraphQL endpoint, capturing the exact messages shipped
+// so their content can be asserted.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Wiz API -------------------------------------------------------------
+
+// mockWiz is an in-memory stand-in for the Wiz API. It serves two endpoints:
+//
+//   - POST /oauth/token: the OAuth2 client-credentials exchange the real
+//     auth.app.wiz.io/oauth/token performs (form-encoded, audience=wiz-api),
+//     returning a bearer token.
+//   - POST /graphql: the GraphQL endpoint (api.<region>.app.wiz.io/graphql in
+//     production). It validates the bearer token, parses the query/variables
+//     the adapter sends, and answers from an in-memory issue set, honoring
+//     the filterBy.<timeField>.after time filter the way the real API filters
+//     issues (strictly newer than "after", newest first).
+type mockWiz struct {
+	mu sync.Mutex
+
+	clientID     string
+	clientSecret string
+	expiresIn    float64
+
+	tokenSerial int    // bumps on every successful token issue
+	lastToken   string // the most recently issued bearer token
+
+	issues []map[string]interface{}
+
+	graphqlError bool // when true, /graphql returns a GraphQL errors envelope
+
+	tokenRequests   int
+	graphqlRequests int
+	lastQuery       string
+	lastVariables   map[string]interface{}
+}
+
+func newMockWiz(clientID, clientSecret string) *mockWiz {
+	return &mockWiz{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		expiresIn:    3600,
+	}
+}
+
+func (m *mockWiz) setIssues(issues []map[string]interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.issues = issues
+}
+
+func (m *mockWiz) addIssue(issue map[string]interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.issues = append(m.issues, issue)
+}
+
+func (m *mockWiz) setGraphQLError(v bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.graphqlError = v
+}
+
+func (m *mockWiz) tokenRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests
+}
+
+func (m *mockWiz) graphqlRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.graphqlRequests
+}
+
+func (m *mockWiz) tokenIssueCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenSerial
+}
+
+func (m *mockWiz) capturedRequest() (string, map[string]interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastQuery, m.lastVariables
+}
+
+func (m *mockWiz) server(t *testing.T) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/token", m.handleToken(t))
+	mux.HandleFunc("/graphql", m.handleGraphQL(t))
+	return httptest.NewServer(mux)
+}
+
+// handleToken implements the OAuth2 client-credentials exchange the way
+// auth.app.wiz.io does: a form-encoded POST carrying grant_type, client_id,
+// client_secret and audience=wiz-api, answered with an access_token JSON.
+func (m *mockWiz) handleToken(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.tokenRequests++
+		m.mu.Unlock()
+
+		// Handlers run on server goroutines: use assert (not require).
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		form, err := url.ParseQuery(string(body))
+		if !assert.NoError(t, err) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		assert.Equal(t, "client_credentials", form.Get("grant_type"),
+			"the token exchange must be a client-credentials grant")
+		assert.Equal(t, "wiz-api", form.Get("audience"),
+			"the Wiz token exchange requires audience=wiz-api")
+
+		if form.Get("client_id") != m.clientID || form.Get("client_secret") != m.clientSecret {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"access_denied","error_description":"Unauthorized"}`))
+			return
+		}
+
+		m.mu.Lock()
+		m.tokenSerial++
+		m.lastToken = fmt.Sprintf("wiz-test-access-token-%04d", m.tokenSerial)
+		token := m.lastToken
+		expiresIn := m.expiresIn
+		m.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": token,
+			"token_type":   "Bearer",
+			"expires_in":   expiresIn,
+		})
+	}
+}
+
+// handleGraphQL validates the bearer token and answers the adapter's query
+// from the in-memory issue set, honoring the filterBy.<timeField>.after
+// filter: only issues with a createdAt strictly newer than "after" are
+// returned, newest first, inside the standard GraphQL data envelope.
+func (m *mockWiz) handleGraphQL(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.graphqlRequests++
+		expectedAuth := "Bearer " + m.lastToken
+		hasToken := m.lastToken != ""
+		gqlError := m.graphqlError
+		m.mu.Unlock()
+
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		if !hasToken || r.Header.Get("Authorization") != expectedAuth {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"errors":[{"message":"Unauthorized","extensions":{"code":"UNAUTHENTICATED"}}]}`))
+			return
+		}
+
+		var reqBody struct {
+			Query     string                 `json:"query"`
+			Variables map[string]interface{} `json:"variables"`
+		}
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&reqBody)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		m.mu.Lock()
+		m.lastQuery = reqBody.Query
+		m.lastVariables = reqBody.Variables
+		m.mu.Unlock()
+
+		if gqlError {
+			// A GraphQL-level failure: HTTP 200 with an errors envelope and no
+			// data, exactly how GraphQL APIs report resolver errors.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"errors":[{"message":"internal server error","extensions":{"code":"INTERNAL_SERVER_ERROR"}}]}`))
+			return
+		}
+
+		after := extractAfter(reqBody.Variables)
+		var afterTime time.Time
+		if after != "" {
+			parsed, err := time.Parse(time.RFC3339, after)
+			if !assert.NoError(t, err, "the after filter must be an RFC3339 timestamp") {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			afterTime = parsed
+		}
+
+		m.mu.Lock()
+		var nodes []map[string]interface{}
+		for _, issue := range m.issues {
+			createdAt, _ := issue["createdAt"].(string)
+			ts, err := time.Parse(time.RFC3339, createdAt)
+			if !assert.NoError(t, err, "fixture createdAt must be RFC3339") {
+				continue
+			}
+			if after != "" && !ts.After(afterTime) {
+				continue
+			}
+			nodes = append(nodes, issue)
+		}
+		m.mu.Unlock()
+
+		// The adapter's incremental polling relies on a newest-first ordering
+		// (it takes the first node's timestamp as the next "after" watermark).
+		sort.SliceStable(nodes, func(i, j int) bool {
+			ti, _ := time.Parse(time.RFC3339, nodes[i]["createdAt"].(string))
+			tj, _ := time.Parse(time.RFC3339, nodes[j]["createdAt"].(string))
+			return ti.After(tj)
+		})
+		if nodes == nil {
+			nodes = []map[string]interface{}{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"issues": map[string]interface{}{
+					"nodes": nodes,
+					"pageInfo": map[string]interface{}{
+						"hasNextPage": false,
+						"endCursor":   nil,
+					},
+					"totalCount": len(nodes),
+				},
+			},
+		})
+	}
+}
+
+// extractAfter digs variables.filterBy.createdAt.after out of the adapter's
+// GraphQL variables.
+func extractAfter(variables map[string]interface{}) string {
+	filterBy, _ := variables["filterBy"].(map[string]interface{})
+	createdAt, _ := filterBy["createdAt"].(map[string]interface{})
+	after, _ := createdAt["after"].(string)
+	return after
+}
+
+// --- realistic fixtures -------------------------------------------------------
+
+// testIssuesQuery is shaped like the issues query Wiz documents for pulling
+// Issues over GraphQL. The adapter treats the query as an opaque string; the
+// mock captures it so tests can assert it is sent verbatim.
+const testIssuesQuery = `query IssuesTable($filterBy: IssueFilters, $first: Int, $after: String, $orderBy: IssueOrder) {
+  issues: issuesV2(filterBy: $filterBy, first: $first, after: $after, orderBy: $orderBy) {
+    nodes {
+      id
+      createdAt
+      updatedAt
+      status
+      severity
+      type
+      sourceRule { id name }
+      entitySnapshot { id type name cloudPlatform region subscriptionExternalId }
+      projects { id name slug }
+    }
+    pageInfo { hasNextPage endCursor }
+    totalCount
+  }
+}`
+
+// realisticWizIssue returns a record shaped like a real Wiz Issue node:
+// nested sourceRule/entitySnapshot objects, a projects array and mixed scalar
+// types. All identifiers are clearly fake.
+func realisticWizIssue(id, createdAt string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":        id,
+		"createdAt": createdAt,
+		"updatedAt": createdAt,
+		"status":    "OPEN",
+		"severity":  "CRITICAL",
+		"type":      "TOXIC_COMBINATION",
+		"sourceRule": map[string]interface{}{
+			"id":   "11111111-1111-1111-1111-111111111111",
+			"name": "Publicly exposed VM with a highly privileged IAM role",
+		},
+		"entitySnapshot": map[string]interface{}{
+			"id":                     "22222222-2222-2222-2222-222222222222",
+			"type":                   "VIRTUAL_MACHINE",
+			"name":                   "prod-web-01.example.com",
+			"cloudPlatform":          "AWS",
+			"region":                 "us-east-1",
+			"subscriptionExternalId": "111111111111",
+			"tags": map[string]interface{}{
+				"env":  "production",
+				"team": "platform",
+			},
+		},
+		"projects": []interface{}{
+			map[string]interface{}{
+				"id":   "33333333-3333-3333-3333-333333333333",
+				"name": "Example Project",
+				"slug": "example-project",
+			},
+		},
+		"notes": []interface{}{},
+	}
+}
+
+// issueTime renders a fixture timestamp n minutes in the past. Fixtures use
+// recent timestamps because the adapter's first poll filters to the last 24h.
+func issueTime(minutesAgo int) string {
+	return time.Now().UTC().Add(-time.Duration(minutesAgo) * time.Minute).Format(time.RFC3339)
+}
+
+const (
+	testClientID     = "test-client-id"
+	testClientSecret = "test-client-secret"
+)
+
+// testWizConfig returns a config pointed at the mock server, polling fast so
+// tests stay quick.
+func testWizConfig(t *testing.T, serverURL string) WizConfig {
+	t.Helper()
+	return WizConfig{
+		ClientOptions: testClientOptions(t),
+		ClientID:      testClientID,
+		ClientSecret:  testClientSecret,
+		URL:           serverURL + "/graphql",
+		TokenURL:      serverURL + "/oauth/token",
+		Query:         testIssuesQuery,
+		Variables: map[string]interface{}{
+			"first": 100,
+			"filterBy": map[string]interface{}{
+				"status": []interface{}{"OPEN", "IN_PROGRESS"},
+			},
+		},
+		TimeField:    "createdAt",
+		DataPath:     []string{"data", "issues", "nodes"},
+		IDField:      "id",
+		PollInterval: 25 * time.Millisecond,
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// --- tests ----------------------------------------------------------------------
+
+// TestMockIssuesEndToEnd drives the adapter against the mock Wiz API and
+// asserts the exact events shipped: verbatim payloads (nested objects and
+// arrays included), the adapter's TimestampMs/EventType conventions, no
+// re-shipping on later polls, and a cached token reused across polls.
+func TestMockIssuesEndToEnd(t *testing.T) {
+	mock := newMockWiz(testClientID, testClientSecret)
+	want := []map[string]interface{}{
+		realisticWizIssue("44444444-4444-4444-4444-000000000001", issueTime(30)),
+		realisticWizIssue("44444444-4444-4444-4444-000000000002", issueTime(20)),
+		realisticWizIssue("44444444-4444-4444-4444-000000000003", issueTime(10)),
+	}
+	mock.setIssues(want)
+
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	startMs := uint64(time.Now().UnixMilli())
+	adapter, _, err := newWizAdapter(ctx, testWizConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 issues to ship")
+
+	// Re-polling must not re-ship: the time filter advances past the newest
+	// shipped issue, so the count stays at 3 across many further polls.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "issues were re-shipped on a later poll")
+
+	endMs := uint64(time.Now().UnixMilli())
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		// The adapter does not set an EventType and stamps events with the
+		// ship time (not the record's createdAt) -- pin both behaviors.
+		assert.Empty(t, msg.EventType, "the wiz adapter does not tag an event type")
+		assert.GreaterOrEqual(t, msg.TimestampMs, startMs)
+		assert.LessOrEqual(t, msg.TimestampMs, endMs)
+
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	// Payloads are shipped verbatim -- nested objects and arrays included.
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "issue %s was not shipped", id)
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Wiz issue")
+	}
+
+	// The bearer token is cached and reused: with expires_in=3600 every poll
+	// after the first reuses the same token.
+	assert.Equal(t, 1, mock.tokenRequestCount(), "the token must be fetched once and cached")
+	assert.GreaterOrEqual(t, mock.graphqlRequestCount(), 2, "multiple polls should have run")
+}
+
+// TestMockNewIssueMidRunShipsOnce verifies an issue appearing mid-run is
+// picked up by the advancing time filter and shipped exactly once, without
+// re-shipping anything already sent.
+func TestMockNewIssueMidRunShipsOnce(t *testing.T) {
+	mock := newMockWiz(testClientID, testClientSecret)
+	mock.setIssues([]map[string]interface{}{
+		realisticWizIssue("44444444-4444-4444-4444-00000000000a", issueTime(30)),
+		realisticWizIssue("44444444-4444-4444-4444-00000000000b", issueTime(20)),
+	})
+
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newWizAdapter(ctx, testWizConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new issue appears, strictly newer than everything shipped so far.
+	mock.addIssue(realisticWizIssue("44444444-4444-4444-4444-00000000000c", issueTime(0)))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new issue should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{
+		"44444444-4444-4444-4444-00000000000a": 1,
+		"44444444-4444-4444-4444-00000000000b": 1,
+		"44444444-4444-4444-4444-00000000000c": 1,
+	}, shippedPerID, "every issue must ship exactly once")
+}
+
+// TestMockGraphQLRequestShape verifies the request the adapter sends: the
+// configured query verbatim, the configured variables preserved, and the
+// filterBy.<time_field>.after watermark injected and advanced to the newest
+// shipped issue's timestamp on later polls.
+func TestMockGraphQLRequestShape(t *testing.T) {
+	newestCreatedAt := issueTime(5)
+	mock := newMockWiz(testClientID, testClientSecret)
+	mock.setIssues([]map[string]interface{}{
+		realisticWizIssue("44444444-4444-4444-4444-000000000001", issueTime(15)),
+		realisticWizIssue("44444444-4444-4444-4444-000000000002", newestCreatedAt),
+	})
+
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newWizAdapter(ctx, testWizConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// Wait for at least one post-shipment poll, whose "after" must be the
+	// newest shipped issue's createdAt.
+	require.Eventually(t, func() bool {
+		_, variables := mock.capturedRequest()
+		return extractAfter(variables) == newestCreatedAt
+	}, 5*time.Second, 20*time.Millisecond, "the after watermark should advance to the newest issue")
+
+	query, variables := mock.capturedRequest()
+	assert.Equal(t, testIssuesQuery, query, "the configured GraphQL query must be sent verbatim")
+	assert.Equal(t, float64(100), variables["first"], "configured variables must be preserved")
+
+	filterBy, ok := variables["filterBy"].(map[string]interface{})
+	require.True(t, ok, "filterBy must be an object")
+	assert.Equal(t, []interface{}{"OPEN", "IN_PROGRESS"}, filterBy["status"],
+		"configured filterBy entries must be preserved alongside the injected time filter")
+}
+
+// TestMockTokenRefreshOnExpiry verifies an expiring token is re-fetched and
+// the new bearer token is used on subsequent GraphQL calls (the mock rejects
+// any token but the most recently issued one).
+func TestMockTokenRefreshOnExpiry(t *testing.T) {
+	mock := newMockWiz(testClientID, testClientSecret)
+	// expires_in=1s is within the adapter's one-minute refresh margin, so
+	// every poll must fetch a fresh token.
+	mock.expiresIn = 1
+	mock.setIssues([]map[string]interface{}{
+		realisticWizIssue("44444444-4444-4444-4444-000000000001", issueTime(10)),
+	})
+
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newWizAdapter(ctx, testWizConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the issue should ship")
+	require.Eventually(t, func() bool { return mock.tokenIssueCount() >= 3 },
+		5*time.Second, 20*time.Millisecond, "an expiring token must be re-fetched on later polls")
+
+	// Polling kept working across token rotations (the mock 401s any stale
+	// token, which would surface as re-ship failures or stalled polls).
+	require.Never(t, func() bool { return sink.count() != 1 },
+		300*time.Millisecond, 30*time.Millisecond)
+}
+
+// TestMockBadCredentialsShipsNothing pins the adapter's behavior on an OAuth
+// failure: nothing ships, the GraphQL endpoint is never reached, and the
+// adapter keeps retrying (it does not stop itself on auth errors).
+func TestMockBadCredentialsShipsNothing(t *testing.T) {
+	mock := newMockWiz(testClientID, "the-real-secret")
+	mock.setIssues([]map[string]interface{}{
+		realisticWizIssue("44444444-4444-4444-4444-000000000001", issueTime(10)),
+	})
+
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := testWizConfig(t, server.URL)
+	conf.ClientSecret = "wrong-secret"
+	adapter, chStopped, err := newWizAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return mock.tokenRequestCount() >= 3 },
+		5*time.Second, 20*time.Millisecond, "the adapter should keep retrying the token exchange")
+
+	assert.Equal(t, 0, sink.count(), "nothing must ship when authentication fails")
+	assert.Equal(t, 0, mock.graphqlRequestCount(), "GraphQL must not be queried without a token")
+
+	select {
+	case <-chStopped:
+		t.Fatal("the wiz adapter keeps polling on auth failure; it must not stop")
+	default:
+	}
+}
+
+// TestMockGraphQLErrorThenRecovery verifies a GraphQL errors envelope (HTTP
+// 200, no data) ships nothing and does not kill the polling loop: once the
+// API recovers, the pending issues ship.
+func TestMockGraphQLErrorThenRecovery(t *testing.T) {
+	mock := newMockWiz(testClientID, testClientSecret)
+	mock.setGraphQLError(true)
+	mock.setIssues([]map[string]interface{}{
+		realisticWizIssue("44444444-4444-4444-4444-000000000001", issueTime(20)),
+		realisticWizIssue("44444444-4444-4444-4444-000000000002", issueTime(10)),
+	})
+
+	server := mock.server(t)
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, chStopped, err := newWizAdapter(ctx, testWizConfig(t, server.URL), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// While the API errors, polls happen but nothing ships and the adapter
+	// stays alive.
+	require.Eventually(t, func() bool { return mock.graphqlRequestCount() >= 3 },
+		5*time.Second, 20*time.Millisecond)
+	assert.Equal(t, 0, sink.count(), "nothing must ship while the API returns errors")
+	select {
+	case <-chStopped:
+		t.Fatal("a GraphQL error must not stop the adapter")
+	default:
+	}
+
+	// The API recovers; both issues ship exactly once.
+	mock.setGraphQLError(false)
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "issues should ship once the API recovers")
+	require.Never(t, func() bool { return sink.count() != 2 },
+		300*time.Millisecond, 30*time.Millisecond)
+}

--- a/zendesk/client.go
+++ b/zendesk/client.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,7 +21,19 @@ import (
 const (
 	logsEndpoint  = "/api/v2/audit_logs"
 	overlapPeriod = 30 * time.Second
+
+	// defaultPollInterval is how long fetchEvents idles between polling ticks.
+	defaultPollInterval = 30 * time.Second
 )
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
 
 type opRequest struct {
 	Limit     int    `json:"page[size],omitempty"`
@@ -30,8 +43,11 @@ type opRequest struct {
 
 type ZendeskAdapter struct {
 	conf       ZendeskConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
+
+	baseURL      string
+	pollInterval time.Duration
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -47,6 +63,15 @@ type ZendeskConfig struct {
 	ApiToken      string                  `json:"api_token" yaml:"api_token"`
 	ZendeskDomain string                  `json:"zendesk_domain" yaml:"zendesk_domain"`
 	ZendeskEmail  string                  `json:"zendesk_email" yaml:"zendesk_email"`
+
+	// BaseURL overrides the scheme and host used to reach the Zendesk API.
+	// Empty means "https://" + ZendeskDomain.
+	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// PollInterval overrides the wait between polls of the audit logs
+	// endpoint (default 30s). It is not settable through a config file; it
+	// exists as a seam for tests.
+	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
 func (c *ZendeskConfig) Validate() error {
@@ -67,7 +92,13 @@ func (c *ZendeskConfig) Validate() error {
 }
 
 func NewZendeskAdapter(ctx context.Context, conf ZendeskConfig) (*ZendeskAdapter, chan struct{}, error) {
-	var err error
+	return newZendeskAdapter(ctx, conf, nil)
+}
+
+// newZendeskAdapter is the implementation behind NewZendeskAdapter. When sink
+// is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newZendeskAdapter(ctx context.Context, conf ZendeskConfig, sink uspSink) (*ZendeskAdapter, chan struct{}, error) {
 	a := &ZendeskAdapter{
 		conf:   conf,
 		ctx:    context.Background(),
@@ -75,9 +106,23 @@ func NewZendeskAdapter(ctx context.Context, conf ZendeskConfig) (*ZendeskAdapter
 		dedupe: make(map[string]int64),
 	}
 
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	a.baseURL = strings.TrimSuffix(conf.BaseURL, "/")
+	if a.baseURL == "" {
+		a.baseURL = fmt.Sprintf("https://%s", conf.ZendeskDomain)
+	}
+	a.pollInterval = conf.PollInterval
+	if a.pollInterval <= 0 {
+		a.pollInterval = defaultPollInterval
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -123,7 +168,7 @@ func (a *ZendeskAdapter) fetchEvents() {
 
 	since := time.Now()
 
-	for !a.doStop.WaitFor(30 * time.Second) {
+	for !a.doStop.WaitFor(a.pollInterval) {
 		// The makeOneRequest function handles error
 		// handling and fatal error handling.
 		items, newSince, _ := a.makeOneRequest(since)
@@ -168,8 +213,8 @@ func (a *ZendeskAdapter) makeOneRequest(since time.Time) ([]utils.Dict, time.Tim
 
 	for {
 		// Prepare the request.
-		req, err := http.NewRequest("GET", fmt.Sprintf("https://%s%s?filter[created_at][]=%s&filter[created_at][]=%s&page[size]=100", a.conf.ZendeskDomain, logsEndpoint, start, until), nil)
-		//a.conf.ClientOptions.DebugLog(fmt.Sprintf("requesting from https://%s%s?filter[created_at][]=%s&filter[created_at][]=%s&page[size]=100", a.conf.ZendeskDomain, logsEndpoint, start, until))
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s%s?filter[created_at][]=%s&filter[created_at][]=%s&page[size]=100", a.baseURL, logsEndpoint, start, until), nil)
+		//a.conf.ClientOptions.DebugLog(fmt.Sprintf("requesting from %s%s?filter[created_at][]=%s&filter[created_at][]=%s&page[size]=100", a.baseURL, logsEndpoint, start, until))
 		if err != nil {
 			a.doStop.Set()
 			return nil, lastDetectionTime, err

--- a/zendesk/client_test.go
+++ b/zendesk/client_test.go
@@ -1,0 +1,100 @@
+package usp_zendesk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func TestValidate(t *testing.T) {
+	valid := func() ZendeskConfig {
+		return ZendeskConfig{
+			ClientOptions: testClientOptions(t),
+			ApiToken:      "test-api-token-0000000000",
+			ZendeskDomain: "example.zendesk.com",
+			ZendeskEmail:  "jdoe@example.com",
+		}
+	}
+
+	t.Run("valid config passes", func(t *testing.T) {
+		c := valid()
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("requires api_token", func(t *testing.T) {
+		c := valid()
+		c.ApiToken = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires zendesk_domain", func(t *testing.T) {
+		c := valid()
+		c.ZendeskDomain = ""
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires zendesk_email", func(t *testing.T) {
+		c := valid()
+		c.ZendeskEmail = ""
+		assert.Error(t, c.Validate())
+	})
+}
+
+// TestBaseURLAndPollIntervalDefaults verifies the adapter derives its base URL
+// from the configured domain when base_url is unset, honors an explicit
+// base_url override (trailing slash trimmed), and applies the default poll
+// interval unless the test seam overrides it.
+func TestBaseURLAndPollIntervalDefaults(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("defaults from domain", func(t *testing.T) {
+		conf := ZendeskConfig{
+			ClientOptions: testClientOptions(t),
+			ApiToken:      "tok",
+			ZendeskDomain: "example.zendesk.com",
+			ZendeskEmail:  "jdoe@example.com",
+		}
+		a, _, err := newZendeskAdapter(ctx, conf, &captureSink{})
+		require.NoError(t, err)
+		defer a.Close()
+		assert.Equal(t, "https://example.zendesk.com", a.baseURL)
+		assert.Equal(t, defaultPollInterval, a.pollInterval)
+	})
+
+	t.Run("base_url override wins and is trimmed", func(t *testing.T) {
+		conf := ZendeskConfig{
+			ClientOptions: testClientOptions(t),
+			ApiToken:      "tok",
+			ZendeskDomain: "example.zendesk.com",
+			ZendeskEmail:  "jdoe@example.com",
+			BaseURL:       "http://127.0.0.1:1/",
+			PollInterval:  time.Hour,
+		}
+		a, _, err := newZendeskAdapter(ctx, conf, &captureSink{})
+		require.NoError(t, err)
+		defer a.Close()
+		assert.Equal(t, "http://127.0.0.1:1", a.baseURL)
+		assert.Equal(t, time.Hour, a.pollInterval)
+	})
+}

--- a/zendesk/mock_test.go
+++ b/zendesk/mock_test.go
@@ -1,0 +1,535 @@
+package usp_zendesk
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock Zendesk Audit Logs
+// API (GET /api/v2/audit_logs), capturing the exact messages it ships so their
+// content -- event type, timestamp and verbatim payload -- can be asserted.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Zendesk Audit Logs API ----------------------------------------------
+
+// basicAuthFor reproduces the Zendesk API-token authentication scheme: HTTP
+// basic auth with the username "<email>/token" and the API token as password.
+func basicAuthFor(email, token string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s/token:%s", email, token)))
+}
+
+// cursorState remembers where a paginated walk left off so the next page can
+// resume from the same created_at window.
+type cursorState struct {
+	start  time.Time
+	until  time.Time
+	offset int
+}
+
+// mockZendesk is an in-memory stand-in for the Zendesk Audit Logs API as the
+// adapter consumes it: GET /api/v2/audit_logs authenticated with
+// "<email>/token:<api_token>" basic auth, filtered by a two-valued
+// filter[created_at][] window (inclusive), paginated by page[size] with a
+// {audit_logs, meta{has_more}, links{next}} envelope.
+//
+// Fidelity note: the real API's links.next is a full URL carrying a
+// page[after] cursor. This adapter feeds links.next back verbatim as the
+// *first* filter[created_at][] value of the next request (see makeOneRequest),
+// so the mock returns an opaque token instead and recognizes it there --
+// matching how the adapter actually consumes pagination.
+type mockZendesk struct {
+	mu    sync.Mutex
+	email string
+	token string
+
+	logs []utils.Dict // insertion order; created_at drives window matching
+
+	cursors    map[string]cursorState
+	nextCursor int
+
+	requests       int // total requests received
+	authFailures   int // requests rejected with 401
+	cursorRequests int // requests that resumed from a links.next cursor
+
+	lastMethod string
+	lastPath   string
+	lastAuth   string
+	lastQuery  url.Values
+}
+
+func newMockZendesk(email, token string) *mockZendesk {
+	return &mockZendesk{
+		email:   email,
+		token:   token,
+		cursors: map[string]cursorState{},
+	}
+}
+
+func (m *mockZendesk) addLog(record utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.logs = append(m.logs, record)
+}
+
+func (m *mockZendesk) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+func (m *mockZendesk) authFailureCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.authFailures
+}
+
+func (m *mockZendesk) cursorRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cursorRequests
+}
+
+func (m *mockZendesk) lastRequest() (method, path, auth string, query url.Values) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastMethod, m.lastPath, m.lastAuth, m.lastQuery
+}
+
+func (m *mockZendesk) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.requests++
+		m.lastMethod = r.Method
+		m.lastPath = r.URL.Path
+		m.lastAuth = r.Header.Get("Authorization")
+		m.lastQuery = r.URL.Query()
+		m.mu.Unlock()
+
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/api/v2/audit_logs" {
+			http.Error(w, `{"error":"InvalidEndpoint"}`, http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("Authorization") != basicAuthFor(m.email, m.token) {
+			m.mu.Lock()
+			m.authFailures++
+			m.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"Couldn't authenticate you"}`))
+			return
+		}
+
+		q := r.URL.Query()
+		pageSize := 100
+		if v, err := strconv.Atoi(q.Get("page[size]")); err == nil && v > 0 {
+			pageSize = v
+		}
+
+		created := q["filter[created_at][]"]
+		var cs cursorState
+		isCursor := false
+		m.mu.Lock()
+		if len(created) >= 1 {
+			if state, ok := m.cursors[created[0]]; ok {
+				cs, isCursor = state, true
+				m.cursorRequests++
+			}
+		}
+		m.mu.Unlock()
+
+		if !isCursor {
+			// A fresh window query carries exactly two created_at bounds.
+			if !assert.Len(t, created, 2, "window query must carry two filter[created_at][] values") {
+				http.Error(w, `{"error":"InvalidPaginationParameter"}`, http.StatusBadRequest)
+				return
+			}
+			start, err1 := time.Parse(time.RFC3339, created[0])
+			until, err2 := time.Parse(time.RFC3339, created[1])
+			if !assert.NoError(t, err1, "start bound must be RFC3339") ||
+				!assert.NoError(t, err2, "until bound must be RFC3339") {
+				http.Error(w, `{"error":"InvalidValue"}`, http.StatusBadRequest)
+				return
+			}
+			cs = cursorState{start: start, until: until}
+		}
+
+		// Select the logs inside the window (inclusive bounds) in insertion
+		// order, then serve the requested page.
+		m.mu.Lock()
+		var matching []utils.Dict
+		for _, rec := range m.logs {
+			tsStr, _ := rec["created_at"].(string)
+			ts, err := time.Parse(time.RFC3339, tsStr)
+			if !assert.NoError(t, err, "fixture created_at must be RFC3339") {
+				continue
+			}
+			if !ts.Before(cs.start) && !ts.After(cs.until) {
+				matching = append(matching, rec)
+			}
+		}
+
+		page := []utils.Dict{}
+		if cs.offset < len(matching) {
+			end := cs.offset + pageSize
+			if end > len(matching) {
+				end = len(matching)
+			}
+			page = matching[cs.offset:end]
+		}
+		hasMore := cs.offset+len(page) < len(matching)
+		next := ""
+		if hasMore {
+			m.nextCursor++
+			next = fmt.Sprintf("cursor_%06d", m.nextCursor)
+			m.cursors[next] = cursorState{start: cs.start, until: cs.until, offset: cs.offset + len(page)}
+		}
+		m.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"audit_logs": page,
+			"meta": map[string]interface{}{
+				"has_more":      hasMore,
+				"after_cursor":  next,
+				"before_cursor": "",
+			},
+			"links": map[string]interface{}{
+				"next": next,
+				"prev": "",
+			},
+		})
+	}
+}
+
+// --- realistic record fixtures ------------------------------------------------
+
+const (
+	mockEmail  = "jdoe@example.com"
+	mockToken  = "zd-test-api-token-0000000000000000"
+	mockDomain = "example.zendesk.com"
+)
+
+// auditLogFixture returns a record shaped like a real Zendesk audit log entry
+// (the documented fields of GET /api/v2/audit_logs).
+//
+// NOTE: the real API returns "id" (and actor_id/source_id) as JSON numbers.
+// The adapter dedupes on `item["id"].(string)`, so string ids are required for
+// it to function; the fixtures use string ids to match what the adapter can
+// actually consume (see the caveat in the test report / adapter review).
+func auditLogFixture(id string, createdAt time.Time, action string) utils.Dict {
+	return utils.Dict{
+		"id":                 id,
+		"url":                fmt.Sprintf("https://%s/api/v2/audit_logs/%s.json", mockDomain, id),
+		"action_label":       "Updated",
+		"actor_id":           11111111,
+		"actor_name":         mockEmail,
+		"source_id":          22222222,
+		"source_type":        "user",
+		"source_label":       "John Doe",
+		"action":             action,
+		"change_description": "Role changed from End User to Administrator",
+		"ip_address":         "192.0.2.10",
+		"created_at":         createdAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// startMockAdapter wires the adapter to the mock server through the captured
+// sink with a fast poll interval.
+func startMockAdapter(t *testing.T, serverURL string, sink uspSink) (*ZendeskAdapter, chan struct{}) {
+	t.Helper()
+	conf := ZendeskConfig{
+		ClientOptions: testClientOptions(t),
+		ApiToken:      mockToken,
+		ZendeskDomain: mockDomain,
+		ZendeskEmail:  mockEmail,
+		BaseURL:       serverURL,
+		PollInterval:  50 * time.Millisecond,
+	}
+	a, chStopped, err := newZendeskAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	return a, chStopped
+}
+
+// fixtureTime returns a created_at safely inside the adapter's filter window.
+// The adapter's window starts at the time the adapter was constructed
+// (truncated to the second by RFC3339 formatting), so a fixture timestamped a
+// couple of seconds in the future is guaranteed to fall inside [start, until]
+// once the wall clock catches up -- without any flaky same-second boundary.
+func fixtureTime() time.Time {
+	return time.Now().Add(2 * time.Second)
+}
+
+// --- tests ----------------------------------------------------------------
+
+// TestMockRequestShape verifies the on-the-wire request the adapter sends:
+// GET /api/v2/audit_logs with "<email>/token:<api_token>" basic auth, two
+// RFC3339 filter[created_at][] bounds (start <= until) and page[size]=100.
+func TestMockRequestShape(t *testing.T) {
+	mock := newMockZendesk(mockEmail, mockToken)
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Use the public constructor: TestSinkMode gives a real usp client wired
+	// to a test sink, proving the production wiring works end to end.
+	conf := ZendeskConfig{
+		ClientOptions: testClientOptions(t),
+		ApiToken:      mockToken,
+		ZendeskDomain: mockDomain,
+		ZendeskEmail:  mockEmail,
+		BaseURL:       server.URL,
+		PollInterval:  50 * time.Millisecond,
+	}
+	adapter, chStopped, err := NewZendeskAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return mock.requestCount() >= 1 },
+		5*time.Second, 20*time.Millisecond, "adapter never called the API")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped unexpectedly")
+	default:
+	}
+
+	method, path, auth, query := mock.lastRequest()
+	assert.Equal(t, http.MethodGet, method)
+	assert.Equal(t, "/api/v2/audit_logs", path)
+	assert.Equal(t, basicAuthFor(mockEmail, mockToken), auth,
+		"auth must be basic auth of '<email>/token:<api_token>'")
+	assert.Equal(t, "100", query.Get("page[size]"))
+
+	created := query["filter[created_at][]"]
+	require.Len(t, created, 2, "expected a two-valued created_at window")
+	start, err := time.Parse(time.RFC3339, created[0])
+	require.NoError(t, err)
+	until, err := time.Parse(time.RFC3339, created[1])
+	require.NoError(t, err)
+	assert.False(t, until.Before(start), "window start must be <= until")
+	assert.Equal(t, 0, mock.authFailureCount())
+}
+
+// TestMockAuditLogsEndToEnd drives the adapter against the mock API and
+// asserts the exact events shipped: every audit log entry ships exactly once
+// with its payload preserved verbatim, an ingestion-time TimestampMs and an
+// empty EventType (the adapter sets neither from the record -- pinned
+// behavior). Re-polling the same window must not re-ship.
+func TestMockAuditLogsEndToEnd(t *testing.T) {
+	mock := newMockZendesk(mockEmail, mockToken)
+	ts := fixtureTime()
+	want := []utils.Dict{
+		auditLogFixture("900000000001", ts, "update"),
+		auditLogFixture("900000000002", ts.Add(100*time.Millisecond), "create"),
+		auditLogFixture("900000000003", ts.Add(200*time.Millisecond), "login"),
+	}
+	for _, rec := range want {
+		mock.addLog(rec)
+	}
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	startMs := uint64(time.Now().UnixMilli())
+	adapter, _ := startMockAdapter(t, server.URL, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		8*time.Second, 25*time.Millisecond, "expected all 3 audit logs to ship")
+
+	// Re-polling must not re-ship: the count stays at 3 even though the mock
+	// keeps returning the same window contents on every poll.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		400*time.Millisecond, 25*time.Millisecond, "records were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		// Pinned behavior: the adapter does not set EventType, and stamps the
+		// message with the ingestion time rather than the record's created_at.
+		assert.Equal(t, "", msg.EventType)
+		assert.GreaterOrEqual(t, msg.TimestampMs, startMs,
+			"TimestampMs is the ingestion time, set after the test started")
+		assert.LessOrEqual(t, msg.TimestampMs, uint64(time.Now().UnixMilli()))
+
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3, "each record must ship exactly once")
+
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "record %s was not shipped", id)
+		// The payload is shipped verbatim.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Zendesk record")
+	}
+}
+
+// TestMockNewEntryShipsOnce verifies an audit log entry that appears mid-run
+// ships exactly once, and already-shipped entries are never re-sent.
+func TestMockNewEntryShipsOnce(t *testing.T) {
+	mock := newMockZendesk(mockEmail, mockToken)
+	mock.addLog(auditLogFixture("900000000010", fixtureTime(), "update"))
+	mock.addLog(auditLogFixture("900000000011", fixtureTime(), "create"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		8*time.Second, 25*time.Millisecond)
+
+	// A new audit log entry appears while the adapter is running.
+	mock.addLog(auditLogFixture("900000000012", fixtureTime(), "destroy"))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		8*time.Second, 25*time.Millisecond, "the new entry should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		400*time.Millisecond, 25*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{
+		"900000000010": 1,
+		"900000000011": 1,
+		"900000000012": 1,
+	}, shippedPerID, "every entry must ship exactly once")
+}
+
+// TestMockPaginationFullDataset verifies a window larger than one page
+// (page[size]=100) is walked to the end via meta.has_more/links.next and every
+// record ships exactly once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const total = 250 // 3 pages at the adapter's hardcoded page[size]=100
+
+	mock := newMockZendesk(mockEmail, mockToken)
+	ts := fixtureTime()
+	for i := 0; i < total; i++ {
+		mock.addLog(auditLogFixture(fmt.Sprintf("9100000%05d", i), ts, "update"))
+	}
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	adapter, _ := startMockAdapter(t, server.URL, sink)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 25*time.Millisecond, "all paginated records should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		400*time.Millisecond, 25*time.Millisecond)
+
+	assert.GreaterOrEqual(t, mock.cursorRequestCount(), 2,
+		"a 250-record window must be fetched through at least 2 follow-up pages")
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["id"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct record should be shipped once")
+}
+
+// TestMockBadCredentials pins the adapter's behavior on auth failure: nothing
+// ships, and the adapter does NOT stop -- a non-200 response only logs an
+// error and the polling loop keeps retrying on the next tick.
+func TestMockBadCredentials(t *testing.T) {
+	mock := newMockZendesk(mockEmail, mockToken)
+	mock.addLog(auditLogFixture("900000000099", fixtureTime(), "update"))
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	conf := ZendeskConfig{
+		ClientOptions: testClientOptions(t),
+		ApiToken:      "wrong-token",
+		ZendeskDomain: mockDomain,
+		ZendeskEmail:  mockEmail,
+		BaseURL:       server.URL,
+		PollInterval:  50 * time.Millisecond,
+	}
+	adapter, chStopped, err := newZendeskAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// The mock rejects the credentials on every poll; wait for several polls
+	// to prove the adapter keeps retrying rather than shipping or crashing.
+	require.Eventually(t, func() bool { return mock.authFailureCount() >= 3 },
+		5*time.Second, 20*time.Millisecond, "adapter should keep polling on 401")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter unexpectedly stopped on auth failure (pinned behavior: it keeps polling)")
+	default:
+	}
+	assert.Equal(t, 0, sink.count(), "nothing must ship when authentication fails")
+}

--- a/zendesk/mock_test.go
+++ b/zendesk/mock_test.go
@@ -73,15 +73,23 @@ type cursorState struct {
 
 // mockZendesk is an in-memory stand-in for the Zendesk Audit Logs API as the
 // adapter consumes it: GET /api/v2/audit_logs authenticated with
-// "<email>/token:<api_token>" basic auth, filtered by a two-valued
-// filter[created_at][] window (inclusive), paginated by page[size] with a
-// {audit_logs, meta{has_more}, links{next}} envelope.
+// "{email_address}/token:{api_token}" basic auth, filtered by a created_at
+// window, paginated by page[size] with a {audit_logs, meta{has_more,
+// after_cursor, before_cursor}, links{next, prev}} envelope.
 //
-// Fidelity note: the real API's links.next is a full URL carrying a
-// page[after] cursor. This adapter feeds links.next back verbatim as the
-// *first* filter[created_at][] value of the next request (see makeOneRequest),
-// so the mock returns an opaque token instead and recognizes it there --
-// matching how the adapter actually consumes pagination.
+// Fidelity notes vs the official docs
+// (https://developer.zendesk.com/api-reference/ticketing/account-configuration/audit_logs/):
+//   - The docs spell the range param "filter[created_at]", supplied twice
+//     ("first with the start time and again with an end time"); the adapter
+//     sends the Rails array spelling "filter[created_at][]", which the mock
+//     mirrors. The docs do not say whether the bounds are inclusive; the mock
+//     treats them as inclusive.
+//   - The real API's links.next is a full URL carrying a page[after] cursor
+//     (https://developer.zendesk.com/api-reference/introduction/pagination/).
+//     This adapter instead feeds links.next back verbatim as the *first*
+//     filter[created_at][] value of the next request (see makeOneRequest), so
+//     the mock returns an opaque token and recognizes it there -- matching how
+//     the adapter actually consumes pagination.
 type mockZendesk struct {
 	mu    sync.Mutex
 	email string
@@ -260,12 +268,14 @@ const (
 )
 
 // auditLogFixture returns a record shaped like a real Zendesk audit log entry
-// (the documented fields of GET /api/v2/audit_logs).
+// (the documented fields of GET /api/v2/audit_logs, per
+// https://developer.zendesk.com/api-reference/ticketing/account-configuration/audit_logs/).
 //
-// NOTE: the real API returns "id" (and actor_id/source_id) as JSON numbers.
-// The adapter dedupes on `item["id"].(string)`, so string ids are required for
-// it to function; the fixtures use string ids to match what the adapter can
-// actually consume (see the caveat in the test report / adapter review).
+// NOTE: the docs type "id" (like actor_id/source_id) as an integer, i.e. a
+// JSON number. The adapter dedupes on `item["id"].(string)`, so string ids are
+// required for it to function; the fixtures use string ids to match what the
+// adapter can actually consume (see the caveat in the test report / adapter
+// review). actor_id/source_id stay numeric as documented.
 func auditLogFixture(id string, createdAt time.Time, action string) utils.Dict {
 	return utils.Dict{
 		"id":                 id,


### PR DESCRIPTION
## What

Adds in-memory mocks of the vendor APIs and end-to-end test suites for 21 previously untested adapters, so they can be tested and evolved **without access to the real products**. All suites follow the established `threatlocker/`/`1password/` pattern: an `httptest` mock that reproduces the vendor API (auth validation, pagination mechanism, response envelope), realistic-but-clearly-fake fixtures, and a `captureSink` asserting exactly what ships.

**Adapters covered:** bitwarden, box, cato, cylance, defender, entraid, hubspot, itglue, mimecast, ms_graph, o365, okta, pandadoc, proofpoint_tap, slack, sophos, sublime, syslog (listener-based — tests act as the syslog sender, no mock needed), trendmicro, wiz, zendesk.

**Not covered (different approach needed, future work):** cloud-SDK adapters (azure_event_hub, bigquery, gcs, pubsub, s3, sqs, sqs-files), SDK/protocol adapters (duo, falconcloud, imap), and OS-specific ones (wel, mac_unified_logging, evtx).

## Documentation verification

Every mock and fixture went through a second review pass against the **official vendor documentation** — API references, OpenAPI specs (Box, Trend Micro, HubSpot, Bitwarden's embedded spec), vendor-published reference clients (Sophos' SIEM integration, Cato's eventsFeed script, Wiz's XSOAR integration, Okta's SDK), and in two cases live read-only probes of the real endpoint (Cato error envelope, Slack 401 body). Sources are cited in the test comments. Where a vendor leaves semantics undocumented (window-boundary inclusivity, opaque cursor formats), comments now say explicitly what is documented versus what the mock chose because the adapter's logic requires it.

## Production changes

Confined to three minimal seams per adapter; **defaults preserve existing behavior**:

1. **`uspSink` test seam** — the standard interface + unexported constructor so tests can capture shipped `DataMessage`s; the public constructor delegates with a `nil` sink and builds the real `uspclient.Client` exactly as before.
2. **URL overrides** — optional config fields for previously hardcoded API/token endpoints (empty = the existing production URL).
3. **`PollInterval` test seam** — where the poll wait was hardcoded, a non-config-settable field (`json:"-" yaml:"-"`) defaulting to the historical value.

Two adapters needed slightly more: **cato** (its poll goroutine had no working exit path — `Close()` on master calls `Done()` on a never-`Add()`ed WaitGroup and panics; the loop now honors the existing `isRunning` flag and balances the `wgSenders` accounting so tests can stop it; production is unaffected since nothing flips the flag there) and **o365** (custom endpoints may now be `http://` in addition to `https://`, needed to reach an `httptest` mock; named and https endpoints behave identically to before).

## Test coverage

Per adapter, as applicable to its semantics: all events ship with verbatim payloads (asserted via `JSONEq`, nested structures included); re-polling does not re-ship; an event appearing mid-run ships exactly once; multi-page/multi-batch datasets are fully consumed; bad credentials ship nothing. Tests **pin actual behavior** rather than idealizing it — e.g. most of these adapters stamp ingestion time (not the event's own timestamp), set no `EventType`, and keep retrying on auth failure rather than stopping.

`go build ./...` passes and the full repo test suite is green under `-race`.

## Real issues surfaced by the mocks (not fixed here — flagged for follow-up)

Writing faithful mocks exposed several likely production bugs. **Each of these was independently re-verified during the documentation review pass** (code line references in the test comments):

- **zendesk** (confirmed): Zendesk documents `id` as an integer, but the adapter dedupes on `item["id"].(string)` → the dedup key is always `""`, so after the first record everything in a window is silently dropped (`continue` on the dedup hit). Also confirmed: `links.next` (documented as a full URL) is fed back as the first `filter[created_at][]` value in an unescaped Sprintf — multi-page walks are broken against the real API.
- **hubspot** (confirmed against HubSpot's official OpenAPI spec): the `paging.next.after` cursor is sent back via the `occurredAfter` date-time param instead of the documented `after` cursor param — multi-page pagination is broken live.
- **itglue** (confirmed): the pagination cursor is read with `FindOneString("next")`, which only matches a top-level key, but the JSON:API envelope nests it at `links.next` — pagination is dead code; only page 1 is ever consumed. (Also: the docs cap /logs at 5 pages.)
- **cylance** (confirmed): within one poll, the page walker rebuilds each page URL from an advancing time filter that all three list APIs honor server-side — the result set shrinks while the walker indexes deeper, permanently losing records.
- **mimecast** (confirmed at spec level): the official spec documents `eventTime` as `yyyy-MM-dd'T'HH:mm:ssZ` with colonless offsets (`+0000`), which the adapter's `time.RFC3339` parse rejects (error discarded) → dedup entries get zero timestamps, are culled same-poll, and boundary events re-ship while inside the 30s overlap window.
- **slack** (confirmed): the API documents newest-first ordering; the adapter's watermark is the max `date_create` of the *last page processed*, so multi-page responses re-ship newer pages on subsequent polls (at-least-once, no loss). A dedicated test pins the exact re-ship pattern under documented ordering.
- **defender / ms_graph** (confirmed): the watermark logic assumes ascending `createdDateTime` ordering; Graph documents newest-first for alerts_v2 and offers no `$orderby` there. ms_graph additionally resets its boundary dedup id on any empty poll or error, re-shipping the boundary record.
- **pandadoc** (new, found in review): documented response timestamps are zone-less (`2024-07-15T18:59:38.000`) but the adapter parses `request_time` with `time.RFC3339Nano` and discards the error — if live responses match the docs, dedup timestamps become zero-time and overlap-window events can re-ship. (Also: `/public/v1/logs` is deprecated, sunset 2027-02-04; v2 is shape-identical.)
- **utils.StreamTokenizer** (new, found in review): an off-by-one (`i-1 > dataStart`) silently drops one-character lines that arrive within a single read — affects the syslog adapter; pinned by a dedicated test.

Tests pin current behavior so any fix shows up as a deliberate test change.

## Fidelity caveats

Mocks were built from the adapter code (source of truth for behavior) plus official vendor documentation (source of truth for shapes); none were validated against live *authenticated* APIs. Where the real API's exact semantics are undocumented, the mock implements the interpretation the adapter's logic requires, explicitly noted in comments with the doc citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)