### PR TITLE
Add Netskope adapter (REST API v2 dataexport iterator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ be added purely through configuration. See [threatlocker/README.md](./threatlock
 ./general threatlocker client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=threatlocker api_key=$THREATLOCKER_API_TOKEN instance=g
 ```
 
+### Netskope
+
+Pulls security telemetry from the Netskope REST API v2 dataexport iterator. By
+default it collects every alert stream (DLP, malware, CTEP, UEBA, compromised
+credentials, ...) plus the admin audit log; additional event streams (page,
+application, network, ...) can be added purely through configuration. Each stream
+uses a server-side iterator cursor, so a restart resumes without gaps. See
+[netskope/README.md](./netskope/README.md).
+
+```
+./general netskope client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=netskope token=$NETSKOPE_API_TOKEN tenant=acme.goskope.com
+```
+
 ### Gmail
 
 Collects incoming email as telemetry from one or many Gmail mailboxes via the

--- a/containers/conf/all.go
+++ b/containers/conf/all.go
@@ -25,6 +25,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/mac_unified_logging"
 	"github.com/refractionPOINT/usp-adapters/mimecast"
 	"github.com/refractionPOINT/usp-adapters/ms_graph"
+	"github.com/refractionPOINT/usp-adapters/netskope"
 	"github.com/refractionPOINT/usp-adapters/o365"
 	"github.com/refractionPOINT/usp-adapters/okta"
 	"github.com/refractionPOINT/usp-adapters/pandadoc"
@@ -85,6 +86,7 @@ type GeneralConfigs struct {
 	Harmony           usp_harmony.HarmonyConfig                       `json:"harmony" yaml:"harmony"`
 	Mimecast          usp_mimecast.MimecastConfig                     `json:"mimecast" yaml:"mimecast"`
 	MsGraph           usp_ms_graph.MsGraphConfig                      `json:"ms_graph" yaml:"ms_graph"`
+	Netskope          usp_netskope.NetskopeConfig                     `json:"netskope" yaml:"netskope"`
 	Zendesk           usp_zendesk.ZendeskConfig                       `json:"zendesk" yaml:"zendesk"`
 	PandaDoc          usp_pandadoc.PandaDocConfig                     `json:"pandadoc" yaml:"pandadoc"`
 	ProofpointTap     usp_proofpoint_tap.ProofpointTapConfig          `json:"proofpoint_tap" yaml:"proofpoint_tap"`

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -39,6 +39,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/mac_unified_logging"
 	"github.com/refractionPOINT/usp-adapters/mimecast"
 	"github.com/refractionPOINT/usp-adapters/ms_graph"
+	"github.com/refractionPOINT/usp-adapters/netskope"
 	"github.com/refractionPOINT/usp-adapters/o365"
 	"github.com/refractionPOINT/usp-adapters/okta"
 	"github.com/refractionPOINT/usp-adapters/pandadoc"
@@ -510,6 +511,11 @@ func runAdapter(ctx context.Context, method string, configs Configuration, showC
 		configs.ThreatLocker.ClientOptions.Architecture = "usp_adapter"
 		configToShow = configs.ThreatLocker
 		client, chRunning, err = usp_threatlocker.NewThreatLockerAdapter(ctx, configs.ThreatLocker)
+	} else if method == "netskope" {
+		configs.Netskope.ClientOptions = applyLogging(configs.Netskope.ClientOptions)
+		configs.Netskope.ClientOptions.Architecture = "usp_adapter"
+		configToShow = configs.Netskope
+		client, chRunning, err = usp_netskope.NewNetskopeAdapter(ctx, configs.Netskope)
 	} else {
 		return nil, nil, errors.New(logError("unknown adapter_type: %s", method))
 	}

--- a/netskope/README.md
+++ b/netskope/README.md
@@ -1,0 +1,190 @@
+# Netskope Adapter
+
+Pulls security telemetry from the [Netskope](https://www.netskope.com/) REST API
+v2 **dataexport iterator** into LimaCharlie. Events are forwarded in their
+original Netskope JSON form — the adapter does not reshape payloads.
+
+Netskope exposes its telemetry as a set of iterator streams, one per **event
+type** and one per **alert type**. Each stream is consumed by polling
+
+```
+GET /api/v2/events/dataexport/{events|alerts}/{type}?index=<cursor>&operation=next
+```
+
+The adapter models each stream as a **feed**, so adding a new stream is purely a
+configuration change — no code change required.
+
+Docs: [REST API v2 dataexport iterator](https://docs.netskope.com/en/using-the-rest-api-v2-dataexport-iterator-endpoints/),
+[REST API v2 overview](https://docs.netskope.com/en/rest-api-v2-overview-312207/),
+[API tokens](https://docs.netskope.com/en/api-tokens-2/).
+
+## How the iterator works
+
+The `index` query parameter is a **consumer-chosen cursor name**. Netskope stores
+the read position for that name **server-side**, so the adapter keeps no state of
+its own: a restart simply resumes the same `index` with `operation=next` — no
+gaps, no re-reads. Each call returns up to **10,000 records** plus a `wait_time`
+(seconds) telling the consumer how long to wait before the next call; the adapter
+honours it (and the documented **4 requests/second/endpoint** rate limit).
+
+> Each stream needs its own unique `index`. The adapter derives one per feed as
+> `<index_prefix>_<event|alert>_<type>` (e.g. `netskope_alert_dlp`).
+> **Never point two collectors at the same `index`** — concurrent consumers of one
+> index corrupt each other's position.
+
+## Out of the box
+
+With no `feeds` configured, the adapter collects every **alert** stream plus the
+**audit** event stream:
+
+| Default feeds | Streams |
+|---|---|
+| Alerts (`alert_<type>`) | `dlp`, `malware`, `malsite`, `ctep`, `compromisedcredential`, `uba`, `policy`, `quarantine`, `remediation`, `securityassessment`, `watchlist` |
+| Events (`event_<type>`) | `audit` |
+
+Alerts are the high-signal, lower-volume detections a SOC cares about most. The
+`page` / `application` / `network` event streams are **very high volume** and are
+left opt-in — add them with `event_types` or a custom `feeds` entry.
+
+Select a subset with `alert_types` / `event_types`, or replace the set entirely
+with `feeds`. An explicit empty list (`alert_types: []`) disables that whole kind.
+
+## Authentication
+
+Create a REST API v2 token under **Settings → Tools → REST API v2 → New Token**
+in your Netskope tenant, and grant it the **Read** scope for every
+`/api/v2/events/dataexport/...` endpoint the adapter will poll. The token is sent
+in the `Netskope-Api-Token` header.
+
+The API root is `https://<tenant>/api/v2`, where `<tenant>` is your tenant host
+(commonly `<name>.goskope.com`, but EU/other regions and custom hosts differ —
+use the exact host your tenant uses). Provide it via `tenant`, or set `base_url`
+to override the whole root.
+
+## Configuration
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `client_options` | yes | Standard USP adapter options (see the repo README). |
+| `token` | yes | Netskope REST API v2 token, scoped to the dataexport endpoints. |
+| `tenant` | yes* | Tenant host, e.g. `acme.goskope.com`. *Required unless `base_url` is set. |
+| `base_url` | no | Full API root override, e.g. `https://acme.eu.goskope.com/api/v2`. |
+| `index_prefix` | no | Namespaces the per-feed iterator cursor names. Must be unique to this adapter on the tenant. Defaults to `sensor_seed_key` (or `limacharlie`). |
+| `alert_types` | no | Alert streams to collect. Absent = all defaults; `[]` = none. Ignored when `feeds` is set. |
+| `event_types` | no | Event streams to collect. Absent = `["audit"]`; `[]` = none. Ignored when `feeds` is set. |
+| `start_time` | no | One-time seed for a **new** stream's starting position: epoch seconds, RFC3339, or a relative Go duration ago (`24h`). Absent = `operation=next` (resume, or start from Netskope's earliest retained position). See the note below. |
+| `feeds` | no | Explicit list of streams to poll. When set, it replaces the defaults entirely. |
+| `poll_interval` | no | Idle cadence when the server returns no `wait_time` and there is no backlog. Default `30s`. |
+| `max_wait_time` | no | Cap on a server-provided `wait_time`, so a quiet stream is still polled at least this often. Default `5m`. |
+| `dedupe_ttl` | no | How long a record id is remembered to suppress re-shipping (covers iterator resend / re-seed overlap). Default `1h`. |
+| `retry_base_delay` / `max_retry_delay` / `max_retry_attempts` | no | Transient-failure retry tuning. |
+
+### Feed fields
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `kind` | yes | `events` or `alerts`. |
+| `type` | yes | The Netskope stream type within the kind (e.g. `page`, `audit`, `dlp`, `malware`). |
+| `name` | no | Labels the feed and becomes the `EventType` of every shipped record. Defaults to `<event\|alert>_<type>`. |
+| `index` | no | Iterator cursor name. Defaults to `<index_prefix>_<event\|alert>_<type>`. |
+| `timestamp_field` | no | Record field holding the event time (epoch seconds or ISO-8601). Default `timestamp`. |
+| `id_field` | no | Record field holding a stable id, used for dedup. Falls back to `_id`/`id`, then a content hash. |
+
+### About `start_time`
+
+By default the adapter uses `operation=next`, which resumes an existing cursor or,
+for a brand-new `index`, starts from Netskope's earliest retained position. This
+is restart-safe (no gaps, no duplicates).
+
+`start_time` seeds a brand-new stream at a specific point — useful to bound an
+initial backfill (e.g. `start_time: 24h`). **It re-seeds on every process
+restart**, so leaving it set means a restart re-reads from that point; the
+deduper absorbs short overlaps, but for the cleanest behavior set it for the
+initial backfill, then remove it.
+
+## How polling works
+
+One goroutine per feed walks `operation=next` forever, shipping each record
+verbatim with `EventType` set to the feed name and the event timestamp taken from
+the record's `timestamp` (epoch seconds). Between calls it waits the server's
+`wait_time` (capped by `max_wait_time`); with a backlog and no hint it drains
+quickly, and when idle it polls at `poll_interval`.
+
+An in-memory deduper (keyed per feed on the record id) guards the only cases where
+the iterator can re-deliver a record — an `operation=resend` retry or a
+`start_time` re-seed after a restart.
+
+Errors coming back from the Netskope API — persistent 5xx, a malformed response,
+or an authentication failure (401/403, e.g. a token missing the endpoint's scope)
+— are **logged as warnings and never stop the adapter**. The failing feed skips
+that poll and retries on the next interval while the other feeds keep running.
+This is deliberate: a problem on Netskope's side cannot be fixed by restarting the
+collector, so the adapter does not treat it as fatal (which, in the hosted
+cloud-adapter environment, would tear the whole adapter down and eventually
+disable it). Only a failure *delivering* events to LimaCharlie is fatal, because
+there a restart re-establishes the connection.
+
+Transient API failures (HTTP 5xx, 429, network errors) are retried with
+exponential backoff; on a 429 the adapter honours the server's `Retry-After` /
+`RateLimit-Reset` hint.
+
+## Examples
+
+Default (all alert streams + audit events), via the CLI:
+
+```
+./general netskope \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=json \
+  client_options.sensor_seed_key=netskope \
+  token=$NETSKOPE_API_TOKEN \
+  tenant=acme.goskope.com
+```
+
+Collecting a focused set plus high-volume page events, with a bounded initial
+backfill, via a YAML config file:
+
+```yaml
+netskope:
+  client_options:
+    identity:
+      oid: $OID
+      installation_key: $INSTALLATION_KEY
+    platform: json
+    sensor_seed_key: netskope
+  token: $NETSKOPE_API_TOKEN
+  tenant: acme.goskope.com
+  start_time: 24h          # one-time backfill; remove after the first run
+  alert_types:
+    - dlp
+    - malware
+    - ctep
+    - compromisedcredential
+    - uba
+  event_types:
+    - audit
+    - page                 # high volume
+```
+
+Fully custom feeds (overrides the defaults entirely):
+
+```yaml
+netskope:
+  client_options:
+    identity:
+      oid: $OID
+      installation_key: $INSTALLATION_KEY
+    platform: json
+    sensor_seed_key: netskope
+  token: $NETSKOPE_API_TOKEN
+  tenant: acme.goskope.com
+  feeds:
+    - kind: alerts
+      type: dlp
+    - kind: alerts
+      type: malware
+    - kind: events
+      type: application
+      name: saas_activity     # custom EventType label
+```

--- a/netskope/api.go
+++ b/netskope/api.go
@@ -1,0 +1,170 @@
+package usp_netskope
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// HTTPError represents a non-2xx response from the Netskope API. It carries the
+// status code so callers can classify the error (retry vs. give up) without
+// having to parse error strings, plus an optional RetryAfter hint extracted from
+// the rate-limit response headers.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+	Body       string
+	// RetryAfter is the server's suggested wait before retrying, parsed from the
+	// Retry-After or RateLimit-Reset response headers (Netskope sets these on a
+	// 429). Zero when the server gave no hint.
+	RetryAfter time.Duration
+}
+
+func (e *HTTPError) Error() string {
+	body := e.Body
+	if len(body) > 512 {
+		body = body[:512] + "..."
+	}
+	return fmt.Sprintf("unexpected status code %d for %q: %s", e.StatusCode, e.URL, body)
+}
+
+// isTransientError reports whether an error is worth retrying.
+//
+// Transient (retry):
+//   - HTTP 5xx server errors
+//   - HTTP 429 Too Many Requests (Netskope's per-endpoint rate limit is 4 req/s)
+//   - network errors (timeouts, connection refused, DNS failures, ...)
+//
+// Permanent (do not retry):
+//   - HTTP 4xx other than 429 (bad request, auth failure, not found, ...). In
+//     particular a 401/403 means the API token is invalid or is not scoped to
+//     this dataexport endpoint -- retrying cannot help.
+//   - context cancellation (intentional shutdown)
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 500 && httpErr.StatusCode <= 599 {
+			return true
+		}
+		if httpErr.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+		return false
+	}
+
+	// Context cancellation is an intentional shutdown, not a transient blip.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Anything that failed before we got a response (DNS, dial, timeout, ...) is
+	// reported by Do() and wrapped with this prefix; treat it as transient.
+	if strings.Contains(err.Error(), "failed to execute request") {
+		return true
+	}
+
+	return false
+}
+
+// NetskopeClient is a thin wrapper around the Netskope REST API v2 dataexport
+// iterator endpoints. Those endpoints are uniform: a GET to
+// .../api/v2/events/dataexport/{events|alerts}/{type} with an "index" (the
+// server-side cursor name) and an "operation" query parameter.
+type NetskopeClient struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+// NewNetskopeClient builds a client. baseURL is the API root, e.g.
+// "https://<tenant>.goskope.com/api/v2".
+func NewNetskopeClient(baseURL, token string) *NetskopeClient {
+	return &NetskopeClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		httpClient: &http.Client{
+			// Pages carry up to 10,000 records; allow a generous read budget.
+			Timeout: 120 * time.Second,
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout: 10 * time.Second,
+				}).Dial,
+			},
+		},
+	}
+}
+
+// Get issues a GET to the given API path (relative to the API root) with the
+// supplied query parameters and returns the raw response body. A non-200
+// response is returned as an *HTTPError.
+func (c *NetskopeClient) Get(ctx context.Context, path string, query url.Values) ([]byte, error) {
+	u := c.baseURL + "/" + strings.TrimPrefix(path, "/")
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request %q: %v", u, err)
+	}
+
+	// Netskope v2 authenticates with the API token in a custom header (no Bearer
+	// prefix). The token is minted under Settings > Tools > REST API v2 and is
+	// scoped per-endpoint. Header name is case-insensitive; we send the casing
+	// the official SDK uses.
+	req.Header.Set("Netskope-Api-Token", c.token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "LimaCharlie-USP-Adapter")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request %q: %v", u, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response %q: %v", u, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPError{
+			StatusCode: resp.StatusCode,
+			URL:        u,
+			Body:       string(respBody),
+			RetryAfter: retryAfter(resp.Header),
+		}
+	}
+
+	return respBody, nil
+}
+
+// Close releases idle connections held by the underlying transport.
+func (c *NetskopeClient) Close() {
+	c.httpClient.CloseIdleConnections()
+}
+
+// retryAfter extracts a retry delay from rate-limit response headers. Netskope
+// returns "Retry-After" (seconds) on a 429 and also exposes "RateLimit-Reset"
+// (seconds until the window resets); either is honoured, Retry-After first.
+func retryAfter(h http.Header) time.Duration {
+	for _, name := range []string{"Retry-After", "RateLimit-Reset", "Ratelimit-Reset"} {
+		if v := strings.TrimSpace(h.Get(name)); v != "" {
+			if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+				return time.Duration(secs) * time.Second
+			}
+		}
+	}
+	return 0
+}

--- a/netskope/client.go
+++ b/netskope/client.go
@@ -1,0 +1,818 @@
+// Package usp_netskope implements a USP adapter for the Netskope REST API v2
+// "dataexport" iterator endpoints
+// (https://docs.netskope.com/en/using-the-rest-api-v2-dataexport-iterator-endpoints/).
+//
+// Netskope exposes its security telemetry as a set of iterator streams, one per
+// event type (page, application, network, audit, incident, infrastructure,
+// endpoint, alert) and one per alert type (dlp, malware, malsite, ctep,
+// compromisedcredential, uba, policy, quarantine, remediation,
+// securityassessment, watchlist). Each stream is consumed by polling
+//
+//	GET /api/v2/events/dataexport/{events|alerts}/{type}?index=<cursor>&operation=next
+//
+// where "index" is a consumer-chosen, server-side cursor: Netskope remembers the
+// position for that index name, so the adapter does not have to persist any
+// state itself -- a restart simply resumes the same index. The response carries
+// up to 10,000 records plus a "wait_time" telling the consumer how long to wait
+// before the next call.
+//
+// The adapter models each stream as a "feed" and ships every Netskope record to
+// LimaCharlie verbatim (no reshaping); LimaCharlie parses and maps in the cloud.
+package usp_netskope
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	// defaultPollInterval is the idle cadence used when the server returns no
+	// wait_time and there is no backlog to drain.
+	defaultPollInterval = 30 * time.Second
+	// defaultMinWaitTime is the floor used between calls while a backlog is being
+	// drained. It keeps the adapter comfortably under Netskope's documented limit
+	// of 4 requests/second/endpoint.
+	defaultMinWaitTime = 1 * time.Second
+	// defaultMaxWaitTime caps how long the adapter will honour a server-provided
+	// wait_time, so a quiet stream is still polled at least this often.
+	defaultMaxWaitTime = 5 * time.Minute
+
+	defaultDedupeTTL   = 1 * time.Hour
+	dedupeBucketWindow = 5 * time.Minute
+
+	defaultMaxRetryAttempts = 4
+	defaultRetryBaseDelay   = 2 * time.Second
+	defaultMaxRetryDelay    = 60 * time.Second
+
+	defaultTimestampField = "timestamp"
+
+	// operationNext advances a stream's server-side cursor to the next page.
+	operationNext = "next"
+
+	shipTimeout = 10 * time.Second
+)
+
+// defaultAlertTypes are the alert streams collected out of the box. They are the
+// high-signal, lower-volume detections a SOC cares about most. The full list of
+// v2 alert types is collected by default.
+var defaultAlertTypes = []string{
+	"dlp", "malware", "malsite", "ctep", "compromisedcredential",
+	"uba", "policy", "quarantine", "remediation", "securityassessment", "watchlist",
+}
+
+// defaultEventTypes are the event streams collected out of the box. Only the
+// administrative audit trail is on by default; the page / application / network
+// event streams are very high volume and are left opt-in (add them to
+// event_types or to a custom feed).
+var defaultEventTypes = []string{"audit"}
+
+// validKinds is the set of dataexport categories.
+var validKinds = map[string]struct{}{"events": {}, "alerts": {}}
+
+// commonIDFields are the fields probed, in order, for a stable per-record
+// identifier used for deduplication when a feed does not set IDField. Netskope
+// records do not always carry an explicit id, so a content hash is the final
+// fallback (see recordID).
+var commonIDFields = []string{"_id", "id"}
+
+// timestampLayouts are the string time formats accepted for a record's timestamp
+// field. Netskope normally emits an integer epoch-seconds "timestamp", but some
+// fields are ISO-8601 strings.
+var timestampLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05.999999999",
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+}
+
+// NetskopeFeed describes a single dataexport stream to poll. New streams are
+// added purely by configuration -- no code change.
+type NetskopeFeed struct {
+	// Name labels the feed and becomes the EventType of every shipped record.
+	// Defaults to "<kind>_<type>" (e.g. "alert_dlp", "event_audit").
+	Name string `json:"name" yaml:"name"`
+
+	// Kind is the dataexport category: "events" or "alerts".
+	Kind string `json:"kind" yaml:"kind"`
+
+	// Type is the Netskope stream type within the kind, e.g. "page" / "audit"
+	// for events, "dlp" / "malware" for alerts.
+	Type string `json:"type" yaml:"type"`
+
+	// Index is the iterator cursor name for this stream. Netskope stores the read
+	// position server-side under this name, so it must be unique per consumer and
+	// stable across restarts. Defaults to "<index_prefix>_<kind>_<type>".
+	Index string `json:"index" yaml:"index"`
+
+	// TimestampField is the record field holding the event time (epoch seconds,
+	// or an ISO-8601 string). Defaults to "timestamp".
+	TimestampField string `json:"timestamp_field" yaml:"timestamp_field"`
+
+	// IDField is the record field holding a stable identifier, used for
+	// deduplication. Empty means: probe common id fields, then fall back to a
+	// content hash.
+	IDField string `json:"id_field" yaml:"id_field"`
+
+	// seedOp, when non-empty, is the operation used on this feed's first poll of
+	// the process (an epoch-seconds value derived from the config's start_time).
+	// Subsequent polls always use "next". Not settable from config.
+	seedOp string `json:"-" yaml:"-"`
+}
+
+// path is the dataexport endpoint path for the feed, relative to the API root.
+func (f NetskopeFeed) path() string {
+	return "events/dataexport/" + f.Kind + "/" + f.Type
+}
+
+// NetskopeConfig is the adapter configuration.
+type NetskopeConfig struct {
+	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+	// Token is a Netskope REST API v2 token (Settings > Tools > REST API v2). It
+	// is sent in the Netskope-Api-Token header and must be scoped to every
+	// dataexport endpoint the adapter polls.
+	Token string `json:"token" yaml:"token"`
+
+	// Tenant is the Netskope tenant host, e.g. "acme.goskope.com" (a scheme and
+	// trailing path are tolerated). The API root becomes https://<tenant>/api/v2.
+	Tenant string `json:"tenant" yaml:"tenant"`
+
+	// BaseURL fully overrides the API root (e.g. for a non-goskope.com region or
+	// a test server). When set, Tenant is ignored. Should include /api/v2.
+	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// IndexPrefix namespaces the per-feed iterator cursor names. It must be
+	// unique to this adapter on the tenant (two consumers sharing an index name
+	// corrupt each other's position). Defaults to the sensor_seed_key, or
+	// "limacharlie" if that is empty.
+	IndexPrefix string `json:"index_prefix" yaml:"index_prefix"`
+
+	// StartTime optionally seeds a brand-new stream's starting position on the
+	// first poll of the process. Accepts epoch seconds ("1700000000"), an RFC3339
+	// timestamp, or a relative Go duration ago ("24h", "168h"). When empty the
+	// adapter uses operation=next, which resumes an existing cursor or, for a new
+	// one, starts from Netskope's earliest retained position.
+	//
+	// Note: start_time re-seeds on every process restart, so leaving it set means
+	// a restart re-reads from that point (the deduper absorbs short overlaps).
+	// Use it for an initial backfill, then remove it.
+	StartTime string `json:"start_time" yaml:"start_time"`
+
+	// AlertTypes / EventTypes select which default feeds run. A nil (absent)
+	// value means "use the built-in default set"; an explicit empty list means
+	// "none of this kind". Ignored when Feeds is supplied.
+	AlertTypes []string `json:"alert_types" yaml:"alert_types"`
+	EventTypes []string `json:"event_types" yaml:"event_types"`
+
+	// Feeds is the explicit set of streams to poll. When non-empty it replaces
+	// the default set entirely (AlertTypes / EventTypes no longer apply).
+	Feeds []NetskopeFeed `json:"feeds" yaml:"feeds"`
+
+	// PollInterval is the idle cadence used when the server returns no wait_time
+	// and there is no backlog. Default 30s.
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+	// MaxWaitTime caps how long a server-provided wait_time is honoured. Default
+	// 5 minutes.
+	MaxWaitTime time.Duration `json:"max_wait_time" yaml:"max_wait_time"`
+
+	// DedupeTTL is how long a record id is remembered to suppress re-shipping it
+	// (covers the iterator resend/re-seed overlap). Default 1 hour.
+	DedupeTTL time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
+
+	// Retry tuning for transient API failures.
+	RetryBaseDelay   time.Duration `json:"retry_base_delay" yaml:"retry_base_delay"`
+	MaxRetryDelay    time.Duration `json:"max_retry_delay" yaml:"max_retry_delay"`
+	MaxRetryAttempts int           `json:"max_retry_attempts" yaml:"max_retry_attempts"`
+
+	// minWaitTime is the floor between calls while draining a backlog. Not
+	// settable from config; derived from PollInterval.
+	minWaitTime time.Duration
+
+	// startEpoch is the parsed StartTime (epoch seconds), or 0 for operation=next.
+	startEpoch int64
+
+	// Deduper, when set, replaces the built-in in-memory deduper. Not settable
+	// from a config file; a seam for tests and embedders.
+	Deduper utils.Deduper `json:"-" yaml:"-"`
+}
+
+// indexPrefix returns the sanitized cursor-name prefix.
+func (c *NetskopeConfig) indexPrefix() string {
+	p := strings.TrimSpace(c.IndexPrefix)
+	if p == "" {
+		p = c.ClientOptions.SensorSeedKey
+	}
+	if strings.TrimSpace(p) == "" {
+		p = "limacharlie"
+	}
+	return sanitizeIndex(p)
+}
+
+func (c *NetskopeConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+	if c.Token == "" {
+		return errors.New("missing token")
+	}
+	c.BaseURL = strings.TrimSpace(c.BaseURL)
+	c.Tenant = strings.TrimSpace(c.Tenant)
+	if c.BaseURL == "" && c.Tenant == "" {
+		return errors.New("missing tenant (or base_url)")
+	}
+
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
+	c.minWaitTime = defaultMinWaitTime
+	if c.minWaitTime > c.PollInterval {
+		c.minWaitTime = c.PollInterval
+	}
+	if c.MaxWaitTime <= 0 {
+		c.MaxWaitTime = defaultMaxWaitTime
+	}
+	if c.MaxWaitTime < c.PollInterval {
+		c.MaxWaitTime = c.PollInterval
+	}
+	if c.DedupeTTL <= 0 {
+		c.DedupeTTL = defaultDedupeTTL
+	}
+	if c.RetryBaseDelay <= 0 {
+		c.RetryBaseDelay = defaultRetryBaseDelay
+	}
+	if c.MaxRetryDelay <= 0 {
+		c.MaxRetryDelay = defaultMaxRetryDelay
+	}
+	if c.MaxRetryAttempts <= 0 {
+		c.MaxRetryAttempts = defaultMaxRetryAttempts
+	}
+
+	epoch, err := parseStartTime(c.StartTime)
+	if err != nil {
+		return fmt.Errorf("invalid start_time: %v", err)
+	}
+	c.startEpoch = epoch
+
+	if len(c.Feeds) == 0 {
+		c.Feeds = c.defaultFeeds()
+		if len(c.Feeds) == 0 {
+			return errors.New("no feeds: enable at least one alert_types/event_types entry or supply custom feeds")
+		}
+	}
+
+	prefix := c.indexPrefix()
+	seenNames := make(map[string]struct{}, len(c.Feeds))
+	seenIndex := make(map[string]struct{}, len(c.Feeds))
+	for i := range c.Feeds {
+		f := &c.Feeds[i]
+		f.Kind = strings.ToLower(strings.TrimSpace(f.Kind))
+		f.Type = strings.ToLower(strings.TrimSpace(f.Type))
+		f.Name = strings.TrimSpace(f.Name)
+		if _, ok := validKinds[f.Kind]; !ok {
+			return fmt.Errorf("feed %d: kind must be \"events\" or \"alerts\", got %q", i, f.Kind)
+		}
+		if f.Type == "" {
+			return fmt.Errorf("feed %d: missing type", i)
+		}
+		if f.Name == "" {
+			f.Name = singular(f.Kind) + "_" + f.Type
+		}
+		if _, ok := seenNames[f.Name]; ok {
+			return fmt.Errorf("feed %q: duplicate name", f.Name)
+		}
+		seenNames[f.Name] = struct{}{}
+
+		if f.Index == "" {
+			f.Index = sanitizeIndex(prefix + "_" + singular(f.Kind) + "_" + f.Type)
+		} else {
+			f.Index = sanitizeIndex(f.Index)
+		}
+		if _, ok := seenIndex[f.Index]; ok {
+			return fmt.Errorf("feed %q: duplicate iterator index %q (each stream needs a unique index)", f.Name, f.Index)
+		}
+		seenIndex[f.Index] = struct{}{}
+
+		if f.TimestampField == "" {
+			f.TimestampField = defaultTimestampField
+		}
+		if c.startEpoch > 0 {
+			f.seedOp = strconv.FormatInt(c.startEpoch, 10)
+		}
+	}
+	return nil
+}
+
+// defaultFeeds builds the out-of-the-box feed set from AlertTypes / EventTypes,
+// applying the built-in defaults for whichever is absent (nil). An explicit
+// empty list disables that kind.
+func (c *NetskopeConfig) defaultFeeds() []NetskopeFeed {
+	alertTypes := c.AlertTypes
+	if alertTypes == nil {
+		alertTypes = defaultAlertTypes
+	}
+	eventTypes := c.EventTypes
+	if eventTypes == nil {
+		eventTypes = defaultEventTypes
+	}
+	feeds := make([]NetskopeFeed, 0, len(alertTypes)+len(eventTypes))
+	for _, t := range alertTypes {
+		if t = strings.ToLower(strings.TrimSpace(t)); t != "" {
+			feeds = append(feeds, NetskopeFeed{Kind: "alerts", Type: t})
+		}
+	}
+	for _, t := range eventTypes {
+		if t = strings.ToLower(strings.TrimSpace(t)); t != "" {
+			feeds = append(feeds, NetskopeFeed{Kind: "events", Type: t})
+		}
+	}
+	return feeds
+}
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
+// NetskopeAdapter polls one or more Netskope dataexport streams and ships their
+// records to LimaCharlie.
+type NetskopeAdapter struct {
+	conf        NetskopeConfig
+	uspClient   uspSink
+	client      *NetskopeClient
+	deduper     utils.Deduper
+	ownsDeduper bool
+
+	chStopped chan struct{}
+	wgSenders sync.WaitGroup
+	doStop    *utils.Event
+
+	closeOnce sync.Once
+	closeErr  error
+
+	ctx context.Context
+}
+
+// NewNetskopeAdapter creates a Netskope adapter wired to LimaCharlie.
+func NewNetskopeAdapter(ctx context.Context, conf NetskopeConfig) (*NetskopeAdapter, chan struct{}, error) {
+	return newNetskopeAdapter(ctx, conf, nil)
+}
+
+// newNetskopeAdapter is the implementation behind NewNetskopeAdapter. When sink
+// is non-nil it is used in place of a real LimaCharlie client -- the seam tests
+// use to capture shipped events.
+func newNetskopeAdapter(ctx context.Context, conf NetskopeConfig, sink uspSink) (*NetskopeAdapter, chan struct{}, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	a := &NetskopeAdapter{
+		conf:   conf,
+		ctx:    ctx,
+		doStop: utils.NewEvent(),
+	}
+
+	// The iterator can re-deliver records (operation=resend, or a re-seed on
+	// restart), so a deduper ships each record exactly once across those
+	// overlaps. A deduper may be supplied via the config; otherwise an in-memory
+	// one is created (and owned/closed by the adapter).
+	a.deduper = conf.Deduper
+	if a.deduper == nil {
+		window := dedupeBucketWindow
+		if window > conf.DedupeTTL {
+			window = conf.DedupeTTL
+		}
+		deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("netskope: deduper: %v", err)
+		}
+		a.deduper = deduper
+		a.ownsDeduper = true
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			if a.ownsDeduper {
+				a.deduper.Close()
+			}
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
+	}
+
+	a.client = NewNetskopeClient(resolveBaseURL(conf), conf.Token)
+	a.chStopped = make(chan struct{})
+
+	for _, feed := range conf.Feeds {
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf("netskope: starting feed %q -> %s (index=%s)", feed.Name, feed.path(), feed.Index))
+		a.wgSenders.Add(1)
+		go a.runFeed(feed)
+	}
+
+	go func() {
+		a.wgSenders.Wait()
+		close(a.chStopped)
+	}()
+
+	return a, a.chStopped, nil
+}
+
+// Close stops the adapter. It is idempotent: repeated calls are no-ops and
+// return the result of the first call.
+func (a *NetskopeAdapter) Close() error {
+	a.closeOnce.Do(func() {
+		a.conf.ClientOptions.DebugLog("netskope: closing")
+		a.doStop.Set()
+		a.wgSenders.Wait()
+		err1 := a.uspClient.Drain(1 * time.Minute)
+		_, err2 := a.uspClient.Close()
+		a.client.Close()
+		if a.ownsDeduper {
+			a.deduper.Close()
+		}
+		if err1 != nil {
+			a.closeErr = err1
+		} else {
+			a.closeErr = err2
+		}
+	})
+	return a.closeErr
+}
+
+// resolveBaseURL computes the Netskope API root (.../api/v2) from the config.
+func resolveBaseURL(conf NetskopeConfig) string {
+	if conf.BaseURL != "" {
+		return strings.TrimRight(conf.BaseURL, "/")
+	}
+	host := conf.Tenant
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	host = strings.Trim(host, "/")
+	return "https://" + host + "/api/v2"
+}
+
+// runFeed consumes a single dataexport stream forever, until the adapter is
+// asked to stop. Netskope holds the cursor server-side (keyed by feed.Index), so
+// the loop is a straight walk of operation=next: each call returns the next page
+// and a wait_time hint, and the loop honours that wait_time before the next call.
+func (a *NetskopeAdapter) runFeed(feed NetskopeFeed) {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("netskope: feed %q stopped", feed.Name))
+
+	// The first poll uses the seed operation when start_time is configured;
+	// thereafter (and always, once a poll succeeds) it is operation=next.
+	op := operationNext
+	if feed.seedOp != "" {
+		op = feed.seedOp
+	}
+
+	for !a.doStop.IsSet() {
+		items, waitTime, ok := a.fetchPage(feed, op)
+		if ok {
+			op = operationNext
+			for _, item := range items {
+				if a.deduper.CheckAndAdd(a.dedupeKey(feed, item)) {
+					continue
+				}
+				if !a.ship(feed, item) {
+					return
+				}
+			}
+		}
+
+		if a.doStop.WaitFor(a.waitDuration(waitTime, len(items), ok)) {
+			return
+		}
+	}
+}
+
+// waitDuration decides how long to wait before the next call to a feed. It
+// honours the server's wait_time (capped by MaxWaitTime); absent one, it drains
+// quickly while there is a backlog and idles at PollInterval otherwise.
+func (a *NetskopeAdapter) waitDuration(waitTimeSec, nItems int, ok bool) time.Duration {
+	if waitTimeSec > 0 {
+		d := time.Duration(waitTimeSec) * time.Second
+		if d > a.conf.MaxWaitTime {
+			d = a.conf.MaxWaitTime
+		}
+		return d
+	}
+	if ok && nItems > 0 {
+		// A full page with no wait hint means there is likely more backlog: poll
+		// again promptly, but stay under the 4 req/s/endpoint rate limit.
+		return a.conf.minWaitTime
+	}
+	return a.conf.PollInterval
+}
+
+// fetchPage performs one iterator call for a feed, retrying transient failures
+// with exponential backoff. ok is false when the poll should be abandoned (any
+// source-side error, or the adapter is stopping).
+//
+// Source-side errors (4xx/5xx, auth failures, network blips, malformed
+// responses) are reported via OnWarning and NEVER stop the adapter. This is
+// deliberate: the cloud-sensor host treats any adapter OnError as fatal to the
+// instance -- it tears the adapter down, relaunches it, and after enough
+// failures disables it entirely. Restarting cannot fix a problem on Netskope's
+// side (a revoked token, a missing endpoint scope), and it would take the
+// adapter's healthy feeds down with the broken one. So we log, skip just this
+// poll, and let the feed try again. Only a failure delivering to LimaCharlie
+// (see ship) is fatal, since a relaunch reconnects the backend.
+func (a *NetskopeAdapter) fetchPage(feed NetskopeFeed, op string) ([]utils.Dict, int, bool) {
+	q := url.Values{}
+	q.Set("index", feed.Index)
+	q.Set("operation", op)
+
+	var raw []byte
+	var err error
+	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
+		if a.doStop.IsSet() {
+			return nil, 0, false
+		}
+
+		raw, err = a.client.Get(a.ctx, feed.path(), q)
+		if err == nil {
+			break
+		}
+
+		if !isTransientError(err) {
+			msg := fmt.Sprintf("netskope: feed %q request failed (skipping this poll): %v", feed.Name, err)
+			var httpErr *HTTPError
+			if errors.As(err, &httpErr) &&
+				(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
+				msg = fmt.Sprintf(
+					"netskope: feed %q -- HTTP %d, token rejected. Verify the REST API v2 token is "+
+						"valid and scoped to the %q dataexport endpoint (Settings > Tools > REST API v2).",
+					feed.Name, httpErr.StatusCode, feed.path())
+			}
+			a.conf.ClientOptions.OnWarning(msg)
+			return nil, 0, false
+		}
+
+		if attempt+1 >= a.conf.MaxRetryAttempts {
+			break
+		}
+		delay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
+		if delay > a.conf.MaxRetryDelay {
+			delay = a.conf.MaxRetryDelay
+		}
+		// Prefer the server's own retry hint (Retry-After / RateLimit-Reset) when
+		// it rate-limits us.
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && httpErr.RetryAfter > 0 {
+			delay = httpErr.RetryAfter
+			if delay > a.conf.MaxRetryDelay {
+				delay = a.conf.MaxRetryDelay
+			}
+		}
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"netskope: feed %q transient error (attempt %d/%d), retrying in %v: %v",
+			feed.Name, attempt+1, a.conf.MaxRetryAttempts, delay, err))
+		if a.doStop.WaitFor(delay) {
+			return nil, 0, false
+		}
+	}
+	if err != nil {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"netskope: feed %q failed after %d attempts (skipping this poll): %v",
+			feed.Name, a.conf.MaxRetryAttempts, err))
+		return nil, 0, false
+	}
+
+	items, waitTime, perr := parseIteratorResponse(raw)
+	if perr != nil {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"netskope: feed %q response parse error (skipping this poll): %v", feed.Name, perr))
+		return nil, waitTime, false
+	}
+	if n := len(items); n > 0 {
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+			"netskope: feed %q fetched %d records (wait_time=%ds)", feed.Name, n, waitTime))
+	}
+	return items, waitTime, true
+}
+
+// ship forwards a single record to LimaCharlie. It returns false if the adapter
+// should stop (an unrecoverable shipping error).
+func (a *NetskopeAdapter) ship(feed NetskopeFeed, item utils.Dict) bool {
+	msg := &protocol.DataMessage{
+		JsonPayload: item,
+		EventType:   feed.Name,
+		TimestampMs: a.eventTime(feed, item),
+	}
+	if err := a.uspClient.Ship(msg, shipTimeout); err != nil {
+		if err == uspclient.ErrorBufferFull {
+			a.conf.ClientOptions.OnWarning("netskope: stream falling behind")
+			err = a.uspClient.Ship(msg, 1*time.Hour)
+		}
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("netskope: Ship(): %v", err))
+			a.doStop.Set()
+			return false
+		}
+	}
+	return true
+}
+
+// eventTime extracts the record's event time. Netskope emits "timestamp" as
+// epoch seconds; an ISO-8601 string is also accepted. Falls back to now when the
+// field is absent or unparseable.
+func (a *NetskopeAdapter) eventTime(feed NetskopeFeed, item utils.Dict) uint64 {
+	field := feed.TimestampField
+	if field == "" {
+		field = defaultTimestampField
+	}
+	if secs, ok := epochSeconds(item, field); ok {
+		return secs * 1000
+	}
+	if raw := item.FindOneString(field); raw != "" {
+		if t, ok := parseTimestamp(raw); ok {
+			return uint64(t.UnixMilli())
+		}
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+			"netskope: feed %q unparseable timestamp %q at field %q", feed.Name, raw, field))
+	}
+	return uint64(time.Now().UnixMilli())
+}
+
+// epochSeconds reads an integer epoch-seconds value from a record field,
+// accepting either a top-level int or a "/"-pathed int. Returns ok=false when
+// the field is absent (so a real value of 0 is still treated as absent, which is
+// correct -- epoch 0 is not a plausible Netskope event time).
+func epochSeconds(item utils.Dict, field string) (uint64, bool) {
+	if v, ok := item.GetInt(field); ok && v > 0 {
+		return v, true
+	}
+	if ints := item.FindInt(field); len(ints) > 0 && ints[0] > 0 {
+		return ints[0], true
+	}
+	return 0, false
+}
+
+// dedupeKey returns a stable deduplication key for a record, namespaced by feed
+// so identifiers cannot collide across feeds.
+func (a *NetskopeAdapter) dedupeKey(feed NetskopeFeed, item utils.Dict) string {
+	return feed.Name + "|" + recordID(feed, item)
+}
+
+// recordID resolves a record's identifier: the feed's IDField if set, otherwise
+// a probe of common id fields, otherwise a content hash so deduplication still
+// works for records with no recognizable identifier.
+func recordID(feed NetskopeFeed, item utils.Dict) string {
+	if feed.IDField != "" {
+		if id := fieldAsString(item, feed.IDField); id != "" {
+			return id
+		}
+	}
+	for _, k := range commonIDFields {
+		if id := fieldAsString(item, k); id != "" {
+			return id
+		}
+	}
+	if b, err := json.Marshal(item); err == nil {
+		sum := sha256.Sum256(b)
+		return "sha256:" + hex.EncodeToString(sum[:])
+	}
+	return ""
+}
+
+// fieldAsString reads a field as a string, accepting numeric values too (ids are
+// sometimes integers).
+func fieldAsString(item utils.Dict, path string) string {
+	if s := item.FindOneString(path); s != "" {
+		return s
+	}
+	if ints := item.FindInt(path); len(ints) > 0 {
+		return strconv.FormatUint(ints[0], 10)
+	}
+	return ""
+}
+
+// parseIteratorResponse parses a dataexport iterator response envelope
+// ({"ok":1,"result":[...],"wait_time":N}) into a slice of records plus the
+// server's suggested wait_time (seconds). An ok=0 envelope is an error.
+func parseIteratorResponse(raw []byte) ([]utils.Dict, int, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, 0, nil
+	}
+	var env struct {
+		OK       *int              `json:"ok"`
+		Result   []json.RawMessage `json:"result"`
+		WaitTime int               `json:"wait_time"`
+		Message  string            `json:"message"`
+		Error    string            `json:"error"`
+	}
+	if err := json.Unmarshal(trimmed, &env); err != nil {
+		return nil, 0, fmt.Errorf("invalid iterator response: %v", err)
+	}
+	if env.OK != nil && *env.OK == 0 {
+		msg := env.Error
+		if msg == "" {
+			msg = env.Message
+		}
+		if msg == "" {
+			msg = "ok=0"
+		}
+		return nil, env.WaitTime, fmt.Errorf("iterator returned an error: %s", msg)
+	}
+	return rawMessagesToDicts(env.Result), env.WaitTime, nil
+}
+
+// rawMessagesToDicts decodes each record with utils.UnmarshalCleanJSON, which
+// preserves integer precision (no float coercion) so payloads round-trip
+// faithfully. A record that is not a non-empty JSON object is skipped rather than
+// failing the whole page.
+func rawMessagesToDicts(raw []json.RawMessage) []utils.Dict {
+	items := make([]utils.Dict, 0, len(raw))
+	for _, r := range raw {
+		m, err := utils.UnmarshalCleanJSON(string(r))
+		if err != nil || len(m) == 0 {
+			continue
+		}
+		items = append(items, utils.Dict(m))
+	}
+	return items
+}
+
+// parseStartTime interprets the start_time config value. It accepts epoch
+// seconds, an RFC3339 timestamp, or a relative Go duration ago ("24h"). An empty
+// value yields 0, meaning operation=next.
+func parseStartTime(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		if n <= 0 {
+			return 0, fmt.Errorf("epoch must be positive, got %d", n)
+		}
+		return n, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Unix(), nil
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		if d <= 0 {
+			return 0, fmt.Errorf("duration must be positive, got %q", s)
+		}
+		return time.Now().Add(-d).Unix(), nil
+	}
+	return 0, fmt.Errorf("expected epoch seconds, RFC3339, or a Go duration, got %q", s)
+}
+
+func parseTimestamp(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range timestampLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+// sanitizeIndex keeps a Netskope iterator index name to a safe character set
+// (alphanumerics, underscore, hyphen); anything else becomes an underscore.
+func sanitizeIndex(s string) string {
+	var b strings.Builder
+	for _, r := range strings.TrimSpace(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// singular maps a feed kind ("events"/"alerts") to the label prefix used for a
+// feed's default Name ("event"/"alert").
+func singular(kind string) string {
+	return strings.TrimSuffix(kind, "s")
+}

--- a/netskope/client_test.go
+++ b/netskope/client_test.go
@@ -1,0 +1,379 @@
+package usp_netskope
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:      "json",
+		SensorSeedKey: "netskope-test",
+		TestSinkMode:  true,
+		DebugLog:      func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:     func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:       func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// --- unit tests -------------------------------------------------------------
+
+func TestParseIteratorResponse(t *testing.T) {
+	t.Run("ok envelope with result and wait_time", func(t *testing.T) {
+		items, wait, err := parseIteratorResponse([]byte(`{"ok":1,"result":[{"_id":"a"},{"_id":"b"}],"wait_time":12}`))
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, "a", items[0].FindOneString("_id"))
+		assert.Equal(t, 12, wait)
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		items, wait, err := parseIteratorResponse([]byte(`{"ok":1,"result":[],"wait_time":30}`))
+		require.NoError(t, err)
+		assert.Empty(t, items)
+		assert.Equal(t, 30, wait)
+	})
+
+	t.Run("ok=0 is an error and still surfaces wait_time", func(t *testing.T) {
+		_, wait, err := parseIteratorResponse([]byte(`{"ok":0,"error":"bad index","wait_time":5}`))
+		assert.Error(t, err)
+		assert.Equal(t, 5, wait)
+	})
+
+	t.Run("empty body yields no items", func(t *testing.T) {
+		items, _, err := parseIteratorResponse([]byte("   "))
+		require.NoError(t, err)
+		assert.Empty(t, items)
+	})
+
+	t.Run("invalid json errors", func(t *testing.T) {
+		_, _, err := parseIteratorResponse([]byte(`not json`))
+		assert.Error(t, err)
+	})
+
+	t.Run("large integers keep precision", func(t *testing.T) {
+		items, _, err := parseIteratorResponse([]byte(`{"ok":1,"result":[{"timestamp":1748000000,"big":123456789012345678}]}`))
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		v, ok := items[0].GetInt("big")
+		require.True(t, ok)
+		assert.Equal(t, uint64(123456789012345678), v)
+	})
+
+	t.Run("non-object records are skipped, valid ones kept", func(t *testing.T) {
+		items, _, err := parseIteratorResponse([]byte(`{"ok":1,"result":[{"_id":"a"},"junk",123,null,{"_id":"b"}]}`))
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, "a", items[0].FindOneString("_id"))
+		assert.Equal(t, "b", items[1].FindOneString("_id"))
+	})
+}
+
+func TestRecordID(t *testing.T) {
+	t.Run("uses configured id field", func(t *testing.T) {
+		feed := NetskopeFeed{IDField: "alert_id"}
+		assert.Equal(t, "abc", recordID(feed, utils.Dict{"alert_id": "abc", "_id": "other"}))
+	})
+
+	t.Run("falls back to _id then id", func(t *testing.T) {
+		assert.Equal(t, "xyz", recordID(NetskopeFeed{}, utils.Dict{"_id": "xyz"}))
+		assert.Equal(t, "q", recordID(NetskopeFeed{}, utils.Dict{"id": "q"}))
+	})
+
+	t.Run("accepts numeric ids", func(t *testing.T) {
+		feed := NetskopeFeed{IDField: "n"}
+		assert.Equal(t, "42", recordID(feed, utils.Dict{"n": uint64(42)}))
+	})
+
+	t.Run("content hash fallback is stable and distinct", func(t *testing.T) {
+		a1 := recordID(NetskopeFeed{}, utils.Dict{"foo": "bar"})
+		a2 := recordID(NetskopeFeed{}, utils.Dict{"foo": "bar"})
+		b := recordID(NetskopeFeed{}, utils.Dict{"foo": "baz"})
+		assert.Equal(t, a1, a2)
+		assert.NotEqual(t, a1, b)
+		assert.Contains(t, a1, "sha256:")
+	})
+}
+
+func TestEventTime(t *testing.T) {
+	a := &NetskopeAdapter{conf: NetskopeConfig{ClientOptions: testClientOptions(t)}}
+	feed := NetskopeFeed{TimestampField: defaultTimestampField}
+
+	t.Run("epoch seconds become milliseconds", func(t *testing.T) {
+		assert.Equal(t, uint64(1748000000000), a.eventTime(feed, utils.Dict{"timestamp": uint64(1748000000)}))
+	})
+
+	t.Run("epoch seconds as float", func(t *testing.T) {
+		assert.Equal(t, uint64(1748000000000), a.eventTime(feed, utils.Dict{"timestamp": float64(1748000000)}))
+	})
+
+	t.Run("iso-8601 string", func(t *testing.T) {
+		ts, _ := time.Parse(time.RFC3339, "2026-05-21T13:45:30Z")
+		assert.Equal(t, uint64(ts.UnixMilli()), a.eventTime(feed, utils.Dict{"timestamp": "2026-05-21T13:45:30Z"}))
+	})
+
+	t.Run("absent field falls back to now", func(t *testing.T) {
+		before := uint64(time.Now().UnixMilli())
+		got := a.eventTime(feed, utils.Dict{"user": "x"})
+		assert.GreaterOrEqual(t, got, before)
+	})
+}
+
+func TestResolveBaseURL(t *testing.T) {
+	assert.Equal(t, "https://acme.goskope.com/api/v2",
+		resolveBaseURL(NetskopeConfig{Tenant: "acme.goskope.com"}))
+	// A scheme and trailing slash on the tenant are tolerated.
+	assert.Equal(t, "https://acme.goskope.com/api/v2",
+		resolveBaseURL(NetskopeConfig{Tenant: "https://acme.goskope.com/"}))
+	// base_url wins and is used verbatim (minus a trailing slash).
+	assert.Equal(t, "https://test.example/api/v2",
+		resolveBaseURL(NetskopeConfig{Tenant: "acme.goskope.com", BaseURL: "https://test.example/api/v2/"}))
+}
+
+func TestParseStartTime(t *testing.T) {
+	t.Run("empty means next", func(t *testing.T) {
+		v, err := parseStartTime("")
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), v)
+	})
+	t.Run("epoch seconds", func(t *testing.T) {
+		v, err := parseStartTime("1748000000")
+		require.NoError(t, err)
+		assert.Equal(t, int64(1748000000), v)
+	})
+	t.Run("rfc3339", func(t *testing.T) {
+		v, err := parseStartTime("2026-05-21T13:45:30Z")
+		require.NoError(t, err)
+		ts, _ := time.Parse(time.RFC3339, "2026-05-21T13:45:30Z")
+		assert.Equal(t, ts.Unix(), v)
+	})
+	t.Run("relative duration", func(t *testing.T) {
+		before := time.Now().Add(-24 * time.Hour).Unix()
+		v, err := parseStartTime("24h")
+		require.NoError(t, err)
+		assert.InDelta(t, before, v, 5)
+	})
+	t.Run("invalid", func(t *testing.T) {
+		_, err := parseStartTime("yesterday")
+		assert.Error(t, err)
+	})
+	t.Run("non-positive epoch", func(t *testing.T) {
+		_, err := parseStartTime("0")
+		assert.Error(t, err)
+	})
+}
+
+func TestSanitizeIndex(t *testing.T) {
+	assert.Equal(t, "acme_alert_dlp", sanitizeIndex("acme_alert_dlp"))
+	assert.Equal(t, "a_b_c-d", sanitizeIndex("a b/c-d"))
+	assert.Equal(t, "seed_2", sanitizeIndex("seed.2"))
+}
+
+func TestFeedPath(t *testing.T) {
+	assert.Equal(t, "events/dataexport/alerts/dlp", NetskopeFeed{Kind: "alerts", Type: "dlp"}.path())
+	assert.Equal(t, "events/dataexport/events/page", NetskopeFeed{Kind: "events", Type: "page"}.path())
+}
+
+func TestWaitDuration(t *testing.T) {
+	a := &NetskopeAdapter{conf: NetskopeConfig{
+		PollInterval: 30 * time.Second,
+		MaxWaitTime:  5 * time.Minute,
+		minWaitTime:  1 * time.Second,
+	}}
+
+	t.Run("honours server wait_time", func(t *testing.T) {
+		assert.Equal(t, 12*time.Second, a.waitDuration(12, 0, true))
+	})
+	t.Run("caps server wait_time at max", func(t *testing.T) {
+		assert.Equal(t, 5*time.Minute, a.waitDuration(3600, 0, true))
+	})
+	t.Run("backlog with no hint drains at min", func(t *testing.T) {
+		assert.Equal(t, 1*time.Second, a.waitDuration(0, 10000, true))
+	})
+	t.Run("idle with no hint waits poll_interval", func(t *testing.T) {
+		assert.Equal(t, 30*time.Second, a.waitDuration(0, 0, true))
+	})
+	t.Run("failed poll with no hint waits poll_interval", func(t *testing.T) {
+		assert.Equal(t, 30*time.Second, a.waitDuration(0, 0, false))
+	})
+}
+
+func TestIsTransientError(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		isTransient bool
+	}{
+		{"500", &HTTPError{StatusCode: 500}, true},
+		{"503", &HTTPError{StatusCode: 503}, true},
+		{"429", &HTTPError{StatusCode: 429}, true},
+		{"401", &HTTPError{StatusCode: 401}, false},
+		{"403", &HTTPError{StatusCode: 403}, false},
+		{"404", &HTTPError{StatusCode: 404}, false},
+		{"400", &HTTPError{StatusCode: 400}, false},
+		{"network", fmt.Errorf("failed to execute request %q: connection refused", "x"), true},
+		{"context canceled", context.Canceled, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.isTransient, isTransientError(c.err))
+		})
+	}
+}
+
+func TestRetryAfterHeader(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "7")
+	assert.Equal(t, 7*time.Second, retryAfter(h))
+
+	h2 := http.Header{}
+	h2.Set("RateLimit-Reset", "3")
+	assert.Equal(t, 3*time.Second, retryAfter(h2))
+
+	assert.Equal(t, time.Duration(0), retryAfter(http.Header{}))
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("requires token", func(t *testing.T) {
+		c := NetskopeConfig{ClientOptions: testClientOptions(t), Tenant: "acme.goskope.com"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires tenant or base_url", func(t *testing.T) {
+		c := NetskopeConfig{ClientOptions: testClientOptions(t), Token: "k"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("applies defaults and the default feed set", func(t *testing.T) {
+		c := NetskopeConfig{ClientOptions: testClientOptions(t), Token: "k", Tenant: "acme.goskope.com"}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, defaultPollInterval, c.PollInterval)
+		assert.Equal(t, defaultDedupeTTL, c.DedupeTTL)
+
+		// Default = all alert types + the default event types (audit).
+		names := map[string]NetskopeFeed{}
+		for _, f := range c.Feeds {
+			names[f.Name] = f
+		}
+		assert.Contains(t, names, "alert_dlp")
+		assert.Contains(t, names, "alert_malware")
+		assert.Contains(t, names, "event_audit")
+		assert.Len(t, c.Feeds, len(defaultAlertTypes)+len(defaultEventTypes))
+
+		// Each feed gets a unique, sanitized, prefix-namespaced index.
+		assert.Equal(t, "netskope-test_alert_dlp", names["alert_dlp"].Index)
+		assert.Equal(t, "alerts", names["alert_dlp"].Kind)
+		assert.Equal(t, "dlp", names["alert_dlp"].Type)
+		assert.Equal(t, defaultTimestampField, names["alert_dlp"].TimestampField)
+	})
+
+	t.Run("alert_types and event_types select feeds", func(t *testing.T) {
+		c := NetskopeConfig{
+			ClientOptions: testClientOptions(t), Token: "k", Tenant: "acme.goskope.com",
+			AlertTypes: []string{"dlp", "malware"},
+			EventTypes: []string{"page", "audit"},
+		}
+		require.NoError(t, c.Validate())
+		got := map[string]bool{}
+		for _, f := range c.Feeds {
+			got[f.Name] = true
+		}
+		assert.Equal(t, map[string]bool{
+			"alert_dlp": true, "alert_malware": true, "event_page": true, "event_audit": true,
+		}, got)
+	})
+
+	t.Run("explicit empty alert_types disables alerts", func(t *testing.T) {
+		c := NetskopeConfig{
+			ClientOptions: testClientOptions(t), Token: "k", Tenant: "acme.goskope.com",
+			AlertTypes: []string{},
+			EventTypes: []string{"audit"},
+		}
+		require.NoError(t, c.Validate())
+		assert.Len(t, c.Feeds, 1)
+		assert.Equal(t, "event_audit", c.Feeds[0].Name)
+	})
+
+	t.Run("everything disabled is an error", func(t *testing.T) {
+		c := NetskopeConfig{
+			ClientOptions: testClientOptions(t), Token: "k", Tenant: "acme.goskope.com",
+			AlertTypes: []string{}, EventTypes: []string{},
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("custom feeds replace defaults", func(t *testing.T) {
+		c := NetskopeConfig{
+			ClientOptions: testClientOptions(t), Token: "k", Tenant: "acme.goskope.com",
+			AlertTypes: []string{}, EventTypes: []string{}, // ignored when Feeds set
+			Feeds: []NetskopeFeed{{Kind: "alerts", Type: "dlp"}},
+		}
+		require.NoError(t, c.Validate())
+		require.Len(t, c.Feeds, 1)
+		assert.Equal(t, "alert_dlp", c.Feeds[0].Name)
+	})
+
+	t.Run("rejects invalid kind", func(t *testing.T) {
+		c := NetskopeConfig{
+			ClientOptions: testClientOptions(t), Token: "k", Tenant: "acme.goskope.com",
+			Feeds: []NetskopeFeed{{Kind: "things", Type: "dlp"}},
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("rejects feed without type", func(t *testing.T) {
+		c := NetskopeConfig{
+			ClientOptions: testClientOptions(t), Token: "k", Tenant: "acme.goskope.com",
+			Feeds: []NetskopeFeed{{Kind: "alerts"}},
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("rejects duplicate feed names", func(t *testing.T) {
+		c := NetskopeConfig{
+			ClientOptions: testClientOptions(t), Token: "k", Tenant: "acme.goskope.com",
+			Feeds: []NetskopeFeed{
+				{Name: "dup", Kind: "alerts", Type: "dlp"},
+				{Name: "dup", Kind: "alerts", Type: "malware"},
+			},
+		}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("seeds feeds when start_time is set", func(t *testing.T) {
+		c := NetskopeConfig{
+			ClientOptions: testClientOptions(t), Token: "k", Tenant: "acme.goskope.com",
+			StartTime:  "1748000000",
+			AlertTypes: []string{"dlp"}, EventTypes: []string{},
+		}
+		require.NoError(t, c.Validate())
+		require.Len(t, c.Feeds, 1)
+		assert.Equal(t, "1748000000", c.Feeds[0].seedOp)
+	})
+
+	t.Run("index_prefix overrides the sensor seed key", func(t *testing.T) {
+		c := NetskopeConfig{
+			ClientOptions: testClientOptions(t), Token: "k", Tenant: "acme.goskope.com",
+			IndexPrefix: "myprefix",
+			AlertTypes:  []string{"dlp"}, EventTypes: []string{},
+		}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, "myprefix_alert_dlp", c.Feeds[0].Index)
+	})
+}

--- a/netskope/mock_test.go
+++ b/netskope/mock_test.go
@@ -1,0 +1,611 @@
+package usp_netskope
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock Netskope dataexport
+// iterator API, capturing the exact messages it ships so their content -- event
+// type, timestamp and verbatim payload -- can be asserted.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Netskope dataexport iterator API ----------------------------------
+
+// mockNetskope is an in-memory stand-in for the Netskope REST API v2 dataexport
+// iterator. It honours the iterator contract: a GET carrying the
+// Netskope-Api-Token header, an "index" cursor name and an "operation"
+// (next/resend/epoch), returning a {"ok":1,"result":[...],"wait_time":N}
+// envelope and advancing the server-side position for that index.
+type mockNetskope struct {
+	mu        sync.Mutex
+	token     string
+	datasets  map[string][]utils.Dict // "kind/type" -> records (oldest-first)
+	cursors   map[string]int          // index name -> next read position
+	lastStart map[string]int          // index name -> start of last returned page (for resend)
+	pageSize  int
+	waitTime  int // wait_time (seconds) to return; 0 keeps tests fast
+	requests  int
+}
+
+func newMockNetskope(token string) *mockNetskope {
+	return &mockNetskope{
+		token:     token,
+		datasets:  map[string][]utils.Dict{},
+		cursors:   map[string]int{},
+		lastStart: map[string]int{},
+		pageSize:  100,
+	}
+}
+
+// setDataset registers the records a (kind, type) stream serves, oldest-first.
+func (m *mockNetskope) setDataset(kind, typ string, records []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.datasets[kind+"/"+typ] = records
+}
+
+// appendRecord adds a record to the end (newest) of a stream, as the real API
+// would when a new event occurs after the consumer has caught up.
+func (m *mockNetskope) appendRecord(kind, typ string, record utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := kind + "/" + typ
+	m.datasets[key] = append(m.datasets[key], record)
+}
+
+func (m *mockNetskope) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+func (m *mockNetskope) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.requests++
+		m.mu.Unlock()
+
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		// v2 authenticates with the token in the Netskope-Api-Token header.
+		if r.Header.Get("Netskope-Api-Token") != m.token {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"ok":0,"error":"invalid or unauthorized api token"}`))
+			return
+		}
+
+		key := strings.TrimPrefix(r.URL.Path, "/api/v2/events/dataexport/")
+		index := r.URL.Query().Get("index")
+		op := r.URL.Query().Get("operation")
+		if index == "" || op == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"ok":0,"error":"index and operation are required"}`))
+			return
+		}
+
+		m.mu.Lock()
+		records := m.datasets[key]
+		start := m.cursors[index]
+		advance := true
+		switch op {
+		case operationNext:
+			start = m.cursors[index]
+		case "resend":
+			start = m.lastStart[index]
+			advance = false
+		default: // an epoch-seconds seed
+			if epoch, err := strconv.ParseInt(op, 10, 64); err == nil {
+				start = seekByTimestamp(records, epoch)
+			}
+		}
+		if start > len(records) {
+			start = len(records)
+		}
+		end := start + m.pageSize
+		if end > len(records) {
+			end = len(records)
+		}
+		page := append([]utils.Dict(nil), records[start:end]...)
+		if advance {
+			m.lastStart[index] = start
+			m.cursors[index] = end
+		}
+		wait := m.waitTime
+		m.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":        1,
+			"result":    page,
+			"wait_time": wait,
+		})
+	}
+}
+
+// seekByTimestamp returns the index of the first record whose "timestamp" is >=
+// epoch. Records are assumed oldest-first.
+func seekByTimestamp(records []utils.Dict, epoch int64) int {
+	for i, rec := range records {
+		if ts, ok := rec.GetInt("timestamp"); ok && int64(ts) >= epoch {
+			return i
+		}
+	}
+	return len(records)
+}
+
+// --- realistic record fixtures ----------------------------------------------
+
+// realisticDLPAlert returns a record shaped like a real Netskope v2 DLP alert:
+// the documented top-level fields plus a nested dlp_rules array and assorted
+// scalar types.
+func realisticDLPAlert(id string, ts int64) utils.Dict {
+	return utils.Dict{
+		"_id":            id,
+		"alert":          "yes",
+		"alert_name":     "PCI Data Exfiltration",
+		"alert_type":     "dlp",
+		"type":           "nspolicy",
+		"timestamp":      ts,
+		"user":           "jdoe@acme.example",
+		"userip":         "10.0.1.38",
+		"app":            "Google Drive",
+		"appcategory":    "Cloud Storage",
+		"ccl":            "high",
+		"activity":       "Upload",
+		"action":         "block",
+		"severity":       "high",
+		"policy":         "Block PCI to Unsanctioned",
+		"dlp_profile":    "PCI",
+		"dlp_rule":       "INTL-PAN-Name",
+		"dlp_rule_count": int64(1),
+		"object":         "card-numbers.xlsx",
+		"file_size":      int64(10256549),
+		"src_location":   "London",
+		"dst_location":   "Mountain View",
+		"dlp_rules": []interface{}{
+			utils.Dict{"dlp_rule_name": "INTL-PAN-Name", "dlp_rule_severity": "Critical"},
+		},
+	}
+}
+
+// realisticPageEvent returns a record shaped like a Netskope v2 page event.
+func realisticPageEvent(id string, ts int64) utils.Dict {
+	return utils.Dict{
+		"_id":          id,
+		"type":         "page",
+		"timestamp":    ts,
+		"user":         "jdoe@acme.example",
+		"app":          "YouTube",
+		"url":          "socialimpact.youtube.com",
+		"site":         "Youtube",
+		"srcip":        "18.170.239.5",
+		"dstip":        "142.250.187.238",
+		"src_location": "London",
+		"dst_location": "Mountain View",
+		"numbytes":     int64(309293),
+	}
+}
+
+// realisticAuditEvent returns a record shaped like a Netskope v2 audit event.
+func realisticAuditEvent(id string, ts int64) utils.Dict {
+	return utils.Dict{
+		"_id":             id,
+		"type":            "admin_audit_logs",
+		"timestamp":       ts,
+		"user":            "admin@acme.example",
+		"audit_log_event": "Edit Real-time Protection Policy",
+		"supporting_data": utils.Dict{
+			"data_type":   "policy",
+			"data_values": []interface{}{"Block PCI to Unsanctioned"},
+		},
+		"ur_normalized":     "admin@acme.example",
+		"organization_unit": "",
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// newAdapterAgainst builds an adapter pointed at the mock server with a capture
+// sink and short intervals for fast tests.
+func newAdapterAgainst(t *testing.T, ctx context.Context, server *httptest.Server, sink uspSink, conf NetskopeConfig) *NetskopeAdapter {
+	t.Helper()
+	conf.ClientOptions = testClientOptions(t)
+	conf.Token = "tok"
+	conf.BaseURL = server.URL + "/api/v2"
+	if conf.PollInterval == 0 {
+		conf.PollInterval = 40 * time.Millisecond
+	}
+	adapter, _, err := newNetskopeAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	return adapter
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestMockAlertsEndToEnd drives the adapter against the mock API and asserts the
+// exact events shipped: event type, timestamp parsed from the record's epoch
+// "timestamp", and the payload preserved verbatim (nested objects and arrays
+// included).
+func TestMockAlertsEndToEnd(t *testing.T) {
+	mock := newMockNetskope("tok")
+	want := []utils.Dict{
+		realisticDLPAlert("a1", 1748000000),
+		realisticDLPAlert("a2", 1748000305),
+		realisticDLPAlert("a3", 1748000931),
+	}
+	mock.setDataset("alerts", "dlp", want)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter := newAdapterAgainst(t, ctx, server, sink, NetskopeConfig{
+		AlertTypes: []string{"dlp"}, EventTypes: []string{},
+	})
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 DLP alerts to ship")
+
+	// Re-polling (the cursor advances forward) must not re-ship: count stays 3.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "records were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		assert.Equal(t, "alert_dlp", msg.EventType)
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["_id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	for _, src := range want {
+		id := src["_id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "record %s was not shipped", id)
+
+		// The event timestamp is the record's epoch-seconds "timestamp" in ms.
+		ts := src["timestamp"].(int64)
+		assert.Equal(t, uint64(ts*1000), msg.TimestampMs,
+			"event time should come from the record's timestamp (epoch seconds)")
+
+		// The payload is shipped verbatim -- nested objects and arrays included.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Netskope record")
+	}
+}
+
+// TestMockNewRecordShippedOnce verifies a record that appears mid-run (after the
+// consumer caught up) is shipped exactly once.
+func TestMockNewRecordShippedOnce(t *testing.T) {
+	mock := newMockNetskope("tok")
+	mock.setDataset("alerts", "malware", []utils.Dict{
+		realisticDLPAlert("m1", 1748000000),
+		realisticDLPAlert("m2", 1748000060),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter := newAdapterAgainst(t, ctx, server, sink, NetskopeConfig{
+		AlertTypes: []string{"malware"}, EventTypes: []string{},
+	})
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new alert appears once the consumer has caught up.
+	mock.appendRecord("alerts", "malware", realisticDLPAlert("m3", 1748000300))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new record should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shipped := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shipped[msg.JsonPayload["_id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{"m1": 1, "m2": 1, "m3": 1}, shipped,
+		"every record must ship exactly once")
+}
+
+// TestMockPaginationFullDataset verifies a dataset larger than one page is walked
+// completely (the iterator advances page by page) and every record ships once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const total = 250
+	mock := newMockNetskope("tok")
+	mock.pageSize = 100 // 250 records => 3 pages
+	records := make([]utils.Dict, total)
+	for i := 0; i < total; i++ {
+		records[i] = realisticPageEvent(fmt.Sprintf("p-%03d", i), 1748000000+int64(i))
+	}
+	mock.setDataset("events", "page", records)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	adapter := newAdapterAgainst(t, ctx, server, sink, NetskopeConfig{
+		AlertTypes: []string{}, EventTypes: []string{"page"},
+		PollInterval: 50 * time.Millisecond,
+	})
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 25*time.Millisecond, "all paginated records should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		assert.Equal(t, "event_page", msg.EventType)
+		ids[msg.JsonPayload["_id"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct record should be shipped once")
+}
+
+// TestMockMultipleFeeds verifies several streams collect concurrently and each
+// event is tagged with its feed's name.
+func TestMockMultipleFeeds(t *testing.T) {
+	mock := newMockNetskope("tok")
+	mock.setDataset("alerts", "dlp", []utils.Dict{
+		realisticDLPAlert("d1", 1748000000),
+		realisticDLPAlert("d2", 1748000060),
+	})
+	mock.setDataset("events", "audit", []utils.Dict{
+		realisticAuditEvent("au1", 1748000120),
+		realisticAuditEvent("au2", 1748000180),
+		realisticAuditEvent("au3", 1748000240),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter := newAdapterAgainst(t, ctx, server, sink, NetskopeConfig{
+		AlertTypes: []string{"dlp"}, EventTypes: []string{"audit"},
+	})
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 5 },
+		5*time.Second, 20*time.Millisecond)
+	require.Never(t, func() bool { return sink.count() != 5 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	byType := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		byType[msg.EventType]++
+	}
+	assert.Equal(t, map[string]int{"alert_dlp": 2, "event_audit": 3}, byType)
+}
+
+// TestMockDuplicateIDShippedOnce verifies the deduper suppresses a record whose
+// id repeats (covers the iterator resend / re-seed overlap).
+func TestMockDuplicateIDShippedOnce(t *testing.T) {
+	mock := newMockNetskope("tok")
+	// Two distinct records plus a third that repeats the first record's _id.
+	mock.setDataset("alerts", "dlp", []utils.Dict{
+		realisticDLPAlert("dup", 1748000000),
+		realisticDLPAlert("uniq", 1748000060),
+		realisticDLPAlert("dup", 1748000120),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter := newAdapterAgainst(t, ctx, server, sink, NetskopeConfig{
+		AlertTypes: []string{"dlp"}, EventTypes: []string{},
+	})
+	defer adapter.Close()
+
+	// Only two distinct ids should ever ship.
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+	require.Never(t, func() bool { return sink.count() != 2 },
+		400*time.Millisecond, 30*time.Millisecond, "the duplicate _id must not ship twice")
+
+	ids := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["_id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{"dup": 1, "uniq": 1}, ids)
+}
+
+// TestMockStartTimeSeed verifies start_time seeds the iterator: only records at
+// or after the seed timestamp are consumed.
+func TestMockStartTimeSeed(t *testing.T) {
+	mock := newMockNetskope("tok")
+	mock.setDataset("alerts", "dlp", []utils.Dict{
+		realisticDLPAlert("old1", 1748000000),
+		realisticDLPAlert("old2", 1748000100),
+		realisticDLPAlert("new1", 1748000500),
+		realisticDLPAlert("new2", 1748000600),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Seed at 1748000500 -> only new1/new2 should be consumed.
+	adapter := newAdapterAgainst(t, ctx, server, sink, NetskopeConfig{
+		AlertTypes: []string{"dlp"}, EventTypes: []string{},
+		StartTime: "1748000500",
+	})
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+	require.Never(t, func() bool { return sink.count() != 2 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["_id"].(string)] = true
+	}
+	assert.Equal(t, map[string]bool{"new1": true, "new2": true}, ids)
+}
+
+// TestMockRejectsBadToken verifies the adapter warns, keeps running, and ships
+// nothing when the API rejects the token. (Source-side failures are non-fatal:
+// stopping would make the cloud-sensor host tear the adapter down and eventually
+// disable it, and a restart cannot fix a bad token.)
+func TestMockRejectsBadToken(t *testing.T) {
+	mock := newMockNetskope("correct-token")
+	mock.setDataset("alerts", "dlp", []utils.Dict{realisticDLPAlert("a1", 1748000000)})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var warnings, fatalErrors atomic.Int32
+	opts := testClientOptions(t)
+	opts.OnWarning = func(msg string) { warnings.Add(1); t.Logf("WRN: %s", msg) }
+	opts.OnError = func(err error) { fatalErrors.Add(1); t.Logf("ERR: %v", err) }
+
+	conf := NetskopeConfig{
+		ClientOptions: opts,
+		Token:         "wrong-token",
+		BaseURL:       server.URL + "/api/v2",
+		PollInterval:  50 * time.Millisecond,
+		AlertTypes:    []string{"dlp"}, EventTypes: []string{},
+	}
+	adapter, chStopped, err := newNetskopeAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return warnings.Load() > 0 },
+		3*time.Second, 20*time.Millisecond, "expected a warning when the token is rejected")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter must not stop when the API rejects the token")
+	case <-time.After(300 * time.Millisecond):
+	}
+	assert.False(t, adapter.doStop.IsSet(), "doStop must not be set on a rejected token")
+	assert.Equal(t, int32(0), fatalErrors.Load(), "a rejected token must warn, not fatally error")
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	assert.GreaterOrEqual(t, mock.requestCount(), 1, "the adapter should have called the API")
+}
+
+// TestTransientErrorRetry verifies the adapter retries 5xx responses rather than
+// terminating.
+func TestTransientErrorRetry(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestCount.Add(1) <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"ok":0,"error":"transient"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":1,"result":[],"wait_time":0}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := NetskopeConfig{
+		ClientOptions:  testClientOptions(t),
+		Token:          "tok",
+		BaseURL:        server.URL + "/api/v2",
+		PollInterval:   100 * time.Millisecond,
+		RetryBaseDelay: 20 * time.Millisecond,
+		MaxRetryDelay:  40 * time.Millisecond,
+		AlertTypes:     []string{"dlp"}, EventTypes: []string{},
+	}
+	adapter, chStopped, err := newNetskopeAdapter(ctx, conf, &captureSink{})
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter stopped on a transient error - it should have retried")
+	default:
+	}
+	assert.GreaterOrEqual(t, requestCount.Load(), int32(3), "expected retries then success")
+	assert.False(t, adapter.doStop.IsSet())
+}


### PR DESCRIPTION
## Summary

Adds a **Netskope** USP adapter that pulls Netskope security telemetry into LimaCharlie via the [REST API v2 dataexport iterator](https://docs.netskope.com/en/using-the-rest-api-v2-dataexport-iterator-endpoints/) endpoints (`/api/v2/events/dataexport/{events|alerts}/{type}`).

Modeled on the `threatlocker` adapter. Each event/alert stream is a **feed** with its own **server-side iterator cursor** (the `index` query parameter): Netskope remembers the read position per index name, so the adapter keeps **no local state** and a restart resumes each stream with no gaps or duplicates.

## What it ingests

- **Out of the box:** every alert stream — `dlp`, `malware`, `malsite`, `ctep`, `compromisedcredential`, `uba`, `policy`, `quarantine`, `remediation`, `securityassessment`, `watchlist` — plus the `audit` event stream.
- **Opt-in (high volume):** `page` / `application` / `network` / `incident` / `infrastructure` / `endpoint` events, via `alert_types` / `event_types` or a custom `feeds` list.
- Records are shipped **verbatim** (LimaCharlie parses/maps in the cloud); `EventType` is the feed name (e.g. `alert_dlp`, `event_audit`) and the event time is the record's epoch-seconds `timestamp`.

## Implementation notes

- **Auth:** `Netskope-Api-Token` header (REST API v2 token), verified against Netskope's official SDK source.
- **Pacing:** honours the server's `wait_time`, drains backlogs quickly, and respects the documented **4 req/s/endpoint** rate limit (`Retry-After` / `RateLimit-Reset` aware).
- **Resilience:** source-side errors (incl. `401/403` for a missing endpoint scope) are non-fatal warnings, so one broken feed never tears down the whole adapter; only a failure delivering to LimaCharlie is fatal (mirrors `threatlocker`'s rationale for the hosted cloud-adapter environment).
- **`start_time`** optionally seeds a brand-new stream for a bounded backfill (epoch / RFC3339 / relative duration); default is `operation=next` (restart-safe).
- An in-memory deduper guards the only re-delivery cases (iterator `resend` / `start_time` re-seed after restart).

## Registration

- `containers/conf/all.go` — import + `Netskope` field on `GeneralConfigs` (`json:"netskope"`).
- `containers/general/tool.go` — import + `method == "netskope"` dispatch branch.
- Root `README.md` + `netskope/README.md`.

## Testing

- `go build ./containers/general` ✅, `go vet ./netskope/...` ✅, `gofmt` clean ✅
- `go test ./netskope/...` ✅ — a faithful `httptest` mock of the iterator (cursor / epoch-seed / resend semantics, `Netskope-Api-Token` auth, `{"ok":1,"result":[...],"wait_time":N}` envelope) drives end-to-end tests for shipping fidelity (verbatim payload + parsed timestamp), multi-page walking, multi-feed tagging, dedup, `start_time` seeding, transient-error retry, and bad-token handling, plus unit tests for config validation, envelope parsing, base-URL/start-time/index helpers and transient-error classification.
- **Not yet live-verified** against a real Netskope tenant (no tenant credentials available). The mock is built from the official docs + SDK; a few response-shape details (exact field inventories for some streams) are noted for live validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)