### PR TITLE
fix(mac_unified_logging): supervise log stream, shed on stall, fix shutdown

### DIFF
--- a/mac_unified_logging/client.go
+++ b/mac_unified_logging/client.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -26,7 +27,8 @@ type MacUnifiedLoggingAdapter struct {
 	uspClient    *uspclient.Client
 	writeTimeout time.Duration
 
-	logs *Logs
+	logs      *Logs
+	isRunning uint32
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -36,8 +38,9 @@ type MacUnifiedLoggingAdapter struct {
 
 func NewMacUnifiedLoggingAdapter(ctx context.Context, conf MacUnifiedLoggingConfig) (*MacUnifiedLoggingAdapter, chan struct{}, error) {
 	a := &MacUnifiedLoggingAdapter{
-		conf: conf,
-		ctx:  ctx,
+		conf:      conf,
+		ctx:       ctx,
+		isRunning: 1,
 	}
 
 	if a.conf.WriteTimeoutSec == 0 {
@@ -84,16 +87,25 @@ func NewMacUnifiedLoggingAdapter(ctx context.Context, conf MacUnifiedLoggingConf
 func (a *MacUnifiedLoggingAdapter) Close() error {
 	a.conf.ClientOptions.DebugLog("closing")
 
-	// Stops the subprocess and supervisor; this closes logs.Channel,
-	// which winds down handleEvents.
+	// Stop shipping new events, then stop the gatherer (which kills the
+	// subprocess and closes logs.Channel so handleEvents drains and exits).
+	atomic.StoreUint32(&a.isRunning, 0)
 	a.logs.StopGathering()
+
+	// Flush already-queued events, then close the client. Close() also
+	// unblocks any Ship() that handleEvents is parked in on a full buffer
+	// (an uplink stall makes Ship(_, 0) block indefinitely), so the wait
+	// below cannot deadlock. Order matters: wgSenders.Wait() must come
+	// AFTER the client is closed.
+	err1 := a.uspClient.Drain(1 * time.Minute)
+	_, err2 := a.uspClient.Close()
+
 	a.wgSenders.Wait()
 
-	_, err := a.uspClient.Close()
-	if err != nil {
-		return err
+	if err1 != nil {
+		return err1
 	}
-	return nil
+	return err2
 }
 
 func (a *MacUnifiedLoggingAdapter) convertStructToMap(obj interface{}) map[string]interface{} {
@@ -117,6 +129,12 @@ func (a *MacUnifiedLoggingAdapter) handleEvents() {
 	// The channel is closed by StopGathering once the gatherer has fully
 	// wound down, so this loop is guaranteed to exit on shutdown.
 	for log := range a.logs.Channel {
+		// While closing, drain the channel without shipping: the uspClient
+		// is being drained and closed, so further Ship() calls would just
+		// error. This also lets the range complete promptly.
+		if atomic.LoadUint32(&a.isRunning) == 0 {
+			continue
+		}
 		msg := &protocol.DataMessage{
 			JsonPayload: a.convertStructToMap(log),
 			TimestampMs: uint64(time.Now().UnixNano() / int64(time.Millisecond)),

--- a/mac_unified_logging/client.go
+++ b/mac_unified_logging/client.go
@@ -23,11 +23,10 @@ const (
 
 type MacUnifiedLoggingAdapter struct {
 	conf         MacUnifiedLoggingConfig
-	wg           sync.WaitGroup
-	isRunning    uint32
-	mRunning     sync.RWMutex
 	uspClient    *uspclient.Client
 	writeTimeout time.Duration
+
+	logs *Logs
 
 	chStopped chan struct{}
 	wgSenders sync.WaitGroup
@@ -37,8 +36,8 @@ type MacUnifiedLoggingAdapter struct {
 
 func NewMacUnifiedLoggingAdapter(ctx context.Context, conf MacUnifiedLoggingConfig) (*MacUnifiedLoggingAdapter, chan struct{}, error) {
 	a := &MacUnifiedLoggingAdapter{
-		conf:      conf,
-		isRunning: 1,
+		conf: conf,
+		ctx:  ctx,
 	}
 
 	if a.conf.WriteTimeoutSec == 0 {
@@ -52,10 +51,27 @@ func NewMacUnifiedLoggingAdapter(ctx context.Context, conf MacUnifiedLoggingConf
 		return nil, nil, err
 	}
 
+	a.logs = NewLogs()
+	if err := a.logs.StartGathering(a.conf.Predicate, a.conf.ClientOptions.OnWarning); err != nil {
+		a.uspClient.Close()
+		return nil, nil, err
+	}
+
+	// Make sure the `log stream` subprocess does not outlive us if the
+	// process is signaled: stop gathering (which kills the subprocess)
+	// before exiting.
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-signalChannel
+		a.logs.StopGathering()
+		os.Exit(0)
+	}()
+
 	a.chStopped = make(chan struct{})
 
 	a.wgSenders.Add(1)
-	go a.handleEvent(a.conf.Predicate)
+	go a.handleEvents()
 
 	go func() {
 		a.wgSenders.Wait()
@@ -68,12 +84,10 @@ func NewMacUnifiedLoggingAdapter(ctx context.Context, conf MacUnifiedLoggingConf
 func (a *MacUnifiedLoggingAdapter) Close() error {
 	a.conf.ClientOptions.DebugLog("closing")
 
-	a.mRunning.Lock()
-	a.isRunning = 0
-	a.mRunning.Unlock()
-
-	a.wg.Done()
-	a.wg.Wait()
+	// Stops the subprocess and supervisor; this closes logs.Channel,
+	// which winds down handleEvents.
+	a.logs.StopGathering()
+	a.wgSenders.Wait()
 
 	_, err := a.uspClient.Close()
 	if err != nil {
@@ -97,23 +111,12 @@ func (a *MacUnifiedLoggingAdapter) convertStructToMap(obj interface{}) map[strin
 	return mapRepresentation
 }
 
-func (a *MacUnifiedLoggingAdapter) handleEvent(predicate string) uintptr {
+func (a *MacUnifiedLoggingAdapter) handleEvents() {
+	defer a.wgSenders.Done()
 
-	logs := NewLogs()
-
-	signalChannel := make(chan os.Signal)
-	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-signalChannel
-		logs.StopGathering()
-		os.Exit(0)
-	}()
-
-	if err := logs.StartGathering(predicate); err != nil {
-		panic(err)
-	}
-
-	for log := range logs.Channel {
+	// The channel is closed by StopGathering once the gatherer has fully
+	// wound down, so this loop is guaranteed to exit on shutdown.
+	for log := range a.logs.Channel {
 		msg := &protocol.DataMessage{
 			JsonPayload: a.convertStructToMap(log),
 			TimestampMs: uint64(time.Now().UnixNano() / int64(time.Millisecond)),
@@ -127,6 +130,4 @@ func (a *MacUnifiedLoggingAdapter) handleEvent(predicate string) uintptr {
 			a.conf.ClientOptions.OnError(fmt.Errorf("Ship(): %v", err))
 		}
 	}
-
-	return 0
 }

--- a/mac_unified_logging/log.go
+++ b/mac_unified_logging/log.go
@@ -52,14 +52,26 @@ const (
 	// data anyway and can leave the long-lived `log stream` process in a
 	// degraded state that persists until it is restarted.
 	logChannelBuffer = 4096
-	// restartBackoff is the delay between `log stream` subprocess
-	// restarts (subprocess exit, persistent decode failure, ...). Long
-	// enough to avoid a tight respawn loop if `log` is unrunnable, short
-	// enough to not lose meaningful coverage.
-	restartBackoff = 5 * time.Second
 	// dropReportInterval is how often a non-zero shed count is reported.
 	dropReportInterval = 60 * time.Second
 )
+
+// restartBackoff is the delay between `log stream` subprocess restarts
+// (subprocess exit, persistent decode failure, ...). Long enough to avoid a
+// tight respawn loop if `log` is unrunnable, short enough to not lose
+// meaningful coverage. A var (not const) so tests can shorten it.
+var restartBackoff = 5 * time.Second
+
+// streamCommand builds the `log stream` subprocess. It is a package var so
+// tests can substitute a fake stream without a real macOS `log` binary
+// (log.go is not build-constrained, only client.go/noop.go are).
+var streamCommand = func(predicate string) *exec.Cmd {
+	args := []string{"stream", "--color=none", "--style=ndjson"}
+	if predicate != "" {
+		args = append(args, "--predicate", predicate)
+	}
+	return exec.Command("log", args...)
+}
 
 type Logs struct {
 	// Channel delivers parsed log entries. It is closed when gathering
@@ -140,11 +152,7 @@ func (logs *Logs) StartGathering(predicate string, onWarning func(string)) error
 // runOnce runs a single `log stream` subprocess until it exits, its output
 // desyncs, or StopGathering is called.
 func (logs *Logs) runOnce() {
-	args := []string{"stream", "--color=none", "--style=ndjson"}
-	if logs.predicate != "" {
-		args = append(args, "--predicate", logs.predicate)
-	}
-	cmd := exec.Command("log", args...)
+	cmd := streamCommand(logs.predicate)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -210,6 +218,13 @@ func (logs *Logs) runOnce() {
 
 		entry := Log{}
 		if err := dec.Decode(&entry); err != nil {
+			// On a stop request the subprocess was killed on purpose, so
+			// the decode error is expected — exit quietly.
+			select {
+			case <-logs.chStop:
+				return
+			default:
+			}
 			// A json.Decoder does not resync after garbage and EOF means
 			// the subprocess is gone; either way this stream is done.
 			// Return and let the supervisor restart the subprocess.

--- a/mac_unified_logging/log.go
+++ b/mac_unified_logging/log.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os/exec"
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
 type Log struct {
@@ -40,79 +42,199 @@ type Log struct {
 	TimezoneName             string `json:"timezoneName"`
 }
 
+const (
+	// logChannelBuffer gives the consumer (Ship) slack before we start
+	// shedding. The buffer is the decoupling point between the local
+	// `log stream` subprocess and the network: if the consumer stalls
+	// longer than this absorbs, we DROP (and count) rather than stop
+	// draining stdout. Blocking the pipe instead would stall logd's
+	// writer for as long as the consumer is stuck, which both loses the
+	// data anyway and can leave the long-lived `log stream` process in a
+	// degraded state that persists until it is restarted.
+	logChannelBuffer = 4096
+	// restartBackoff is the delay between `log stream` subprocess
+	// restarts (subprocess exit, persistent decode failure, ...). Long
+	// enough to avoid a tight respawn loop if `log` is unrunnable, short
+	// enough to not lose meaningful coverage.
+	restartBackoff = 5 * time.Second
+	// dropReportInterval is how often a non-zero shed count is reported.
+	dropReportInterval = 60 * time.Second
+)
+
 type Logs struct {
-	m       sync.Mutex
+	// Channel delivers parsed log entries. It is closed when gathering
+	// stops for good (StopGathering), so consumers can range over it.
 	Channel chan Log
-	exit    chan bool
+
+	predicate string
+	onWarning func(string)
+
+	chStop   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+
+	dropped atomic.Uint64
 }
 
 func NewLogs() *Logs {
 	return &Logs{
-		Channel: make(chan Log),
-		exit:    make(chan bool),
+		Channel: make(chan Log, logChannelBuffer),
+		chStop:  make(chan struct{}),
 	}
 }
 
-func (logs *Logs) StartGathering(predicate string) error {
-
-	cmd := exec.Command("log", "stream", "--color=none", "--style=ndjson")
-	if predicate != "" {
-		cmd = exec.Command("log", "stream", "--color=none", "--style=ndjson", "--predicate", predicate)
+func (logs *Logs) warn(format string, args ...interface{}) {
+	if logs.onWarning != nil {
+		logs.onWarning(fmt.Sprintf(format, args...))
 	}
+}
 
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
+// StartGathering starts and supervises a `log stream` subprocess,
+// restarting it (with backoff) if it exits or its output desyncs, until
+// StopGathering is called. The returned error only reflects supervisor
+// startup; subprocess failures are reported through onWarning and retried.
+func (logs *Logs) StartGathering(predicate string, onWarning func(string)) error {
+	logs.predicate = predicate
+	logs.onWarning = onWarning
 
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
+	// Periodically report shed counts. Dropping is preferable to stalling
+	// the subprocess pipe, but it must never be silent.
+	logs.wg.Add(1)
 	go func() {
-		logs.m.Lock()
-		defer logs.m.Unlock()
-
-		cmd.Start()
-		defer cmd.Process.Kill()
-
-		// drop first message
-		bufio.NewReader(stdout).ReadLine()
-
-		dec := json.NewDecoder(stdout)
-
+		defer logs.wg.Done()
+		t := time.NewTicker(dropReportInterval)
+		defer t.Stop()
 		for {
 			select {
-			case <-logs.exit:
+			case <-logs.chStop:
+				if n := logs.dropped.Swap(0); n != 0 {
+					logs.warn("shed %d events while output was stalled", n)
+				}
 				return
-			default:
-				log := Log{}
-
-				if err := dec.Decode(&log); err != nil {
-					fmt.Println("error decoding json")
-					fmt.Println(err.Error())
-				} else {
-					logs.Channel <- log
+			case <-t.C:
+				if n := logs.dropped.Swap(0); n != 0 {
+					logs.warn("shed %d events while output was stalled", n)
 				}
 			}
 		}
 	}()
 
+	logs.wg.Add(1)
 	go func() {
-		stderrBuf := bufio.NewReader(stderr)
+		defer logs.wg.Done()
+		defer close(logs.Channel)
 		for {
-			line, _, _ := stderrBuf.ReadLine()
-			if len(line) > 0 {
-				logs.StopGathering()
-				panic(err)
+			logs.runOnce()
+			select {
+			case <-logs.chStop:
+				return
+			case <-time.After(restartBackoff):
 			}
+			logs.warn("restarting `log stream`")
 		}
 	}()
 
 	return nil
 }
 
+// runOnce runs a single `log stream` subprocess until it exits, its output
+// desyncs, or StopGathering is called.
+func (logs *Logs) runOnce() {
+	args := []string{"stream", "--color=none", "--style=ndjson"}
+	if logs.predicate != "" {
+		args = append(args, "--predicate", logs.predicate)
+	}
+	cmd := exec.Command("log", args...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		logs.warn("log stream stdout pipe: %v", err)
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		logs.warn("log stream stderr pipe: %v", err)
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		logs.warn("log stream start: %v", err)
+		return
+	}
+	// `log stream` writes informational notices to stderr (including
+	// drop/throttle warnings under pressure). Surface them; they are not
+	// fatal and must never tear down gathering.
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		s := bufio.NewScanner(stderr)
+		for s.Scan() {
+			if line := s.Text(); line != "" {
+				logs.warn("log stream stderr: %s", line)
+			}
+		}
+	}()
+
+	// Always reap the subprocess: kill on every exit path, wait for the
+	// stderr reader to drain to EOF (Wait must not race pipe reads), then
+	// Wait so the subprocess cannot linger as a zombie.
+	defer func() {
+		cmd.Process.Kill()
+		<-stderrDone
+		cmd.Wait()
+	}()
+
+	// A stop request must unblock the decoder even if it is parked reading
+	// a quiet stream: killing the subprocess closes stdout, which fails the
+	// pending Decode.
+	stopWatch := make(chan struct{})
+	defer close(stopWatch)
+	go func() {
+		select {
+		case <-logs.chStop:
+			cmd.Process.Kill()
+		case <-stopWatch:
+		}
+	}()
+
+	r := bufio.NewReader(stdout)
+	// Drop the first line: `log stream` prints a non-JSON header.
+	r.ReadLine()
+
+	dec := json.NewDecoder(r)
+	for {
+		select {
+		case <-logs.chStop:
+			return
+		default:
+		}
+
+		entry := Log{}
+		if err := dec.Decode(&entry); err != nil {
+			// A json.Decoder does not resync after garbage and EOF means
+			// the subprocess is gone; either way this stream is done.
+			// Return and let the supervisor restart the subprocess.
+			logs.warn("log stream decode failed, restarting subprocess: %v", err)
+			return
+		}
+
+		select {
+		case logs.Channel <- entry:
+		case <-logs.chStop:
+			return
+		default:
+			// Consumer stalled and the buffer is full: shed instead of
+			// blocking. Blocking here backs the stall up through the
+			// stdout pipe into logd (see logChannelBuffer).
+			logs.dropped.Add(1)
+		}
+	}
+}
+
+// StopGathering stops the supervisor and subprocess, closes Channel once
+// everything has wound down, and is safe to call more than once.
 func (logs *Logs) StopGathering() {
-	logs.exit <- true
+	logs.stopOnce.Do(func() {
+		close(logs.chStop)
+	})
+	logs.wg.Wait()
 }

--- a/mac_unified_logging/log_test.go
+++ b/mac_unified_logging/log_test.go
@@ -1,0 +1,164 @@
+package usp_mac_unified_logging
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeStream installs a streamCommand that runs `sh -c script` and restores
+// the original on cleanup. The script stands in for macOS `log stream`.
+func fakeStream(t *testing.T, script string) {
+	t.Helper()
+	orig := streamCommand
+	streamCommand = func(predicate string) *exec.Cmd {
+		return exec.Command("sh", "-c", script)
+	}
+	t.Cleanup(func() { streamCommand = orig })
+}
+
+func collectWarnings() (func(string), *[]string, *sync.Mutex) {
+	var mu sync.Mutex
+	var got []string
+	return func(s string) {
+		mu.Lock()
+		got = append(got, s)
+		mu.Unlock()
+	}, &got, &mu
+}
+
+func TestLogs_DropsHeaderAndDelivers(t *testing.T) {
+	// First line is the `log stream` header and must be discarded; the
+	// following ndjson objects must be delivered in order.
+	fakeStream(t, `printf 'Filtering the log data\n{"processID":11}\n{"processID":22}\n'; exec cat`)
+
+	logs := NewLogs()
+	if err := logs.StartGathering("", nil); err != nil {
+		t.Fatalf("StartGathering: %v", err)
+	}
+	defer logs.StopGathering()
+
+	for _, want := range []int{11, 22} {
+		select {
+		case got := <-logs.Channel:
+			if got.ProcessID != want {
+				t.Fatalf("ProcessID = %d, want %d", got.ProcessID, want)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for entry processID=%d", want)
+		}
+	}
+}
+
+func TestLogs_RestartsOnSubprocessExit(t *testing.T) {
+	restoreBackoff := restartBackoff
+	restartBackoff = 10 * time.Millisecond
+	t.Cleanup(func() { restartBackoff = restoreBackoff })
+
+	// Each subprocess invocation emits one event then exits, forcing the
+	// supervisor to restart it repeatedly. We must receive several events
+	// across multiple subprocess lifetimes.
+	fakeStream(t, `printf 'hdr\n{"processID":7}\n'`)
+
+	logs := NewLogs()
+	if err := logs.StartGathering("", nil); err != nil {
+		t.Fatalf("StartGathering: %v", err)
+	}
+	defer logs.StopGathering()
+
+	for i := 0; i < 3; i++ {
+		select {
+		case got := <-logs.Channel:
+			if got.ProcessID != 7 {
+				t.Fatalf("ProcessID = %d, want 7", got.ProcessID)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("did not get restart-produced event #%d", i+1)
+		}
+	}
+}
+
+func TestLogs_ShedsWhenConsumerStalls(t *testing.T) {
+	// Emit many events while nobody reads. With a tiny buffer the producer
+	// must shed (and count) rather than block the subprocess pipe.
+	var b strings.Builder
+	b.WriteString("hdr\n")
+	const emitted = 200
+	for i := 0; i < emitted; i++ {
+		b.WriteString(fmt.Sprintf(`{"processID":%d}`, i))
+		b.WriteByte('\n')
+	}
+	// printf the payload, then idle so the subprocess stays alive.
+	fakeStream(t, `printf `+shellQuote(b.String())+`; exec cat`)
+
+	warn, warnings, wmu := collectWarnings()
+	logs := NewLogs()
+	logs.Channel = make(chan Log, 2) // tiny buffer to force shedding
+	if err := logs.StartGathering("", warn); err != nil {
+		t.Fatalf("StartGathering: %v", err)
+	}
+
+	// Give the producer time to fill the buffer and shed the rest.
+	deadline := time.After(5 * time.Second)
+	for {
+		if logs.dropped.Load() > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected some events to be shed, dropped=0")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	// Shedding must never lose more than what was emitted, and the buffered
+	// events must still be readable (producer didn't deadlock).
+	if d := logs.dropped.Load(); d > emitted {
+		t.Fatalf("dropped=%d exceeds emitted=%d", d, emitted)
+	}
+	select {
+	case <-logs.Channel:
+	case <-time.After(2 * time.Second):
+		t.Fatal("buffered event not readable; producer may have blocked")
+	}
+
+	// StopGathering reports a non-zero shed count.
+	logs.StopGathering()
+	wmu.Lock()
+	defer wmu.Unlock()
+	foundShedReport := false
+	for _, w := range *warnings {
+		if strings.Contains(w, "shed") {
+			foundShedReport = true
+		}
+	}
+	if !foundShedReport {
+		t.Fatalf("expected a shed-count warning, got %v", *warnings)
+	}
+}
+
+func TestLogs_StopGatheringClosesChannelAndIsIdempotent(t *testing.T) {
+	fakeStream(t, `printf 'hdr\n'; exec cat`)
+
+	logs := NewLogs()
+	if err := logs.StartGathering("", nil); err != nil {
+		t.Fatalf("StartGathering: %v", err)
+	}
+
+	logs.StopGathering()
+	logs.StopGathering() // must not panic (double close guarded by stopOnce)
+
+	// Channel must be closed once gathering has fully stopped.
+	if _, ok := <-logs.Channel; ok {
+		t.Fatal("Channel should be closed and drained after StopGathering")
+	}
+}
+
+// shellQuote wraps s in single quotes for use in `sh -c`, escaping any
+// embedded single quotes. The test payloads contain none, but keep it safe.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}


### PR DESCRIPTION
## Problem

The macOS Unified Logging adapter cannot recover from any subprocess-level disruption without a full process restart, and a prolonged downstream stall (USP output blocked for an extended period — e.g. a long server-side disruption) can leave it permanently degraded at a fraction of its real event rate while looking perfectly healthy (process up, websocket connected, keepalives flowing).

Specific defects in the previous implementation:

1. **Backpressure propagated into `logd`.** The decoder fed an *unbuffered* channel; a stalled `Ship()` (which retries with an infinite timeout on `ErrorBufferFull`) froze the decoder, filled the 64KB stdout pipe, and blocked the `log stream` process itself for the duration of the stall. Besides guaranteed data loss, a long-lived `log stream` left in that state can remain degraded after the stall clears.
2. **No subprocess supervision.** `cmd.Start()` with no `Wait()`, exit detection, or restart — a dead or degraded `log stream` silently meant fewer/no events forever.
3. **Decode errors spun forever.** `json.Decoder` does not resync after garbage; the loop printed to stdout and retried the same error indefinitely.
4. **Broken stderr handling.** Any stderr line (where `log stream` writes informational notices, including under pressure) tore down gathering and called `panic()` on a captured `nil` error; the channel was never closed, so the sender goroutine blocked on `range` forever — connected and mute.
5. **Broken shutdown.** `Close()` called `Done()` on a never-`Add()`ed WaitGroup (panic), and the sender never released `wgSenders`, so the stopped-channel could never fire.

## Fix

- **Shed, don't stall:** buffered channel (4096) decouples the subprocess from the network; when the consumer stalls past the buffer, events are dropped and counted, with the shed count reported every minute. The `logd` pipe is always drained.
- **Supervision:** a supervisor loop restarts `log stream` (5s backoff) on subprocess exit or decoder desync, reaping it correctly (Kill → drain stderr to EOF → Wait, respecting the os/exec pipe rules).
- **stderr surfaced as warnings**, never fatal.
- **Deterministic shutdown:** `StopGathering` is idempotent, kills the subprocess to unblock a parked decoder, closes the channel so the sender exits, and `Close()` waits on the correct WaitGroup.

## Verification

- `GOOS=darwin go build ./mac_unified_logging/` and `GOOS=darwin go vet ./mac_unified_logging/` clean (linux noop build unchanged).
- No external callers of the package's internals (`NewLogs`/`StartGathering` are package-scoped usage only); the adapter's public constructor/Close signatures are unchanged.
- Draft: would appreciate a sanity pass on the shed-vs-block policy (live tail semantics) and a real-Mac smoke test of restart-on-`log stream`-death before merge, since CI cannot exercise darwin subprocess behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)