### PR TITLE
feat(threatlocker): parent-org scoping, per-feed toggles, non-fatal source errors

### DIFF
--- a/threatlocker/README.md
+++ b/threatlocker/README.md
@@ -53,6 +53,27 @@ Access** (e.g. `ThreatLocker Access (C)` → `instance: c`).
 > `TOKEN_REVOKED`, double-check the instance before assuming the token was
 > revoked.
 
+## Parent-organization tokens
+
+ThreatLocker scopes every query to the **currently managed organization** — the
+organization that minted the token (or the one named by the
+`managed_organization_id` header). By default the feeds ask only for *that*
+organization's own records (`showChildOrganizations` / `viewChildOrganizations`
+are `false`).
+
+This is correct for a token scoped to a single (leaf) organization. It is **not**
+what you want for a token scoped to a parent/master organization: a parent has no
+endpoints of its own, so with the child-org flags off you will see
+
+- no `approval_request` events (the parent has no pending approvals of its own),
+- `system_audit` events that are mostly the adapter's *own* API polling, and
+- an HTTP 500 from the `unified_audit` (`ActionLog`) endpoint.
+
+For a parent/master token, set **`include_child_organizations: true`**. The
+default feeds then flip their child-org flags on and return the parent's children
+(and grandchildren) too. Alternatively, set `managed_organization_id` to a
+specific child's GUID to scope every request down to that one child.
+
 ## Configuration
 
 | Key | Required | Description |
@@ -62,6 +83,7 @@ Access** (e.g. `ThreatLocker Access (C)` → `instance: c`).
 | `instance` | yes* | ThreatLocker instance identifier (e.g. `g`). *Required unless `base_url` is set. |
 | `base_url` | no | Full API root override, e.g. `https://portalapi.g.threatlocker.com/portalapi`. |
 | `managed_organization_id` | no | Scopes every request to that organization via the `managedOrganizationId` header. |
+| `include_child_organizations` | no | When `true`, the default feeds include child (and grandchild) organizations in their results. **Set this when the token is scoped to a parent/master organization** — see [Parent-organization tokens](#parent-organization-tokens). Default `false`. Only affects the default feeds; with custom `feeds`, set the flags in each feed's `parameters` yourself. |
 | `feeds` | no | List of feeds to poll. Defaults to the three feeds listed under [Out of the box](#out-of-the-box). |
 | `page_size` | no | Records per page. Default `100` (max `1000`). |
 | `poll_interval` | no | Wait between polls, as a Go duration in nanoseconds. Default `60000000000` (1 minute). |

--- a/threatlocker/README.md
+++ b/threatlocker/README.md
@@ -26,9 +26,11 @@ on every request; the adapter rewrites those fields automatically (see the
 `window` feed setting below). At-least-once delivery is preserved by the
 per-feed deduper.
 
-Override `feeds` in your config to add custom feeds (e.g. denied approval
-requests, child-organization-scoped queries) or to replace the defaults
-entirely.
+Each default feed can be turned off individually with `collect_approval_requests`
+/ `collect_unified_audit` / `collect_system_audit` (all default `true`) without
+having to re-declare the others. Override `feeds` in your config to add custom
+feeds (e.g. denied approval requests, child-organization-scoped queries) or to
+replace the defaults entirely.
 
 ## Authentication
 
@@ -84,7 +86,10 @@ specific child's GUID to scope every request down to that one child.
 | `base_url` | no | Full API root override, e.g. `https://portalapi.g.threatlocker.com/portalapi`. |
 | `managed_organization_id` | no | Scopes every request to that organization via the `managedOrganizationId` header. |
 | `include_child_organizations` | no | When `true`, the default feeds include child (and grandchild) organizations in their results. **Set this when the token is scoped to a parent/master organization** — see [Parent-organization tokens](#parent-organization-tokens). Default `false`. Only affects the default feeds; with custom `feeds`, set the flags in each feed's `parameters` yourself. |
-| `feeds` | no | List of feeds to poll. Defaults to the three feeds listed under [Out of the box](#out-of-the-box). |
+| `collect_approval_requests` | no | Whether to run the `approval_request` default feed. Default `true`. |
+| `collect_unified_audit` | no | Whether to run the `unified_audit` default feed. Default `true`. |
+| `collect_system_audit` | no | Whether to run the `system_audit` default feed. Default `true`. |
+| `feeds` | no | List of feeds to poll. Defaults to the three feeds listed under [Out of the box](#out-of-the-box). When set, it replaces the defaults entirely and the `collect_*` / `include_child_organizations` options no longer apply. |
 | `page_size` | no | Records per page. Default `100` (max `1000`). |
 | `poll_interval` | no | Wait between polls, as a Go duration in nanoseconds. Default `60000000000` (1 minute). |
 | `dedupe_ttl` | no | How long a record id is remembered to suppress re-shipping. Default 7 days. |

--- a/threatlocker/README.md
+++ b/threatlocker/README.md
@@ -117,7 +117,20 @@ the result set is exhausted (a short or empty page) or the feed's `max_pages`
 cap is reached. An in-memory deduper, keyed per feed, guarantees each record is
 shipped to LimaCharlie exactly once even though pages are re-fetched on every
 poll. Transient API failures (HTTP 5xx, 429, network errors) are retried with
-exponential backoff; an authentication failure (401/403) stops the adapter.
+exponential backoff.
+
+Errors coming back from the ThreatLocker API — including persistent 5xx, a
+malformed response, or an authentication failure (401/403) — are **logged as
+warnings and never stop the adapter**. The failing feed simply skips that poll
+and tries again on the next interval, while the other feeds keep running. This
+is deliberate: a problem on ThreatLocker's side cannot be fixed by restarting
+the collector, so the adapter does not treat it as fatal (which, in the hosted
+cloud-adapter environment, would tear the whole adapter down and eventually
+disable it). A token or endpoint that is fixed on the ThreatLocker side
+therefore recovers on its own, with no operator action. Only a failure
+*delivering* events to LimaCharlie is fatal, because there a restart re-establishes
+the connection. If a feed is known to be permanently broken for your tenant, turn
+it off with the matching `collect_*` option rather than leaving it to warn each poll.
 
 The adapter deliberately re-walks every page rather than stopping early at the
 first page of already-seen records: the API paginates by offset over a live,

--- a/threatlocker/client.go
+++ b/threatlocker/client.go
@@ -52,6 +52,12 @@ const (
 	// rolling-window dates into ThreatLocker request bodies. ThreatLocker's API
 	// accepts RFC 3339 with a Z suffix and millisecond precision.
 	windowTimestampLayout = "2006-01-02T15:04:05.000Z"
+
+	// Names of the three default feeds. Used both to build the default feed set
+	// and to select among it from the per-feed enable options.
+	feedApprovalRequest = "approval_request"
+	feedUnifiedAudit    = "unified_audit"
+	feedSystemAudit     = "system_audit"
 )
 
 // itemsArrayKeys are the keys the adapter probes, in order, to locate the list
@@ -161,6 +167,16 @@ type ThreatLockerConfig struct {
 	// `parameters` yourself.
 	IncludeChildOrganizations bool `json:"include_child_organizations" yaml:"include_child_organizations"`
 
+	// CollectApprovalRequests / CollectUnifiedAudit / CollectSystemAudit select
+	// which of the three default feeds run. A nil (absent) value means enabled,
+	// so the zero-config default collects all three. Set one to false to drop
+	// that feed. These are ignored when a custom `feeds` list is supplied (in
+	// that case the list itself is authoritative). At least one default feed
+	// must remain enabled.
+	CollectApprovalRequests *bool `json:"collect_approval_requests" yaml:"collect_approval_requests"`
+	CollectUnifiedAudit     *bool `json:"collect_unified_audit" yaml:"collect_unified_audit"`
+	CollectSystemAudit      *bool `json:"collect_system_audit" yaml:"collect_system_audit"`
+
 	// Feeds is the set of ThreatLocker endpoints to poll. When empty, the
 	// adapter defaults to a single feed of pending Application Control
 	// approval requests.
@@ -217,7 +233,7 @@ type ThreatLockerConfig struct {
 func defaultFeeds(includeChildOrgs bool) []ThreatLockerFeed {
 	return []ThreatLockerFeed{
 		{
-			Name: "approval_request",
+			Name: feedApprovalRequest,
 			URL:  "ApprovalRequest/ApprovalRequestGetByParameters",
 			Parameters: utils.Dict{
 				// statusId 1 == pending (awaiting an approve/deny decision).
@@ -230,7 +246,7 @@ func defaultFeeds(includeChildOrgs bool) []ThreatLockerFeed {
 			IDField:        "approvalRequestId",
 		},
 		{
-			Name: "unified_audit",
+			Name: feedUnifiedAudit,
 			URL:  "ActionLog/ActionLogGetByParametersV2",
 			// These body fields are documented as optional in the OpenAPI
 			// spec but ThreatLocker's own Postman example sends every one --
@@ -251,7 +267,7 @@ func defaultFeeds(includeChildOrgs bool) []ThreatLockerFeed {
 			Window:         defaultWindow,
 		},
 		{
-			Name: "system_audit",
+			Name: feedSystemAudit,
 			URL:  "SystemAudit/SystemAuditGetByParameters",
 			Parameters: utils.Dict{
 				"viewChildOrganizations": includeChildOrgs,
@@ -261,6 +277,23 @@ func defaultFeeds(includeChildOrgs bool) []ThreatLockerFeed {
 			IDField:        "systemAuditId",
 			Window:         defaultWindow,
 		},
+	}
+}
+
+// feedEnabled reports whether a named default feed should run, given the
+// per-feed Collect* toggles. A nil toggle (absent from config) means enabled,
+// so the zero-config default runs every feed. An unrecognized name is enabled.
+func (c *ThreatLockerConfig) feedEnabled(name string) bool {
+	on := func(b *bool) bool { return b == nil || *b }
+	switch name {
+	case feedApprovalRequest:
+		return on(c.CollectApprovalRequests)
+	case feedUnifiedAudit:
+		return on(c.CollectUnifiedAudit)
+	case feedSystemAudit:
+		return on(c.CollectSystemAudit)
+	default:
+		return true
 	}
 }
 
@@ -301,7 +334,17 @@ func (c *ThreatLockerConfig) Validate() error {
 	}
 
 	if len(c.Feeds) == 0 {
-		c.Feeds = defaultFeeds(c.IncludeChildOrganizations)
+		feeds := make([]ThreatLockerFeed, 0, 3)
+		for _, f := range defaultFeeds(c.IncludeChildOrganizations) {
+			if !c.feedEnabled(f.Name) {
+				continue
+			}
+			feeds = append(feeds, f)
+		}
+		if len(feeds) == 0 {
+			return errors.New("all default feeds are disabled; enable at least one (collect_*) or supply custom feeds")
+		}
+		c.Feeds = feeds
 	}
 	seenNames := make(map[string]struct{}, len(c.Feeds))
 	for i := range c.Feeds {

--- a/threatlocker/client.go
+++ b/threatlocker/client.go
@@ -575,7 +575,18 @@ func (a *ThreatLockerAdapter) pollFeed(feed ThreatLockerFeed) {
 
 // fetchPage requests one page of a feed, retrying transient failures with
 // exponential backoff. The bool result is false when the poll should be
-// abandoned (a permanent error, or the adapter is stopping).
+// abandoned (any source-side error, or the adapter is stopping).
+//
+// Source-side errors (anything that comes back from the ThreatLocker API:
+// 4xx/5xx, auth failures, network blips, malformed responses) are reported via
+// OnWarning and NEVER stop the adapter. This is deliberate: the cloud-sensor
+// host treats any adapter OnError as fatal to the instance -- it tears the
+// adapter down and relaunches it, and after enough failures disables it
+// entirely. Restarting cannot fix a problem on ThreatLocker's side, and it
+// would take the adapter's healthy feeds down along with the broken one. So we
+// log, skip just this poll, and let the feed try again next interval; a
+// recovered token or endpoint then heals on its own. Only a failure delivering
+// to LimaCharlie (see ship) is fatal, since a relaunch reconnects the backend.
 func (a *ThreatLockerAdapter) fetchPage(feed ThreatLockerFeed, pageNumber int) ([]utils.Dict, bool) {
 	body := a.buildRequestBody(feed, pageNumber)
 
@@ -592,11 +603,11 @@ func (a *ThreatLockerAdapter) fetchPage(feed ThreatLockerFeed, pageNumber int) (
 		}
 
 		if !isTransientError(err) {
-			a.conf.ClientOptions.OnError(fmt.Errorf("threatlocker: feed %q request failed: %v", feed.Name, err))
-			// An authentication/authorization failure affects every feed, so
-			// stop the whole adapter rather than spin uselessly. Other
-			// permanent errors (e.g. a misconfigured feed URL) are isolated to
-			// this feed: abandon the poll but keep the adapter alive.
+			// A permanent source-side error (bad request, auth failure, a
+			// misconfigured feed URL, ...). Reported as a warning, not a fatal
+			// OnError -- see the function doc for why we never stop on a
+			// source-side problem.
+			msg := fmt.Sprintf("threatlocker: feed %q request failed (skipping this poll): %v", feed.Name, err)
 			var httpErr *HTTPError
 			if errors.As(err, &httpErr) &&
 				(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
@@ -606,13 +617,13 @@ func (a *ThreatLockerAdapter) fetchPage(feed ThreatLockerFeed, pageNumber int) (
 				// not chase a token rotation when the real fix is to flip
 				// `instance` to the letter their portal shows next to
 				// "ThreatLocker Access" under the Help menu.
-				a.conf.ClientOptions.OnError(fmt.Errorf(
-					"threatlocker: HTTP %d -- token rejected. If the token is known to be active, "+
-						"verify `instance` matches the letter shown in the ThreatLocker Portal "+
-						"(Help > 'ThreatLocker Access (X)'); a token from a different instance "+
-						"is reported as TOKEN_REVOKED.", httpErr.StatusCode))
-				a.doStop.Set()
+				msg = fmt.Sprintf(
+					"threatlocker: feed %q -- HTTP %d, token rejected. If the token is known to be "+
+						"active, verify `instance` matches the letter shown in the ThreatLocker Portal "+
+						"(Help > 'ThreatLocker Access (X)'); a token from a different instance is "+
+						"reported as TOKEN_REVOKED.", feed.Name, httpErr.StatusCode)
 			}
+			a.conf.ClientOptions.OnWarning(msg)
 			return nil, false
 		}
 
@@ -631,14 +642,19 @@ func (a *ThreatLockerAdapter) fetchPage(feed ThreatLockerFeed, pageNumber int) (
 		}
 	}
 	if err != nil {
-		a.conf.ClientOptions.OnError(fmt.Errorf(
-			"threatlocker: feed %q failed after %d attempts: %v", feed.Name, a.conf.MaxRetryAttempts, err))
+		// Transient failures persisted across every retry. Log and skip this
+		// poll (a warning, not a fatal OnError -- see the function doc); the
+		// next interval tries again.
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"threatlocker: feed %q failed after %d attempts (skipping this poll): %v",
+			feed.Name, a.conf.MaxRetryAttempts, err))
 		return nil, false
 	}
 
 	items, err := extractItems(raw, feed.ItemsPath)
 	if err != nil {
-		a.conf.ClientOptions.OnError(fmt.Errorf("threatlocker: feed %q response parse error: %v", feed.Name, err))
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"threatlocker: feed %q response parse error (skipping this poll): %v", feed.Name, err))
 		return nil, false
 	}
 	return items, true

--- a/threatlocker/client.go
+++ b/threatlocker/client.go
@@ -148,6 +148,19 @@ type ThreatLockerConfig struct {
 	// organizations querying a specific child).
 	ManagedOrganizationID string `json:"managed_organization_id" yaml:"managed_organization_id"`
 
+	// IncludeChildOrganizations, when true, makes the default feeds include
+	// child (and grandchild) organizations in their results by flipping on the
+	// per-endpoint child-org flags (showChildOrganizations / viewChildOrganizations).
+	//
+	// Set this when the API token is scoped to a parent/master organization and
+	// you want to collect the children's data: a parent has no endpoints of its
+	// own, so with this off the approval-request feed is empty, the system-audit
+	// feed carries only the adapter's own API activity, and the unified-audit
+	// (ActionLog) feed can fail with HTTP 500. This only affects the default
+	// feeds; when you supply your own `feeds`, set the flags in each feed's
+	// `parameters` yourself.
+	IncludeChildOrganizations bool `json:"include_child_organizations" yaml:"include_child_organizations"`
+
 	// Feeds is the set of ThreatLocker endpoints to poll. When empty, the
 	// adapter defaults to a single feed of pending Application Control
 	// approval requests.
@@ -190,7 +203,18 @@ type ThreatLockerConfig struct {
 // the adapter's Window mechanism rewrites startDate/endDate on each poll, and
 // the deduper suppresses re-shipping records that fall into successive
 // overlapping windows.
-func defaultFeeds() []ThreatLockerFeed {
+//
+// includeChildOrgs controls organization scope. ThreatLocker queries are scoped
+// to the "currently managed organization" -- the org that minted the token (or
+// the one named by the managedOrganizationId header). When false, each feed
+// returns only that org's own records. When true, the child-organization flags
+// are flipped on, so a parent/master org sees its children's records too.
+//
+// This matters for parent-org tokens: a parent has no endpoints of its own, so
+// with the flags off `approval_request` returns nothing, `system_audit` returns
+// only the adapter's own API activity, and `ActionLog` can fail outright (HTTP
+// 500). Flipping the flags on is what makes a parent-org token usable.
+func defaultFeeds(includeChildOrgs bool) []ThreatLockerFeed {
 	return []ThreatLockerFeed{
 		{
 			Name: "approval_request",
@@ -198,7 +222,7 @@ func defaultFeeds() []ThreatLockerFeed {
 			Parameters: utils.Dict{
 				// statusId 1 == pending (awaiting an approve/deny decision).
 				"statusId":               1,
-				"showChildOrganizations": false,
+				"showChildOrganizations": includeChildOrgs,
 				"showCurrentTierOnly":    false,
 			},
 			OrderBy:        defaultOrderBy,
@@ -217,7 +241,7 @@ func defaultFeeds() []ThreatLockerFeed {
 				"groupBys":               []any{},
 				"exportMode":             false,
 				"showTotalCount":         false,
-				"showChildOrganizations": false,
+				"showChildOrganizations": includeChildOrgs,
 				"onlyTrueDenies":         false,
 				"simulateDeny":           false,
 			},
@@ -230,7 +254,7 @@ func defaultFeeds() []ThreatLockerFeed {
 			Name: "system_audit",
 			URL:  "SystemAudit/SystemAuditGetByParameters",
 			Parameters: utils.Dict{
-				"viewChildOrganizations": false,
+				"viewChildOrganizations": includeChildOrgs,
 			},
 			OrderBy:        defaultOrderBy,
 			TimestampField: defaultTimestampField,
@@ -277,7 +301,7 @@ func (c *ThreatLockerConfig) Validate() error {
 	}
 
 	if len(c.Feeds) == 0 {
-		c.Feeds = defaultFeeds()
+		c.Feeds = defaultFeeds(c.IncludeChildOrganizations)
 	}
 	seenNames := make(map[string]struct{}, len(c.Feeds))
 	for i := range c.Feeds {

--- a/threatlocker/client_test.go
+++ b/threatlocker/client_test.go
@@ -366,6 +366,32 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
+	t.Run("include_child_organizations toggles the child-org flags in the default feeds", func(t *testing.T) {
+		// Off (the default): every child-org flag is false.
+		off := ThreatLockerConfig{ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g"}
+		require.NoError(t, off.Validate())
+		for _, f := range off.Feeds {
+			switch f.Name {
+			case "approval_request", "unified_audit":
+				assert.Equal(t, false, f.Parameters["showChildOrganizations"], "feed %q", f.Name)
+			case "system_audit":
+				assert.Equal(t, false, f.Parameters["viewChildOrganizations"], "feed %q", f.Name)
+			}
+		}
+
+		// On: the flags flip to true so a parent-org token sees its children.
+		on := ThreatLockerConfig{ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g", IncludeChildOrganizations: true}
+		require.NoError(t, on.Validate())
+		for _, f := range on.Feeds {
+			switch f.Name {
+			case "approval_request", "unified_audit":
+				assert.Equal(t, true, f.Parameters["showChildOrganizations"], "feed %q", f.Name)
+			case "system_audit":
+				assert.Equal(t, true, f.Parameters["viewChildOrganizations"], "feed %q", f.Name)
+			}
+		}
+	})
+
 	t.Run("rejects feed without url", func(t *testing.T) {
 		c := ThreatLockerConfig{
 			ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g",

--- a/threatlocker/client_test.go
+++ b/threatlocker/client_test.go
@@ -392,6 +392,47 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
+	t.Run("collect_* toggles select which default feeds run", func(t *testing.T) {
+		feedNames := func(c ThreatLockerConfig) []string {
+			require.NoError(t, c.Validate())
+			names := make([]string, 0, len(c.Feeds))
+			for _, f := range c.Feeds {
+				names = append(names, f.Name)
+			}
+			return names
+		}
+		falsePtr := false
+
+		// Dropping one feed leaves the other two.
+		got := feedNames(ThreatLockerConfig{
+			ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g",
+			CollectSystemAudit: &falsePtr,
+		})
+		assert.ElementsMatch(t, []string{"approval_request", "unified_audit"}, got)
+
+		// Dropping two leaves exactly one.
+		got = feedNames(ThreatLockerConfig{
+			ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g",
+			CollectUnifiedAudit: &falsePtr, CollectSystemAudit: &falsePtr,
+		})
+		assert.ElementsMatch(t, []string{"approval_request"}, got)
+
+		// Disabling all default feeds is an error.
+		all := ThreatLockerConfig{
+			ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g",
+			CollectApprovalRequests: &falsePtr, CollectUnifiedAudit: &falsePtr, CollectSystemAudit: &falsePtr,
+		}
+		assert.Error(t, all.Validate())
+
+		// The toggles do not apply when a custom feeds list is supplied.
+		custom := ThreatLockerConfig{
+			ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g",
+			CollectApprovalRequests: &falsePtr, CollectUnifiedAudit: &falsePtr, CollectSystemAudit: &falsePtr,
+			Feeds: []ThreatLockerFeed{{Name: "custom", URL: "X/XGetByParameters"}},
+		}
+		assert.Equal(t, []string{"custom"}, feedNames(custom))
+	})
+
 	t.Run("rejects feed without url", func(t *testing.T) {
 		c := ThreatLockerConfig{
 			ClientOptions: testClientOptions(t), APIKey: "k", Instance: "g",

--- a/threatlocker/client_test.go
+++ b/threatlocker/client_test.go
@@ -751,9 +751,14 @@ func TestTransientErrorRetry(t *testing.T) {
 	assert.False(t, adapter.doStop.IsSet())
 }
 
-// TestPermanentAuthErrorStops verifies a 401/403 stops the whole adapter.
-func TestPermanentAuthErrorStops(t *testing.T) {
-	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+// TestPermanentSourceErrorDoesNotStop verifies that a permanent source-side
+// error (401/403/500 from ThreatLocker) is reported as a warning and does NOT
+// stop the adapter. The cloud-sensor host treats any fatal OnError as a reason
+// to tear down, relaunch and eventually disable the whole adapter, so a problem
+// on ThreatLocker's side (which a restart cannot fix) must stay non-fatal and
+// let the feed retry on the next poll.
+func TestPermanentSourceErrorDoesNotStop(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusInternalServerError} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(status)
@@ -764,24 +769,38 @@ func TestPermanentAuthErrorStops(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
+			var warnings, fatalErrors atomic.Int32
+			opts := testClientOptions(t)
+			opts.OnWarning = func(msg string) { warnings.Add(1); t.Logf("WRN: %s", msg) }
+			opts.OnError = func(err error) { fatalErrors.Add(1); t.Logf("ERR: %v", err) }
+
 			conf := ThreatLockerConfig{
-				ClientOptions: testClientOptions(t),
-				APIKey:        "bad-key",
-				BaseURL:       server.URL,
-				PollInterval:  100 * time.Millisecond,
-				Feeds:         approvalRequestFeed(),
+				ClientOptions:  opts,
+				APIKey:         "bad-key",
+				BaseURL:        server.URL,
+				PollInterval:   100 * time.Millisecond,
+				RetryBaseDelay: 10 * time.Millisecond,
+				MaxRetryDelay:  20 * time.Millisecond,
+				Feeds:          approvalRequestFeed(),
 			}
 			adapter, chStopped, err := NewThreatLockerAdapter(ctx, conf)
 			require.NoError(t, err)
 			defer adapter.Close()
 
+			// The feed should warn about the failure...
+			require.Eventually(t, func() bool { return warnings.Load() > 0 },
+				3*time.Second, 20*time.Millisecond, "expected a warning for the source error")
+
+			// ...but the adapter must keep running and never escalate to a fatal
+			// OnError or stop itself.
 			select {
 			case <-chStopped:
-				// Expected: an auth failure terminates the adapter.
-			case <-time.After(3 * time.Second):
-				t.Fatalf("adapter should have stopped on HTTP %d", status)
+				t.Fatalf("adapter stopped on HTTP %d - source errors must be non-fatal", status)
+			case <-time.After(300 * time.Millisecond):
 			}
-			assert.True(t, adapter.doStop.IsSet())
+			assert.False(t, adapter.doStop.IsSet(), "doStop must not be set on a source error")
+			assert.Equal(t, int32(0), fatalErrors.Load(),
+				"source errors must be warnings, not fatal OnError")
 		})
 	}
 }

--- a/threatlocker/mock_test.go
+++ b/threatlocker/mock_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -482,8 +483,13 @@ func TestMockRejectsBadToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	var warnings, fatalErrors atomic.Int32
+	opts := testClientOptions(t)
+	opts.OnWarning = func(msg string) { warnings.Add(1); t.Logf("WRN: %s", msg) }
+	opts.OnError = func(err error) { fatalErrors.Add(1); t.Logf("ERR: %v", err) }
+
 	conf := ThreatLockerConfig{
-		ClientOptions: testClientOptions(t),
+		ClientOptions: opts,
 		APIKey:        "wrong-token",
 		BaseURL:       server.URL,
 		PollInterval:  50 * time.Millisecond,
@@ -492,12 +498,21 @@ func TestMockRejectsBadToken(t *testing.T) {
 	require.NoError(t, err)
 	defer adapter.Close()
 
+	// A rejected token is a source-side problem: the adapter warns and keeps
+	// running (retrying each poll) rather than stopping. Stopping would make the
+	// cloud-sensor host tear it down, relaunch and eventually disable it -- a
+	// restart cannot fix a bad token, and an operator fixing the token should
+	// see the adapter recover on its own.
+	require.Eventually(t, func() bool { return warnings.Load() > 0 },
+		3*time.Second, 20*time.Millisecond, "expected a warning when the token is rejected")
+
 	select {
 	case <-chStopped:
-		// Expected: a rejected token stops the adapter.
-	case <-time.After(3 * time.Second):
-		t.Fatal("adapter should stop when the API rejects the token")
+		t.Fatal("adapter must not stop when the API rejects the token")
+	case <-time.After(300 * time.Millisecond):
 	}
+	assert.False(t, adapter.doStop.IsSet(), "doStop must not be set on a rejected token")
+	assert.Equal(t, int32(0), fatalErrors.Load(), "a rejected token must warn, not fatally error")
 	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
 	assert.GreaterOrEqual(t, mock.requestCount(), 1, "the adapter should have called the API")
 }


### PR DESCRIPTION
Three related ThreatLocker adapter improvements that came out of debugging a tenant where the Unified Audit feed fails.

## 1. Child-organization scoping (`include_child_organizations`)

ThreatLocker scopes every query to the **currently managed organization**. The default feeds ask only for that org's own records (`showChildOrganizations`/`viewChildOrganizations: false`). That's correct for a leaf-org token but wrong for a parent/master-org token (no endpoints of its own → empty approvals, self-referential system audit). The new option (default `false`) flips the per-endpoint child-org flags on so a parent token collects its children's records. Per ThreatLocker docs, `false` = "only the currently managed organization"; `true` = that org "AND any child and grandchild organizations".

## 2. Per-feed toggles (`collect_approval_requests` / `collect_unified_audit` / `collect_system_audit`)

Each default feed can now be turned off individually (all default `true`); disabling all is a config error. Ignored when a custom `feeds` list is supplied.

## 3. Source-side API errors are non-fatal

**Why:** in the hosted cloud-adapter environment (`legion_cloud_sensor_host`), *any* adapter `OnError` is fatal to the instance — the host tears it down, relaunches it, and after enough failures **disables it entirely**. Previously a persistent ThreatLocker-side error (e.g. an `ActionLogGetByParametersV2` that 500s server-side for a tenant, regardless of request shape) escalated via `OnError` every poll, churning the whole adapter and taking its *healthy* feeds down with it; a 401/403 stopped it outright.

**Change:** errors returned from the ThreatLocker API (persistent 5xx, malformed responses, 401/403) are now logged via `OnWarning` and never stop the adapter. The failing feed skips that poll and retries next interval while the other feeds keep running; a token/endpoint fixed on the ThreatLocker side recovers on its own. Only a failure *delivering* events to LimaCharlie stays fatal, since there a relaunch re-establishes the backend connection. A feed known to be permanently broken can be turned off with its `collect_*` option.

## Tests / docs

- `TestValidate` extended for the child-org flag and the `collect_*` selection (incl. all-disabled error and custom-feeds override).
- `TestPermanentAuthErrorStops` → `TestPermanentSourceErrorDoesNotStop`: asserts the adapter keeps running and warns (no fatal `OnError`, `doStop` unset) for 401/403/500. Mock bad-token test updated to match.
- README updated: new "Parent-organization tokens" section, the new config keys, and the non-fatal error-handling behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)