### PR TITLE
Add Cortex XSOAR adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ be added purely through configuration. See [threatlocker/README.md](./threatlock
 ./general threatlocker client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=threatlocker api_key=$THREATLOCKER_API_TOKEN instance=g
 ```
 
+### Cortex XSOAR
+
+Pulls incidents from the Palo Alto Networks Cortex XSOAR (formerly Demisto)
+"search incidents by filter" API. Works against both Cortex XSOAR 6 (on-prem)
+and 8 (cloud); collection is incremental by the incident `modified` time. See
+[cortex_xsoar/README.md](./cortex_xsoar/README.md).
+
+```
+./general cortex_xsoar client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=cortex_xsoar url=$XSOAR_URL api_key=$XSOAR_API_KEY
+```
+
 ### Gmail
 
 Collects incoming email as telemetry from one or many Gmail mailboxes via the

--- a/containers/conf/all.go
+++ b/containers/conf/all.go
@@ -8,6 +8,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/bitwarden"
 	"github.com/refractionPOINT/usp-adapters/box"
 	"github.com/refractionPOINT/usp-adapters/cato"
+	"github.com/refractionPOINT/usp-adapters/cortex_xsoar"
 	"github.com/refractionPOINT/usp-adapters/cylance"
 	"github.com/refractionPOINT/usp-adapters/defender"
 	"github.com/refractionPOINT/usp-adapters/duo"
@@ -62,6 +63,7 @@ type GeneralConfigs struct {
 	EntraID           usp_entraid.EntraIDConfig                       `json:"entraid" yaml:"entraid"`
 	Defender          usp_defender.DefenderConfig                     `json:"defender" yaml:"defender"`
 	Cato              usp_cato.CatoConfig                             `json:"cato" yaml:"cato"`
+	CortexXSOAR       usp_cortex_xsoar.XSOARConfig                    `json:"cortex_xsoar" yaml:"cortex_xsoar"`
 	Cylance           usp_cylance.CylanceConfig                       `json:"cylance" yaml:"cylance"`
 	Okta              usp_okta.OktaConfig                             `json:"okta" yaml:"okta"`
 	Office365         usp_o365.Office365Config                        `json:"office365" yaml:"office365"`

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -22,6 +22,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/bitwarden"
 	"github.com/refractionPOINT/usp-adapters/box"
 	"github.com/refractionPOINT/usp-adapters/cato"
+	"github.com/refractionPOINT/usp-adapters/cortex_xsoar"
 	"github.com/refractionPOINT/usp-adapters/cylance"
 	"github.com/refractionPOINT/usp-adapters/defender"
 	"github.com/refractionPOINT/usp-adapters/duo"
@@ -510,6 +511,11 @@ func runAdapter(ctx context.Context, method string, configs Configuration, showC
 		configs.ThreatLocker.ClientOptions.Architecture = "usp_adapter"
 		configToShow = configs.ThreatLocker
 		client, chRunning, err = usp_threatlocker.NewThreatLockerAdapter(ctx, configs.ThreatLocker)
+	} else if method == "cortex_xsoar" {
+		configs.CortexXSOAR.ClientOptions = applyLogging(configs.CortexXSOAR.ClientOptions)
+		configs.CortexXSOAR.ClientOptions.Architecture = "usp_adapter"
+		configToShow = configs.CortexXSOAR
+		client, chRunning, err = usp_cortex_xsoar.NewXSOARAdapter(ctx, configs.CortexXSOAR)
 	} else {
 		return nil, nil, errors.New(logError("unknown adapter_type: %s", method))
 	}

--- a/cortex_xsoar/README.md
+++ b/cortex_xsoar/README.md
@@ -1,0 +1,179 @@
+# Cortex XSOAR adapter
+
+Pulls **incidents** from Palo Alto Networks [Cortex XSOAR](https://www.paloaltonetworks.com/cortex/cortex-xsoar)
+(formerly Demisto) into LimaCharlie. Incidents are shipped verbatim, in their
+original XSOAR JSON form; LimaCharlie does field parsing and mapping in the cloud.
+
+The same adapter works against both **Cortex XSOAR 6** (on-prem) and **Cortex
+XSOAR 8** (cloud) — the request and response shapes are identical, only the API
+path prefix and the authentication headers differ, both selected from
+configuration.
+
+API references this is built against:
+
+- Search incidents by filter (`POST /incidents/search`) — the [demisto-py SDK
+  swagger](https://github.com/demisto/demisto-py/blob/master/server_api_swagger.json)
+  (`searchIncidents`, `SearchIncidentsData`, `IncidentFilter`, `Order`) and the
+  [`SearchIncidentsV2` content script](https://github.com/demisto/content/blob/master/Packs/CommonScripts/Scripts/SearchIncidentsV2/README.md)
+  (sample incident payload).
+- API keys & authentication — [Cortex XSOAR 8 "Get started with APIs"](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSOAR/8/Cortex-XSOAR-Administrator-Guide/Get-Started-with-APIs)
+  and the [demisto-py auth client](https://github.com/demisto/demisto-py/blob/master/demisto_client/__init__.py)
+  (standard vs. advanced key headers; the advanced-key signing scheme).
+
+## Authentication
+
+Create an API key under **Settings → Integrations → API Keys**. XSOAR offers two
+key security levels, and the cloud (v8) product additionally requires the key's
+numeric **ID**:
+
+| Key type / version | `Authorization` | `x-xdr-auth-id` | Signed (`x-xdr-nonce`, `x-xdr-timestamp`) |
+|---|---|---|---|
+| Standard, XSOAR 6 | the raw API key | — | — |
+| Standard, XSOAR 8 | the raw API key | the key's ID | — |
+| Advanced, either version | SHA-256 hex of `apiKey + nonce + timestamp` | the key's ID | yes |
+
+- **Standard** keys send the key verbatim in the `Authorization` header.
+- **Advanced** keys are signed per-request: the adapter sends a random 64-char
+  nonce and a millisecond timestamp, and `Authorization` carries the lowercase
+  hex SHA-256 of `apiKey + nonce + timestamp` (plain SHA-256, not HMAC). The
+  server re-validates this against its clock, so **the adapter host's clock must
+  be in sync** or requests are rejected with HTTP 401.
+
+Set `advanced: true` for an advanced key, and supply `api_key_id` for XSOAR 8 and
+for any advanced key. The `api_key_id` is the **ID** column shown next to the key
+in the API Keys table.
+
+## Configuration
+
+| Key | Required | Default | Description |
+|---|---|---|---|
+| `url` | yes | — | XSOAR server base URL. v6: the server root (`https://xsoar.example.com`). v8: the host from the API key's **Copy URL** action (`https://api-<tenant>...paloaltonetworks.com`); the `/xsoar/public/v1` path is added automatically. |
+| `api_key` | yes | — | The API key value. |
+| `api_key_id` | for v8 / advanced | — | The numeric key ID (`x-xdr-auth-id`). Required for XSOAR 8 and for advanced keys; ignored for an XSOAR 6 standard key. |
+| `api_version` | no | `6` | `6` (endpoints at the server root) or `8` (endpoints under `/xsoar/public/v1`). |
+| `advanced` | no | `false` | Use the advanced (signed) API-key scheme. Requires `api_key_id`. |
+| `query` | no | — | Lucene filter ANDed with the modified-time cursor every poll, e.g. `type:Phishing and severity:>=2`. Empty collects every incident. |
+| `event_type` | no | `incident` | The `EventType` stamped on every shipped message. |
+| `timestamp_field` | no | `modified` | Incident field used as the event time. `modified` timestamps each shipped version at its update; set to `created` or `occurred` for the incident's birth/occurrence time. |
+| `initial_lookback` | no | `24h` | How far back the first poll reaches. Later polls continue from the cursor. |
+| `page_size` | no | `100` | Incidents per page. Capped at `1000` by XSOAR. |
+| `poll_interval` | no | `1m` | Wait between polls. |
+| `max_pages` | no | `200` | Per-poll page cap, bounding a first poll against a large backlog. |
+| `dedupe_ttl` | no | `168h` (7d) | How long an incident version is remembered to suppress re-shipping across overlapping polls. |
+| `insecure_skip_verify` | no | `false` | Disable TLS verification. Only for on-prem v6 behind a self-signed certificate. |
+| `base_path` | no | — | Override the API path prefix (escape hatch for non-standard deployments). |
+| `retry_base_delay` / `max_retry_delay` / `max_retry_attempts` | no | `5s` / `30s` / `3` | Transient-failure retry tuning. |
+
+## How it works
+
+- **Endpoint.** Each poll issues `POST {url}[/xsoar/public/v1]/incidents/search`
+  with a `filter` carrying the query, an ascending sort on `modified`, and
+  0-indexed `page` / `size`. The response envelope is `{"data": [...], "total": N}`.
+- **Incremental by `modified`.** The adapter keeps a high-water cursor on the
+  incident `modified` time. Each poll queries `modified:>="<cursor>"` (sorted
+  ascending) and advances the cursor to the newest `modified` seen. Because an
+  incident's `modified` time changes whenever it is updated (re-opened,
+  re-assigned, a note added, …), **updated incidents are re-collected** — so the
+  platform sees the incident's evolution, not just its creation.
+- **Exactly-once per version.** Deduplication is keyed on `id` + `modified`, so a
+  re-fetched boundary incident or an unchanged re-poll is suppressed, while a
+  genuine update (new `modified`) ships again as a new version. The first poll's
+  reach is bounded by `initial_lookback`.
+- **Pagination.** Pages are walked until a short page or the reported `total` is
+  reached, bounded by `max_pages` (a warning is emitted if the cap is hit; the
+  remainder is collected on later polls as the cursor advances).
+- **Errors.** Source-side failures (4xx/5xx, auth rejection, network blips,
+  malformed responses) are logged as warnings and the poll is skipped and retried
+  next interval — they never stop the adapter (a restart cannot fix a bad key or
+  an unreachable instance). 5xx and 429 are retried with exponential backoff.
+  Only a failure delivering to LimaCharlie is fatal.
+
+XSOAR publishes no numeric rate limit for this endpoint; the adapter still honors
+a `429 Too Many Requests` with backoff if the instance returns one.
+
+## What the data looks like
+
+Each shipped event is a full XSOAR incident object. Notable fields: `id` (stable
+identifier), `modified` / `created` / `occurred` (RFC 3339 times; an unset time
+such as `closed` on an open incident is the Go zero-time `0001-01-01T00:00:00Z`),
+`severity` and `status` as **numbers** (severity 0–4, status 0 Pending / 1 Active
+/ 2 Closed / 3 Archive), `name`, `type`, `owner`, `labels`, and `CustomFields`.
+
+```json
+{
+  "id": "978",
+  "version": 7,
+  "name": "Suspicious login - case 978",
+  "type": "Phishing",
+  "severity": 3,
+  "status": 1,
+  "owner": "analyst1",
+  "created": "2026-05-21T13:45:30.162034Z",
+  "modified": "2026-05-21T13:50:05.001Z",
+  "occurred": "2026-05-21T13:45:30.162034Z",
+  "closed": "0001-01-01T00:00:00Z",
+  "labels": [{ "type": "Email/from", "value": "attacker@evil.example" }],
+  "CustomFields": { "sourceip": "203.0.113.10", "verdict": "malicious" },
+  "sourceBrand": "Mail Listener v2",
+  "investigationId": "978"
+}
+```
+
+## Run examples
+
+XSOAR 6 (on-prem), standard key:
+
+```
+./general cortex_xsoar \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=json \
+  client_options.sensor_seed_key=cortex_xsoar \
+  url=https://xsoar.example.com \
+  api_key=$XSOAR_API_KEY
+```
+
+XSOAR 8 (cloud), standard key with an auth ID:
+
+```
+./general cortex_xsoar \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=json \
+  client_options.sensor_seed_key=cortex_xsoar \
+  url=https://api-your-tenant.xdr.us.paloaltonetworks.com \
+  api_version=8 \
+  api_key=$XSOAR_API_KEY \
+  api_key_id=$XSOAR_API_KEY_ID
+```
+
+YAML (XSOAR 6 with an advanced key, collecting only medium+ incidents):
+
+```yaml
+cortex_xsoar:
+  url: https://xsoar.example.com
+  api_key: "<api-key>"
+  api_key_id: "42"
+  advanced: true
+  query: "severity:>=2"
+  poll_interval: 1m
+  client_options:
+    identity:
+      oid: "<oid>"
+      installation_key: "<installation-key>"
+    platform: json
+    sensor_seed_key: cortex_xsoar
+```
+
+## Testing
+
+```
+go test ./cortex_xsoar/...
+```
+
+The suite runs end-to-end against an in-memory mock of the XSOAR API that
+reproduces standard and advanced authentication, the `modified` filter and
+ascending sort, 0-indexed pagination, and the `{"data":[...],"total":N}`
+envelope. It has **not** yet been live-verified against a real Cortex XSOAR
+instance; the mock and fixtures mirror the documented API shapes (see the
+references above).

--- a/cortex_xsoar/api.go
+++ b/cortex_xsoar/api.go
@@ -1,0 +1,226 @@
+package usp_cortex_xsoar
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// HTTPError represents a non-2xx response from the Cortex XSOAR API. It carries
+// the status code so callers can classify the error (retry vs. give up) without
+// having to parse error strings.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	body := e.Body
+	if len(body) > 512 {
+		body = body[:512] + "..."
+	}
+	return fmt.Sprintf("unexpected status code %d for %q: %s", e.StatusCode, e.URL, body)
+}
+
+// isTransientError reports whether an error is worth retrying.
+//
+// Transient (retry):
+//   - HTTP 5xx server errors
+//   - HTTP 429 Too Many Requests (XSOAR publishes no numeric rate limit, but the
+//     standard throttling status is still honoured if the instance returns it)
+//   - network errors (timeouts, connection refused, DNS failures, ...)
+//
+// Permanent (do not retry):
+//   - HTTP 4xx other than 429 (bad request, auth failure, not found, ...). Note
+//     a 401 from an *advanced* key can also be host-clock skew (the signature is
+//     time-validated) -- still not worth retrying the same request, the operator
+//     must fix the clock.
+//   - context cancellation (intentional shutdown)
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 500 && httpErr.StatusCode <= 599 {
+			return true
+		}
+		if httpErr.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+		return false
+	}
+
+	// Context cancellation is an intentional shutdown, not a transient blip.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Anything that failed before we got a response (DNS, dial, timeout, ...) is
+	// reported by Do() and wrapped with this prefix; treat it as transient.
+	if strings.Contains(err.Error(), "failed to execute request") {
+		return true
+	}
+
+	return false
+}
+
+// XSOARClient is a thin wrapper around the Cortex XSOAR REST API. It knows how to
+// authenticate (standard or advanced API keys, for both XSOAR 6 and 8) and how
+// to POST a JSON body to an endpoint relative to the resolved API root.
+//
+// The same request shapes serve XSOAR 6 (on-prem, endpoints at the server root)
+// and XSOAR 8 (cloud, endpoints under /xsoar/public/v1); only the base URL and
+// the presence of the x-xdr-auth-id header differ, both captured at construction.
+type XSOARClient struct {
+	baseURL    string
+	apiKey     string
+	apiKeyID   string
+	advanced   bool
+	httpClient *http.Client
+}
+
+// NewXSOARClient builds a client. baseURL is the fully-resolved API root
+// (including the /xsoar/public/v1 prefix for XSOAR 8). apiKeyID is the numeric
+// key ID surfaced in the XSOAR API Keys table; it is required for XSOAR 8 and for
+// advanced keys, and ignored for an XSOAR 6 standard key. When advanced is true
+// the request is signed with the Cortex SHA-256 scheme.
+func NewXSOARClient(baseURL, apiKey, apiKeyID string, advanced, insecure bool) *XSOARClient {
+	transport := &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: 10 * time.Second,
+		}).Dial,
+	}
+	if insecure {
+		// On-prem XSOAR 6 instances are frequently fronted by a self-signed
+		// certificate; allow operators to opt out of verification explicitly.
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	return &XSOARClient{
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		apiKey:   apiKey,
+		apiKeyID: apiKeyID,
+		advanced: advanced,
+		httpClient: &http.Client{
+			Timeout:   90 * time.Second,
+			Transport: transport,
+		},
+	}
+}
+
+// Post issues a POST to the given API path with a JSON body and returns the raw
+// response body. A non-2xx response is returned as an *HTTPError.
+func (c *XSOARClient) Post(ctx context.Context, path string, body interface{}) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %v", err)
+	}
+
+	url := c.baseURL + "/" + strings.TrimPrefix(path, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request %q: %v", url, err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if err := c.setAuthHeaders(req); err != nil {
+		return nil, fmt.Errorf("failed to build auth headers: %v", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request %q: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response %q: %v", url, err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, &HTTPError{
+			StatusCode: resp.StatusCode,
+			URL:        url,
+			Body:       string(respBody),
+		}
+	}
+
+	return respBody, nil
+}
+
+// setAuthHeaders applies the right authentication headers for the configured key.
+//
+// Standard key (XSOAR 6): the raw key in the Authorization header, nothing else.
+// Standard key (XSOAR 8): the same, plus x-xdr-auth-id carrying the key's ID.
+// Advanced key (either version): the Cortex signed scheme -- a random nonce and a
+// millisecond timestamp are sent in x-xdr-nonce / x-xdr-timestamp, the key ID in
+// x-xdr-auth-id, and Authorization carries the lowercase hex SHA-256 digest of
+// apiKey + nonce + timestamp (plain SHA-256, not HMAC). The server recomputes the
+// same digest to verify the request, which is why an advanced key is sensitive to
+// the caller's clock.
+func (c *XSOARClient) setAuthHeaders(req *http.Request) error {
+	if !c.advanced {
+		req.Header.Set("Authorization", c.apiKey)
+		if c.apiKeyID != "" {
+			req.Header.Set("x-xdr-auth-id", c.apiKeyID)
+		}
+		return nil
+	}
+
+	nonce, err := newNonce(64)
+	if err != nil {
+		return err
+	}
+	timestamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	req.Header.Set("x-xdr-timestamp", timestamp)
+	req.Header.Set("x-xdr-nonce", nonce)
+	req.Header.Set("x-xdr-auth-id", c.apiKeyID)
+	req.Header.Set("Authorization", signAdvanced(c.apiKey, nonce, timestamp))
+	return nil
+}
+
+// signAdvanced computes the advanced-key Authorization value: the lowercase hex
+// SHA-256 of the concatenation apiKey + nonce + timestamp, in that exact order.
+func signAdvanced(apiKey, nonce, timestamp string) string {
+	sum := sha256.Sum256([]byte(apiKey + nonce + timestamp))
+	return hex.EncodeToString(sum[:])
+}
+
+const nonceAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// newNonce returns a cryptographically-random alphanumeric string of length n,
+// matching the nonce shape the Cortex SDK generates for advanced keys.
+func newNonce(n int) (string, error) {
+	b := make([]byte, n)
+	max := big.NewInt(int64(len(nonceAlphabet)))
+	for i := range b {
+		idx, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", fmt.Errorf("nonce generation failed: %v", err)
+		}
+		b[i] = nonceAlphabet[idx.Int64()]
+	}
+	return string(b), nil
+}
+
+// Close releases idle connections held by the underlying transport.
+func (c *XSOARClient) Close() {
+	c.httpClient.CloseIdleConnections()
+}

--- a/cortex_xsoar/client.go
+++ b/cortex_xsoar/client.go
@@ -1,0 +1,678 @@
+// Package usp_cortex_xsoar implements a USP adapter for Palo Alto Networks
+// Cortex XSOAR (formerly Demisto). It polls the "search incidents by filter"
+// endpoint and ships each incident to LimaCharlie in its original XSOAR JSON
+// form; the adapter does not reshape payloads.
+//
+// The same code serves both Cortex XSOAR 6 (on-prem) and Cortex XSOAR 8 (cloud):
+// the request and response shapes are identical, only the base path
+// (/xsoar/public/v1 on v8) and the authentication headers differ, both selected
+// from configuration. See README.md for the API references this is built against.
+//
+// Incremental collection is by the incident "modified" time: each poll fetches
+// incidents modified at or after a high-water cursor, sorted ascending, and
+// advances the cursor to the newest "modified" seen. Because an incident's
+// "modified" time changes whenever it is updated (re-opened, re-assigned, a new
+// note added, ...), updated incidents are re-collected -- deduplication is keyed
+// on id+modified so each distinct version ships exactly once.
+package usp_cortex_xsoar
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	defaultPageSize         = 100
+	maxPageSize             = 1000 // XSOAR caps a search page at 1000 records.
+	defaultPollInterval     = 1 * time.Minute
+	defaultDedupeTTL        = 7 * 24 * time.Hour
+	dedupeBucketWindow      = 1 * time.Hour
+	defaultMaxPages         = 200
+	defaultInitialLookback  = 24 * time.Hour
+	defaultEventType        = "incident"
+	defaultTimestampField   = "modified"
+	defaultMaxRetryAttempts = 3
+	defaultRetryBaseDelay   = 5 * time.Second
+	defaultMaxRetryDelay    = 30 * time.Second
+
+	// searchIncidentsPath is the endpoint, relative to the resolved API root, that
+	// searches incidents by filter. It is the same on XSOAR 6 and 8; the v8
+	// /xsoar/public/v1 prefix is folded into the resolved base URL.
+	searchIncidentsPath = "incidents/search"
+
+	// cursorLayout is the time format used to render the modified-time cursor into
+	// the Lucene query. XSOAR accepts RFC 3339 / ISO-8601; second precision with a
+	// Z suffix is unambiguous and avoids fractional-second quoting concerns.
+	cursorLayout = "2006-01-02T15:04:05Z"
+
+	shipTimeout = 10 * time.Second
+)
+
+// idFields are the fields probed, in order, for a stable per-incident identifier
+// used for deduplication. XSOAR incidents carry "id"; the others are defensive.
+var idFields = []string{"id", "investigationId", "_id"}
+
+// timestampLayouts are the formats accepted for an incident time field. XSOAR
+// serializes Go time.Time values: RFC 3339 with a variable number of fractional
+// digits and either a Z or a numeric offset (e.g. "2020-09-29T17:29:44.162034+03:00"
+// or "2022-04-27T08:37:29.197107197Z"). RFC3339Nano covers both; the bare RFC3339
+// and offset-less forms are kept as fallbacks.
+var timestampLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05.999999999",
+	"2006-01-02T15:04:05",
+}
+
+// XSOARConfig is the adapter configuration.
+type XSOARConfig struct {
+	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+	// URL is the XSOAR server base URL.
+	//   - XSOAR 6 (on-prem): the server root, e.g. "https://xsoar.example.com".
+	//   - XSOAR 8 (cloud): the host shown by the API key's "Copy URL" action,
+	//     e.g. "https://api-your-tenant.xdr.us.paloaltonetworks.com". The
+	//     /xsoar/public/v1 path is added automatically when api_version is "8".
+	URL string `json:"url" yaml:"url"`
+
+	// APIKey is the API key value (Settings -> Integrations -> API Keys).
+	APIKey string `json:"api_key" yaml:"api_key"`
+
+	// APIKeyID is the numeric ID of the API key (the "ID" column in the API Keys
+	// table), sent as the x-xdr-auth-id header. Required for XSOAR 8 and for
+	// advanced keys; ignored for an XSOAR 6 standard key.
+	APIKeyID string `json:"api_key_id" yaml:"api_key_id"`
+
+	// APIVersion selects the API surface: "6" (default, endpoints at the server
+	// root) or "8" (endpoints under /xsoar/public/v1).
+	APIVersion string `json:"api_version" yaml:"api_version"`
+
+	// Advanced selects the advanced (signed) API key authentication scheme. Set
+	// this when the key was created as an Advanced key. Requires APIKeyID.
+	Advanced bool `json:"advanced" yaml:"advanced"`
+
+	// BasePath overrides the API path prefix added to URL. Empty means: derive
+	// from APIVersion ("/xsoar/public/v1" for "8", none for "6"). Provided as an
+	// escape hatch for non-standard deployments.
+	BasePath string `json:"base_path" yaml:"base_path"`
+
+	// Query is an optional Lucene filter ANDed with the modified-time cursor on
+	// every poll, e.g. `type:Phishing and severity:>=2` to collect only certain
+	// incidents. Empty means: collect every incident.
+	Query string `json:"query" yaml:"query"`
+
+	// EventType is the EventType stamped on every shipped message. Default
+	// "incident".
+	EventType string `json:"event_type" yaml:"event_type"`
+
+	// TimestampField is the incident field used as the event time. Default
+	// "modified" (so an updated incident is timestamped at its update). Set to
+	// "created" or "occurred" to use the incident's birth/occurrence time.
+	TimestampField string `json:"timestamp_field" yaml:"timestamp_field"`
+
+	// InitialLookback is how far back the first poll reaches. Subsequent polls
+	// continue from the cursor. Default 24h.
+	InitialLookback time.Duration `json:"initial_lookback" yaml:"initial_lookback"`
+
+	// PageSize is the number of incidents requested per page. Default 100, capped
+	// at 1000 by XSOAR.
+	PageSize int `json:"page_size" yaml:"page_size"`
+
+	// PollInterval is the wait between polls. Default 1 minute.
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+
+	// MaxPages caps how many pages are fetched per poll, bounding the work of a
+	// first poll against a large backlog. Default 200.
+	MaxPages int `json:"max_pages" yaml:"max_pages"`
+
+	// DedupeTTL is how long an incident version (id+modified) is remembered to
+	// suppress re-shipping it on subsequent overlapping polls. Default 7 days.
+	DedupeTTL time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
+
+	// InsecureSkipVerify disables TLS certificate verification. Only for on-prem
+	// XSOAR 6 instances behind a self-signed certificate; leave off otherwise.
+	InsecureSkipVerify bool `json:"insecure_skip_verify" yaml:"insecure_skip_verify"`
+
+	// Retry tuning for transient API failures.
+	RetryBaseDelay   time.Duration `json:"retry_base_delay" yaml:"retry_base_delay"`
+	MaxRetryDelay    time.Duration `json:"max_retry_delay" yaml:"max_retry_delay"`
+	MaxRetryAttempts int           `json:"max_retry_attempts" yaml:"max_retry_attempts"`
+
+	// Deduper, when set, replaces the built-in in-memory deduper. It is not
+	// settable through a config file; it exists as a seam for tests and for
+	// embedders that want to supply a shared deduper.
+	Deduper utils.Deduper `json:"-" yaml:"-"`
+}
+
+func (c *XSOARConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+	if c.APIKey == "" {
+		return errors.New("missing api_key")
+	}
+	c.URL = strings.TrimSpace(c.URL)
+	if c.URL == "" {
+		return errors.New("missing url")
+	}
+
+	c.APIVersion = strings.TrimSpace(c.APIVersion)
+	if c.APIVersion == "" {
+		c.APIVersion = "6"
+	}
+	if c.APIVersion != "6" && c.APIVersion != "8" {
+		return fmt.Errorf("unsupported api_version %q (expected \"6\" or \"8\")", c.APIVersion)
+	}
+	// XSOAR 8 always authenticates with an auth ID; an advanced key (either
+	// version) needs it to sign. Only an XSOAR 6 standard key may omit it.
+	if c.Advanced && c.APIKeyID == "" {
+		return errors.New("advanced api key requires api_key_id")
+	}
+	if c.APIVersion == "8" && c.APIKeyID == "" {
+		return errors.New("api_version 8 requires api_key_id (the x-xdr-auth-id of the API key)")
+	}
+
+	if c.EventType == "" {
+		c.EventType = defaultEventType
+	}
+	if c.TimestampField == "" {
+		c.TimestampField = defaultTimestampField
+	}
+	if c.PageSize <= 0 {
+		c.PageSize = defaultPageSize
+	}
+	if c.PageSize > maxPageSize {
+		c.PageSize = maxPageSize
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
+	if c.MaxPages <= 0 {
+		c.MaxPages = defaultMaxPages
+	}
+	if c.InitialLookback <= 0 {
+		c.InitialLookback = defaultInitialLookback
+	}
+	if c.DedupeTTL <= 0 {
+		c.DedupeTTL = defaultDedupeTTL
+	}
+	if c.RetryBaseDelay <= 0 {
+		c.RetryBaseDelay = defaultRetryBaseDelay
+	}
+	if c.MaxRetryDelay <= 0 {
+		c.MaxRetryDelay = defaultMaxRetryDelay
+	}
+	if c.MaxRetryAttempts <= 0 {
+		c.MaxRetryAttempts = defaultMaxRetryAttempts
+	}
+	return nil
+}
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
+// XSOARAdapter polls Cortex XSOAR incidents and ships them to LimaCharlie.
+type XSOARAdapter struct {
+	conf        XSOARConfig
+	uspClient   uspSink
+	client      *XSOARClient
+	deduper     utils.Deduper
+	ownsDeduper bool
+
+	// cursor is the modified-time high-water mark; only touched by the single
+	// poll goroutine, so it needs no synchronization.
+	cursor time.Time
+
+	chStopped chan struct{}
+	wg        sync.WaitGroup
+	doStop    *utils.Event
+
+	closeOnce sync.Once
+	closeErr  error
+
+	ctx context.Context
+}
+
+// NewXSOARAdapter creates a Cortex XSOAR adapter wired to LimaCharlie.
+func NewXSOARAdapter(ctx context.Context, conf XSOARConfig) (*XSOARAdapter, chan struct{}, error) {
+	return newXSOARAdapter(ctx, conf, nil)
+}
+
+// newXSOARAdapter is the implementation behind NewXSOARAdapter. When sink is
+// non-nil it is used in place of a real LimaCharlie client -- the seam tests use
+// to capture shipped events.
+func newXSOARAdapter(ctx context.Context, conf XSOARConfig, sink uspSink) (*XSOARAdapter, chan struct{}, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	a := &XSOARAdapter{
+		conf:   conf,
+		ctx:    ctx,
+		doStop: utils.NewEvent(),
+		cursor: time.Now().UTC().Add(-conf.InitialLookback),
+	}
+
+	// The modified-time window overlaps successive polls (>= cursor), and a live
+	// incident list can shift across page boundaries mid-poll, so a deduper is
+	// required to ship each incident version exactly once.
+	a.deduper = conf.Deduper
+	if a.deduper == nil {
+		window := dedupeBucketWindow
+		if window > conf.DedupeTTL {
+			window = conf.DedupeTTL
+		}
+		deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cortex_xsoar: deduper: %v", err)
+		}
+		a.deduper = deduper
+		a.ownsDeduper = true
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			if a.ownsDeduper {
+				a.deduper.Close()
+			}
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
+	}
+
+	a.client = NewXSOARClient(resolveBaseURL(conf), conf.APIKey, conf.APIKeyID, conf.Advanced, conf.InsecureSkipVerify)
+	a.chStopped = make(chan struct{})
+
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"cortex_xsoar: starting (api_version=%s base=%s)", conf.APIVersion, a.client.baseURL))
+	a.wg.Add(1)
+	go a.run()
+
+	go func() {
+		a.wg.Wait()
+		close(a.chStopped)
+	}()
+
+	return a, a.chStopped, nil
+}
+
+// Close stops the adapter. It is idempotent: repeated calls are no-ops and return
+// the result of the first call.
+func (a *XSOARAdapter) Close() error {
+	a.closeOnce.Do(func() {
+		a.conf.ClientOptions.DebugLog("cortex_xsoar: closing")
+		a.doStop.Set()
+		a.wg.Wait()
+		err1 := a.uspClient.Drain(1 * time.Minute)
+		_, err2 := a.uspClient.Close()
+		a.client.Close()
+		if a.ownsDeduper {
+			a.deduper.Close()
+		}
+		if err1 != nil {
+			a.closeErr = err1
+		} else {
+			a.closeErr = err2
+		}
+	})
+	return a.closeErr
+}
+
+// resolveBaseURL computes the API root from the config: the configured URL plus
+// the version-derived (or explicitly overridden) path prefix.
+func resolveBaseURL(conf XSOARConfig) string {
+	base := strings.TrimRight(strings.TrimSpace(conf.URL), "/")
+	prefix := strings.Trim(strings.TrimSpace(conf.BasePath), "/")
+	if conf.BasePath == "" && conf.APIVersion == "8" {
+		prefix = "xsoar/public/v1"
+	}
+	if prefix != "" {
+		base = base + "/" + prefix
+	}
+	return base
+}
+
+// run polls forever, until the adapter is asked to stop.
+func (a *XSOARAdapter) run() {
+	defer a.wg.Done()
+	defer a.conf.ClientOptions.DebugLog("cortex_xsoar: poll loop stopped")
+
+	isFirstRun := true
+	for isFirstRun || !a.doStop.WaitFor(a.conf.PollInterval) {
+		isFirstRun = false
+		a.poll()
+	}
+}
+
+// poll fetches incidents modified since the cursor, ships each new version, and
+// advances the cursor to the newest "modified" observed. Pages are walked until
+// the result set is exhausted (a short page, or the reported total is reached) or
+// MaxPages is hit. On any source-side error the poll is abandoned without
+// advancing the cursor, so the next interval retries from the same point.
+func (a *XSOARAdapter) poll() {
+	query := buildQuery(a.conf.Query, a.cursor)
+	maxModified := a.cursor
+	nSeen, nShipped, nCollected := 0, 0, 0
+
+	for page := 0; !a.doStop.IsSet(); page++ {
+		if page >= a.conf.MaxPages {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"cortex_xsoar: hit max_pages=%d; incidents past that are collected on a later poll "+
+					"as the cursor advances -- raise max_pages or narrow the query to catch up faster",
+				a.conf.MaxPages))
+			break
+		}
+
+		incidents, total, ok := a.fetchPage(query, page)
+		if !ok {
+			// The error has already been reported; abandon this poll (cursor
+			// unchanged) and try again on the next interval.
+			return
+		}
+		if len(incidents) == 0 {
+			break
+		}
+
+		for _, inc := range incidents {
+			nSeen++
+			if a.deduper.CheckAndAdd(a.dedupeKey(inc)) {
+				continue
+			}
+			if !a.ship(inc) {
+				return
+			}
+			nShipped++
+			if t, ok := incidentModified(inc); ok && t.After(maxModified) {
+				maxModified = t
+			}
+		}
+
+		nCollected += len(incidents)
+		// A short page is the end of the result set.
+		if len(incidents) < a.conf.PageSize {
+			break
+		}
+		// Or we have collected everything the server says matched.
+		if total > 0 && nCollected >= total {
+			break
+		}
+	}
+
+	// Advance the cursor forward only. Using the newest modified time seen (with a
+	// >= query and id+modified dedup) means same-millisecond boundary incidents
+	// are re-queried next poll but not re-shipped, so none are skipped.
+	if maxModified.After(a.cursor) {
+		a.cursor = maxModified
+	}
+
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"cortex_xsoar: poll complete (seen=%d shipped=%d cursor=%s)",
+		nSeen, nShipped, a.cursor.Format(cursorLayout)))
+}
+
+// fetchPage requests one page of incidents, retrying transient failures with
+// exponential backoff. The bool result is false when the poll should be abandoned
+// (any source-side error, or the adapter is stopping).
+//
+// Source-side errors (anything the XSOAR API returns: 4xx/5xx, auth failures,
+// network blips, malformed responses) are reported via OnWarning and NEVER stop
+// the adapter. This is deliberate: the cloud-sensor host treats any adapter
+// OnError as fatal to the instance -- it tears the adapter down, relaunches it,
+// and after enough failures disables it entirely. Restarting cannot fix a problem
+// on XSOAR's side (a revoked key, a clock-skewed advanced signature, an
+// unreachable instance), so we log, skip this poll, and let the next interval try
+// again; a fixed key or healed instance then recovers on its own. Only a failure
+// delivering to LimaCharlie (see ship) is fatal, since a relaunch reconnects the
+// backend.
+func (a *XSOARAdapter) fetchPage(query string, page int) ([]utils.Dict, int, bool) {
+	body := buildRequestBody(query, page, a.conf.PageSize)
+
+	var raw []byte
+	var err error
+	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
+		if a.doStop.IsSet() {
+			return nil, 0, false
+		}
+
+		raw, err = a.client.Post(a.ctx, searchIncidentsPath, body)
+		if err == nil {
+			break
+		}
+
+		if !isTransientError(err) {
+			msg := fmt.Sprintf("cortex_xsoar: incident search failed (skipping this poll): %v", err)
+			var httpErr *HTTPError
+			if errors.As(err, &httpErr) &&
+				(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
+				msg = fmt.Sprintf(
+					"cortex_xsoar: incident search rejected with HTTP %d. Verify the api_key (and "+
+						"api_key_id for XSOAR 8 / advanced keys), that the key's role has API access, "+
+						"and -- for an advanced key -- that this host's clock is in sync (the signature "+
+						"is time-validated).", httpErr.StatusCode)
+			}
+			a.conf.ClientOptions.OnWarning(msg)
+			return nil, 0, false
+		}
+
+		if attempt+1 >= a.conf.MaxRetryAttempts {
+			break
+		}
+		delay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
+		if delay > a.conf.MaxRetryDelay {
+			delay = a.conf.MaxRetryDelay
+		}
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"cortex_xsoar: transient error (attempt %d/%d), retrying in %v: %v",
+			attempt+1, a.conf.MaxRetryAttempts, delay, err))
+		if a.doStop.WaitFor(delay) {
+			return nil, 0, false
+		}
+	}
+	if err != nil {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"cortex_xsoar: incident search failed after %d attempts (skipping this poll): %v",
+			a.conf.MaxRetryAttempts, err))
+		return nil, 0, false
+	}
+
+	incidents, total, err := extractIncidents(raw)
+	if err != nil {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"cortex_xsoar: response parse error (skipping this poll): %v", err))
+		return nil, 0, false
+	}
+	return incidents, total, true
+}
+
+// ship forwards a single incident to LimaCharlie. It returns false if the adapter
+// should stop (an unrecoverable shipping error).
+func (a *XSOARAdapter) ship(inc utils.Dict) bool {
+	msg := &protocol.DataMessage{
+		JsonPayload: inc,
+		EventType:   a.conf.EventType,
+		TimestampMs: a.eventTime(inc),
+	}
+	if err := a.uspClient.Ship(msg, shipTimeout); err != nil {
+		if err == uspclient.ErrorBufferFull {
+			a.conf.ClientOptions.OnWarning("cortex_xsoar: stream falling behind")
+			err = a.uspClient.Ship(msg, 1*time.Hour)
+		}
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("cortex_xsoar: Ship(): %v", err))
+			a.doStop.Set()
+			return false
+		}
+	}
+	return true
+}
+
+// eventTime extracts the incident's event time from the configured field,
+// falling back to "modified" and then to now.
+func (a *XSOARAdapter) eventTime(inc utils.Dict) uint64 {
+	for _, field := range []string{a.conf.TimestampField, defaultTimestampField} {
+		if field == "" {
+			continue
+		}
+		if raw := inc.FindOneString(field); raw != "" {
+			if t, ok := parseTimestamp(raw); ok {
+				return uint64(t.UnixMilli())
+			}
+		}
+	}
+	return uint64(time.Now().UnixMilli())
+}
+
+// dedupeKey returns a stable deduplication key for an incident version. Keying on
+// id+modified means an incident ships once per distinct version: re-fetched
+// boundary records and unchanged re-polls are suppressed, but a genuine update
+// (which changes "modified") ships again.
+func (a *XSOARAdapter) dedupeKey(inc utils.Dict) string {
+	return incidentID(inc) + "|" + inc.FindOneString("modified")
+}
+
+// incidentModified parses an incident's "modified" time.
+func incidentModified(inc utils.Dict) (time.Time, bool) {
+	return parseTimestamp(inc.FindOneString("modified"))
+}
+
+// incidentID resolves an incident's identifier: the "id" field (string or
+// numeric), otherwise a probe of fallback fields, otherwise a content hash so
+// deduplication still works for a record with no recognizable identifier.
+func incidentID(inc utils.Dict) string {
+	for _, k := range idFields {
+		if id := fieldAsString(inc, k); id != "" {
+			return id
+		}
+	}
+	if b, err := json.Marshal(inc); err == nil {
+		sum := sha256.Sum256(b)
+		return "sha256:" + hex.EncodeToString(sum[:])
+	}
+	return ""
+}
+
+// fieldAsString reads a field as a string, accepting numeric values too (ids are
+// sometimes serialized as numbers).
+func fieldAsString(inc utils.Dict, path string) string {
+	if s := inc.FindOneString(path); s != "" {
+		return s
+	}
+	// FindInt returns every match at the path; a non-empty result means the field
+	// is present -- including a legitimate value of 0, which a string read cannot
+	// distinguish from "absent".
+	if ints := inc.FindInt(path); len(ints) > 0 {
+		return strconv.FormatUint(ints[0], 10)
+	}
+	return ""
+}
+
+// buildQuery assembles the Lucene query for one poll: incidents modified at or
+// after the cursor, ANDed with any operator-supplied filter.
+func buildQuery(userQuery string, cursor time.Time) string {
+	modifiedClause := fmt.Sprintf(`modified:>="%s"`, cursor.UTC().Format(cursorLayout))
+	userQuery = strings.TrimSpace(userQuery)
+	if userQuery == "" {
+		return modifiedClause
+	}
+	return fmt.Sprintf("(%s) and %s", userQuery, modifiedClause)
+}
+
+// buildRequestBody assembles the JSON body for a /incidents/search call: the
+// filter with the query, an ascending sort on "modified" (so the cursor advances
+// monotonically), and 0-indexed pagination.
+func buildRequestBody(query string, page, size int) utils.Dict {
+	return utils.Dict{
+		"filter": utils.Dict{
+			"query": query,
+			"sort": []utils.Dict{
+				{"field": "modified", "asc": true},
+			},
+			"page": page,
+			"size": size,
+		},
+	}
+}
+
+// extractIncidents parses a /incidents/search response into the incident slice
+// and the reported total. The documented envelope is {"data": [...], "total": N};
+// a bare array is also accepted defensively.
+func extractIncidents(raw []byte) ([]utils.Dict, int, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil, 0, nil
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var arr []json.RawMessage
+		if err := json.Unmarshal([]byte(trimmed), &arr); err != nil {
+			return nil, 0, fmt.Errorf("invalid JSON array: %v", err)
+		}
+		items := rawMessagesToDicts(arr)
+		return items, len(items), nil
+
+	case '{':
+		var obj struct {
+			Data  []json.RawMessage `json:"data"`
+			Total int               `json:"total"`
+		}
+		if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
+			return nil, 0, fmt.Errorf("invalid JSON object: %v", err)
+		}
+		return rawMessagesToDicts(obj.Data), obj.Total, nil
+
+	default:
+		return nil, 0, errors.New("response is neither a JSON array nor a JSON object")
+	}
+}
+
+// rawMessagesToDicts decodes each incident with utils.UnmarshalCleanJSON, which
+// preserves integer precision (no float coercion) so payloads round-trip
+// faithfully. A record that is not a non-empty JSON object is skipped rather than
+// failing the whole page -- one anomalous element should not block the rest.
+func rawMessagesToDicts(raw []json.RawMessage) []utils.Dict {
+	items := make([]utils.Dict, 0, len(raw))
+	for _, r := range raw {
+		m, err := utils.UnmarshalCleanJSON(string(r))
+		if err != nil || len(m) == 0 {
+			continue
+		}
+		items = append(items, utils.Dict(m))
+	}
+	return items
+}
+
+func parseTimestamp(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range timestampLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}

--- a/cortex_xsoar/client.go
+++ b/cortex_xsoar/client.go
@@ -362,6 +362,12 @@ func (a *XSOARAdapter) run() {
 	isFirstRun := true
 	for isFirstRun || !a.doStop.WaitFor(a.conf.PollInterval) {
 		isFirstRun = false
+		// Stop if the parent context is cancelled, not only on Close(): otherwise
+		// every poll would fail fast (context.Canceled is non-transient) and the
+		// loop would spin once per interval until Close() is eventually called.
+		if a.ctx.Err() != nil {
+			return
+		}
 		a.poll()
 	}
 }
@@ -385,13 +391,13 @@ func (a *XSOARAdapter) poll() {
 			break
 		}
 
-		incidents, total, ok := a.fetchPage(query, page)
+		incidents, total, pageLen, ok := a.fetchPage(query, page)
 		if !ok {
 			// The error has already been reported; abandon this poll (cursor
 			// unchanged) and try again on the next interval.
 			return
 		}
-		if len(incidents) == 0 {
+		if pageLen == 0 {
 			break
 		}
 
@@ -409,9 +415,12 @@ func (a *XSOARAdapter) poll() {
 			}
 		}
 
-		nCollected += len(incidents)
+		// Paginate on the raw page length (pageLen), not len(incidents): a record
+		// dropped as malformed must not make a full page look short and end the
+		// walk early.
+		nCollected += pageLen
 		// A short page is the end of the result set.
-		if len(incidents) < a.conf.PageSize {
+		if pageLen < a.conf.PageSize {
 			break
 		}
 		// Or we have collected everything the server says matched.
@@ -422,7 +431,14 @@ func (a *XSOARAdapter) poll() {
 
 	// Advance the cursor forward only. Using the newest modified time seen (with a
 	// >= query and id+modified dedup) means same-millisecond boundary incidents
-	// are re-queried next poll but not re-shipped, so none are skipped.
+	// are re-queried next poll but not re-shipped, so none are skipped. Cap at now:
+	// a single incident with a future-dated "modified" (clock skew, a bad record)
+	// must not jump the cursor ahead and starve collection of everything between
+	// now and that future time.
+	now := time.Now().UTC()
+	if maxModified.After(now) {
+		maxModified = now
+	}
 	if maxModified.After(a.cursor) {
 		a.cursor = maxModified
 	}
@@ -446,14 +462,14 @@ func (a *XSOARAdapter) poll() {
 // again; a fixed key or healed instance then recovers on its own. Only a failure
 // delivering to LimaCharlie (see ship) is fatal, since a relaunch reconnects the
 // backend.
-func (a *XSOARAdapter) fetchPage(query string, page int) ([]utils.Dict, int, bool) {
+func (a *XSOARAdapter) fetchPage(query string, page int) (incidents []utils.Dict, total, pageLen int, ok bool) {
 	body := buildRequestBody(query, page, a.conf.PageSize)
 
 	var raw []byte
 	var err error
 	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
 		if a.doStop.IsSet() {
-			return nil, 0, false
+			return nil, 0, 0, false
 		}
 
 		raw, err = a.client.Post(a.ctx, searchIncidentsPath, body)
@@ -473,7 +489,7 @@ func (a *XSOARAdapter) fetchPage(query string, page int) ([]utils.Dict, int, boo
 						"is time-validated).", httpErr.StatusCode)
 			}
 			a.conf.ClientOptions.OnWarning(msg)
-			return nil, 0, false
+			return nil, 0, 0, false
 		}
 
 		if attempt+1 >= a.conf.MaxRetryAttempts {
@@ -487,23 +503,23 @@ func (a *XSOARAdapter) fetchPage(query string, page int) ([]utils.Dict, int, boo
 			"cortex_xsoar: transient error (attempt %d/%d), retrying in %v: %v",
 			attempt+1, a.conf.MaxRetryAttempts, delay, err))
 		if a.doStop.WaitFor(delay) {
-			return nil, 0, false
+			return nil, 0, 0, false
 		}
 	}
 	if err != nil {
 		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
 			"cortex_xsoar: incident search failed after %d attempts (skipping this poll): %v",
 			a.conf.MaxRetryAttempts, err))
-		return nil, 0, false
+		return nil, 0, 0, false
 	}
 
-	incidents, total, err := extractIncidents(raw)
+	incidents, total, pageLen, err = extractIncidents(raw)
 	if err != nil {
 		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
 			"cortex_xsoar: response parse error (skipping this poll): %v", err))
-		return nil, 0, false
+		return nil, 0, 0, false
 	}
-	return incidents, total, true
+	return incidents, total, pageLen, true
 }
 
 // ship forwards a single incident to LimaCharlie. It returns false if the adapter
@@ -615,23 +631,29 @@ func buildRequestBody(query string, page, size int) utils.Dict {
 	}
 }
 
-// extractIncidents parses a /incidents/search response into the incident slice
-// and the reported total. The documented envelope is {"data": [...], "total": N};
-// a bare array is also accepted defensively.
-func extractIncidents(raw []byte) ([]utils.Dict, int, error) {
+// extractIncidents parses a /incidents/search response into the incident slice,
+// the reported total, and the number of raw records in the page. The documented
+// envelope is {"data": [...], "total": N}; a bare array is also accepted
+// defensively.
+//
+// pageLen is the count of records the server returned, BEFORE any are dropped as
+// malformed. The caller paginates on pageLen (not len(incidents)) so a single
+// unparseable record on an otherwise-full page does not look like a short page
+// and prematurely end the walk.
+func extractIncidents(raw []byte) (items []utils.Dict, total, pageLen int, err error) {
 	trimmed := strings.TrimSpace(string(raw))
 	if trimmed == "" {
-		return nil, 0, nil
+		return nil, 0, 0, nil
 	}
 
 	switch trimmed[0] {
 	case '[':
 		var arr []json.RawMessage
 		if err := json.Unmarshal([]byte(trimmed), &arr); err != nil {
-			return nil, 0, fmt.Errorf("invalid JSON array: %v", err)
+			return nil, 0, 0, fmt.Errorf("invalid JSON array: %v", err)
 		}
 		items := rawMessagesToDicts(arr)
-		return items, len(items), nil
+		return items, len(arr), len(arr), nil
 
 	case '{':
 		var obj struct {
@@ -639,12 +661,12 @@ func extractIncidents(raw []byte) ([]utils.Dict, int, error) {
 			Total int               `json:"total"`
 		}
 		if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
-			return nil, 0, fmt.Errorf("invalid JSON object: %v", err)
+			return nil, 0, 0, fmt.Errorf("invalid JSON object: %v", err)
 		}
-		return rawMessagesToDicts(obj.Data), obj.Total, nil
+		return rawMessagesToDicts(obj.Data), obj.Total, len(obj.Data), nil
 
 	default:
-		return nil, 0, errors.New("response is neither a JSON array nor a JSON object")
+		return nil, 0, 0, errors.New("response is neither a JSON array nor a JSON object")
 	}
 }
 

--- a/cortex_xsoar/client_test.go
+++ b/cortex_xsoar/client_test.go
@@ -1,0 +1,344 @@
+package usp_cortex_xsoar
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	t.Run("requires api_key", func(t *testing.T) {
+		c := XSOARConfig{ClientOptions: testClientOptions(t), URL: "https://x"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("requires url", func(t *testing.T) {
+		c := XSOARConfig{ClientOptions: testClientOptions(t), APIKey: "k"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("applies defaults", func(t *testing.T) {
+		c := XSOARConfig{ClientOptions: testClientOptions(t), APIKey: "k", URL: "https://x"}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, "6", c.APIVersion)
+		assert.Equal(t, defaultEventType, c.EventType)
+		assert.Equal(t, defaultTimestampField, c.TimestampField)
+		assert.Equal(t, defaultPageSize, c.PageSize)
+		assert.Equal(t, defaultPollInterval, c.PollInterval)
+		assert.Equal(t, defaultMaxPages, c.MaxPages)
+		assert.Equal(t, defaultInitialLookback, c.InitialLookback)
+		assert.Equal(t, defaultDedupeTTL, c.DedupeTTL)
+		assert.Equal(t, defaultMaxRetryAttempts, c.MaxRetryAttempts)
+	})
+
+	t.Run("caps page size at the XSOAR maximum", func(t *testing.T) {
+		c := XSOARConfig{ClientOptions: testClientOptions(t), APIKey: "k", URL: "https://x", PageSize: 5000}
+		require.NoError(t, c.Validate())
+		assert.Equal(t, maxPageSize, c.PageSize)
+	})
+
+	t.Run("rejects an unsupported api_version", func(t *testing.T) {
+		c := XSOARConfig{ClientOptions: testClientOptions(t), APIKey: "k", URL: "https://x", APIVersion: "7"}
+		assert.Error(t, c.Validate())
+	})
+
+	t.Run("api_version 8 requires api_key_id", func(t *testing.T) {
+		c := XSOARConfig{ClientOptions: testClientOptions(t), APIKey: "k", URL: "https://x", APIVersion: "8"}
+		assert.Error(t, c.Validate())
+
+		c.APIKeyID = "42"
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("advanced key requires api_key_id", func(t *testing.T) {
+		c := XSOARConfig{ClientOptions: testClientOptions(t), APIKey: "k", URL: "https://x", Advanced: true}
+		assert.Error(t, c.Validate())
+
+		c.APIKeyID = "42"
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("api_version 6 standard key needs no api_key_id", func(t *testing.T) {
+		c := XSOARConfig{ClientOptions: testClientOptions(t), APIKey: "k", URL: "https://x", APIVersion: "6"}
+		assert.NoError(t, c.Validate())
+	})
+}
+
+func TestResolveBaseURL(t *testing.T) {
+	t.Run("v6 has no path prefix", func(t *testing.T) {
+		assert.Equal(t, "https://xsoar.example.com",
+			resolveBaseURL(XSOARConfig{URL: "https://xsoar.example.com/", APIVersion: "6"}))
+	})
+
+	t.Run("v8 adds the public api prefix", func(t *testing.T) {
+		assert.Equal(t, "https://api-tenant.example.com/xsoar/public/v1",
+			resolveBaseURL(XSOARConfig{URL: "https://api-tenant.example.com", APIVersion: "8"}))
+	})
+
+	t.Run("base_path overrides the version default", func(t *testing.T) {
+		assert.Equal(t, "https://xsoar.example.com/custom/api",
+			resolveBaseURL(XSOARConfig{URL: "https://xsoar.example.com", APIVersion: "8", BasePath: "/custom/api/"}))
+	})
+}
+
+func TestBuildQuery(t *testing.T) {
+	cursor := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("modified clause only when no user query", func(t *testing.T) {
+		assert.Equal(t, `modified:>="2026-06-01T00:00:00Z"`, buildQuery("", cursor))
+	})
+
+	t.Run("user query is ANDed with the modified clause", func(t *testing.T) {
+		assert.Equal(t,
+			`(type:Phishing and severity:>=2) and modified:>="2026-06-01T00:00:00Z"`,
+			buildQuery("type:Phishing and severity:>=2", cursor))
+	})
+
+	t.Run("cursor is rendered in UTC", func(t *testing.T) {
+		loc := time.FixedZone("UTC+3", 3*60*60)
+		assert.Equal(t, `modified:>="2026-06-01T00:00:00Z"`,
+			buildQuery("", cursor.In(loc)))
+	})
+}
+
+func TestBuildRequestBody(t *testing.T) {
+	body := buildRequestBody(`modified:>="2026-06-01T00:00:00Z"`, 2, 100)
+	filter, ok := body["filter"].(utils.Dict)
+	require.True(t, ok, "body must carry a filter object")
+
+	assert.Equal(t, `modified:>="2026-06-01T00:00:00Z"`, filter["query"])
+	assert.Equal(t, 2, filter["page"], "page must be 0-indexed as passed")
+	assert.Equal(t, 100, filter["size"])
+
+	sort, ok := filter["sort"].([]utils.Dict)
+	require.True(t, ok, "sort must be a list of order objects")
+	require.Len(t, sort, 1)
+	assert.Equal(t, "modified", sort[0]["field"])
+	assert.Equal(t, true, sort[0]["asc"], "ascending sort keeps the cursor monotonic")
+}
+
+func TestExtractIncidents(t *testing.T) {
+	t.Run("documented envelope with total", func(t *testing.T) {
+		items, total, err := extractIncidents([]byte(`{"data":[{"id":"1"},{"id":"2"}],"total":57}`))
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, 57, total)
+		assert.Equal(t, "1", items[0].FindOneString("id"))
+	})
+
+	t.Run("empty data array", func(t *testing.T) {
+		items, total, err := extractIncidents([]byte(`{"data":[],"total":0}`))
+		require.NoError(t, err)
+		assert.Empty(t, items)
+		assert.Equal(t, 0, total)
+	})
+
+	t.Run("bare array fallback", func(t *testing.T) {
+		items, total, err := extractIncidents([]byte(`[{"id":"1"}]`))
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.Equal(t, 1, total)
+	})
+
+	t.Run("empty body yields nothing", func(t *testing.T) {
+		items, total, err := extractIncidents([]byte("   "))
+		require.NoError(t, err)
+		assert.Empty(t, items)
+		assert.Equal(t, 0, total)
+	})
+
+	t.Run("non-json errors", func(t *testing.T) {
+		_, _, err := extractIncidents([]byte(`not json`))
+		assert.Error(t, err)
+	})
+
+	t.Run("large integers keep precision", func(t *testing.T) {
+		items, _, err := extractIncidents([]byte(`{"data":[{"autime":1601389784162034000}],"total":1}`))
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		v, ok := items[0].GetInt("autime")
+		require.True(t, ok)
+		assert.Equal(t, uint64(1601389784162034000), v)
+	})
+
+	t.Run("non-object records are skipped, valid ones kept", func(t *testing.T) {
+		items, _, err := extractIncidents([]byte(`{"data":[{"id":"a"},"junk",123,null,{"id":"b"}],"total":5}`))
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, "a", items[0].FindOneString("id"))
+		assert.Equal(t, "b", items[1].FindOneString("id"))
+	})
+}
+
+func TestIncidentID(t *testing.T) {
+	t.Run("uses the id field", func(t *testing.T) {
+		assert.Equal(t, "978", incidentID(utils.Dict{"id": "978", "investigationId": "other"}))
+	})
+
+	t.Run("accepts a numeric id", func(t *testing.T) {
+		assert.Equal(t, "978", incidentID(utils.Dict{"id": uint64(978)}))
+	})
+
+	t.Run("accepts a numeric id of zero", func(t *testing.T) {
+		assert.Equal(t, "0", incidentID(utils.Dict{"id": uint64(0)}))
+	})
+
+	t.Run("falls back to investigationId", func(t *testing.T) {
+		assert.Equal(t, "inv-1", incidentID(utils.Dict{"investigationId": "inv-1"}))
+	})
+
+	t.Run("content hash fallback is stable and distinct", func(t *testing.T) {
+		a1 := incidentID(utils.Dict{"foo": "bar"})
+		a2 := incidentID(utils.Dict{"foo": "bar"})
+		b := incidentID(utils.Dict{"foo": "baz"})
+		assert.Equal(t, a1, a2)
+		assert.NotEqual(t, a1, b)
+		assert.Contains(t, a1, "sha256:")
+	})
+}
+
+func TestDedupeKey(t *testing.T) {
+	a := &XSOARAdapter{}
+	// Same incident, different modified -> different keys (an update re-ships).
+	k1 := a.dedupeKey(utils.Dict{"id": "1", "modified": "2026-05-21T10:00:00Z"})
+	k2 := a.dedupeKey(utils.Dict{"id": "1", "modified": "2026-05-21T11:00:00Z"})
+	assert.NotEqual(t, k1, k2)
+	// Same id and modified -> same key (a re-fetch is suppressed).
+	k3 := a.dedupeKey(utils.Dict{"id": "1", "modified": "2026-05-21T10:00:00Z"})
+	assert.Equal(t, k1, k3)
+}
+
+func TestEventTime(t *testing.T) {
+	now := uint64(time.Now().UnixMilli())
+
+	t.Run("uses the configured field", func(t *testing.T) {
+		a := &XSOARAdapter{conf: XSOARConfig{TimestampField: "created"}}
+		inc := utils.Dict{"created": "2026-05-21T13:45:30Z", "modified": "2026-05-21T14:00:00Z"}
+		ts, _ := parseTimestamp("2026-05-21T13:45:30Z")
+		assert.Equal(t, uint64(ts.UnixMilli()), a.eventTime(inc))
+	})
+
+	t.Run("falls back to modified when the field is absent", func(t *testing.T) {
+		a := &XSOARAdapter{conf: XSOARConfig{TimestampField: "created"}}
+		inc := utils.Dict{"modified": "2026-05-21T14:00:00Z"}
+		ts, _ := parseTimestamp("2026-05-21T14:00:00Z")
+		assert.Equal(t, uint64(ts.UnixMilli()), a.eventTime(inc))
+	})
+
+	t.Run("falls back to now when nothing parses", func(t *testing.T) {
+		a := &XSOARAdapter{conf: XSOARConfig{TimestampField: "created"}}
+		assert.GreaterOrEqual(t, a.eventTime(utils.Dict{"created": "not-a-date"}), now)
+	})
+}
+
+func TestParseTimestamp(t *testing.T) {
+	cases := []string{
+		"2026-05-21T12:00:00Z",
+		"2026-05-21T12:00:00.123456Z",      // microseconds + Z
+		"2022-04-27T08:37:29.197107197Z",   // nanoseconds + Z (RFC3339Nano)
+		"2020-09-29T17:29:44.162034+03:00", // microseconds + numeric offset
+		"0001-01-01T00:00:00Z",             // Go zero-time sentinel
+		"2026-05-21T12:00:00",              // offset-less fallback
+	}
+	for _, c := range cases {
+		_, ok := parseTimestamp(c)
+		assert.True(t, ok, "expected %q to parse", c)
+	}
+	_, ok := parseTimestamp("not a date")
+	assert.False(t, ok)
+	_, ok = parseTimestamp("")
+	assert.False(t, ok)
+}
+
+func TestSignAdvanced(t *testing.T) {
+	// The advanced signature is a plain SHA-256 hex of apiKey+nonce+timestamp.
+	apiKey, nonce, ts := "secret", "abc123", "1700000000000"
+	expected := sha256.Sum256([]byte(apiKey + nonce + ts))
+	assert.Equal(t, hex.EncodeToString(expected[:]), signAdvanced(apiKey, nonce, ts))
+}
+
+func TestNewNonce(t *testing.T) {
+	n, err := newNonce(64)
+	require.NoError(t, err)
+	assert.Len(t, n, 64)
+	for _, r := range n {
+		assert.True(t, strings.ContainsRune(nonceAlphabet, r), "nonce char %q must be alphanumeric", r)
+	}
+	// Two nonces must differ (cryptographically random).
+	other, err := newNonce(64)
+	require.NoError(t, err)
+	assert.NotEqual(t, n, other)
+}
+
+func TestSetAuthHeaders(t *testing.T) {
+	newReq := func() *http.Request {
+		r, err := http.NewRequest(http.MethodPost, "https://x/incidents/search", nil)
+		require.NoError(t, err)
+		return r
+	}
+
+	t.Run("standard v6: only Authorization", func(t *testing.T) {
+		c := NewXSOARClient("https://x", "the-key", "", false, false)
+		r := newReq()
+		require.NoError(t, c.setAuthHeaders(r))
+		assert.Equal(t, "the-key", r.Header.Get("Authorization"))
+		assert.Empty(t, r.Header.Get("x-xdr-auth-id"))
+		assert.Empty(t, r.Header.Get("x-xdr-nonce"))
+	})
+
+	t.Run("standard v8: Authorization plus x-xdr-auth-id", func(t *testing.T) {
+		c := NewXSOARClient("https://x", "the-key", "77", false, false)
+		r := newReq()
+		require.NoError(t, c.setAuthHeaders(r))
+		assert.Equal(t, "the-key", r.Header.Get("Authorization"))
+		assert.Equal(t, "77", r.Header.Get("x-xdr-auth-id"))
+		assert.Empty(t, r.Header.Get("x-xdr-nonce"), "a standard key is not signed")
+	})
+
+	t.Run("advanced: signed headers verify against the scheme", func(t *testing.T) {
+		c := NewXSOARClient("https://x", "the-key", "42", true, false)
+		r := newReq()
+		require.NoError(t, c.setAuthHeaders(r))
+
+		ts := r.Header.Get("x-xdr-timestamp")
+		nonce := r.Header.Get("x-xdr-nonce")
+		assert.NotEmpty(t, ts)
+		assert.Len(t, nonce, 64)
+		assert.Equal(t, "42", r.Header.Get("x-xdr-auth-id"))
+		assert.Equal(t, signAdvanced("the-key", nonce, ts), r.Header.Get("Authorization"),
+			"Authorization must be SHA-256(apiKey+nonce+timestamp)")
+	})
+}
+
+func TestIsTransientError(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		isTransient bool
+	}{
+		{"500", &HTTPError{StatusCode: 500}, true},
+		{"503", &HTTPError{StatusCode: 503}, true},
+		{"429", &HTTPError{StatusCode: 429}, true},
+		{"401", &HTTPError{StatusCode: 401}, false},
+		{"403", &HTTPError{StatusCode: 403}, false},
+		{"404", &HTTPError{StatusCode: 404}, false},
+		{"400", &HTTPError{StatusCode: 400}, false},
+		{"network", fmt.Errorf("failed to execute request %q: connection refused", "x"), true},
+		{"context canceled", context.Canceled, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.isTransient, isTransientError(c.err))
+		})
+	}
+}

--- a/cortex_xsoar/client_test.go
+++ b/cortex_xsoar/client_test.go
@@ -128,41 +128,45 @@ func TestBuildRequestBody(t *testing.T) {
 
 func TestExtractIncidents(t *testing.T) {
 	t.Run("documented envelope with total", func(t *testing.T) {
-		items, total, err := extractIncidents([]byte(`{"data":[{"id":"1"},{"id":"2"}],"total":57}`))
+		items, total, pageLen, err := extractIncidents([]byte(`{"data":[{"id":"1"},{"id":"2"}],"total":57}`))
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		assert.Equal(t, 57, total)
+		assert.Equal(t, 2, pageLen)
 		assert.Equal(t, "1", items[0].FindOneString("id"))
 	})
 
 	t.Run("empty data array", func(t *testing.T) {
-		items, total, err := extractIncidents([]byte(`{"data":[],"total":0}`))
+		items, total, pageLen, err := extractIncidents([]byte(`{"data":[],"total":0}`))
 		require.NoError(t, err)
 		assert.Empty(t, items)
 		assert.Equal(t, 0, total)
+		assert.Equal(t, 0, pageLen)
 	})
 
 	t.Run("bare array fallback", func(t *testing.T) {
-		items, total, err := extractIncidents([]byte(`[{"id":"1"}]`))
+		items, total, pageLen, err := extractIncidents([]byte(`[{"id":"1"}]`))
 		require.NoError(t, err)
 		require.Len(t, items, 1)
 		assert.Equal(t, 1, total)
+		assert.Equal(t, 1, pageLen)
 	})
 
 	t.Run("empty body yields nothing", func(t *testing.T) {
-		items, total, err := extractIncidents([]byte("   "))
+		items, total, pageLen, err := extractIncidents([]byte("   "))
 		require.NoError(t, err)
 		assert.Empty(t, items)
 		assert.Equal(t, 0, total)
+		assert.Equal(t, 0, pageLen)
 	})
 
 	t.Run("non-json errors", func(t *testing.T) {
-		_, _, err := extractIncidents([]byte(`not json`))
+		_, _, _, err := extractIncidents([]byte(`not json`))
 		assert.Error(t, err)
 	})
 
 	t.Run("large integers keep precision", func(t *testing.T) {
-		items, _, err := extractIncidents([]byte(`{"data":[{"autime":1601389784162034000}],"total":1}`))
+		items, _, _, err := extractIncidents([]byte(`{"data":[{"autime":1601389784162034000}],"total":1}`))
 		require.NoError(t, err)
 		require.Len(t, items, 1)
 		v, ok := items[0].GetInt("autime")
@@ -170,10 +174,15 @@ func TestExtractIncidents(t *testing.T) {
 		assert.Equal(t, uint64(1601389784162034000), v)
 	})
 
-	t.Run("non-object records are skipped, valid ones kept", func(t *testing.T) {
-		items, _, err := extractIncidents([]byte(`{"data":[{"id":"a"},"junk",123,null,{"id":"b"}],"total":5}`))
+	t.Run("non-object records are skipped but counted in pageLen", func(t *testing.T) {
+		// pageLen reflects the raw record count (5), so a dropped record does not
+		// make a full page look short and end pagination early; len(items) is the
+		// kept count (2).
+		items, total, pageLen, err := extractIncidents([]byte(`{"data":[{"id":"a"},"junk",123,null,{"id":"b"}],"total":5}`))
 		require.NoError(t, err)
 		require.Len(t, items, 2)
+		assert.Equal(t, 5, pageLen, "pageLen must count raw records, not just the kept ones")
+		assert.Equal(t, 5, total)
 		assert.Equal(t, "a", items[0].FindOneString("id"))
 		assert.Equal(t, "b", items[1].FindOneString("id"))
 	})

--- a/cortex_xsoar/mock_test.go
+++ b/cortex_xsoar/mock_test.go
@@ -590,6 +590,110 @@ func TestMockXSOAR8PathAndAuthID(t *testing.T) {
 	assert.Equal(t, keyID, mock.lastAuth, "XSOAR 8 requests must carry x-xdr-auth-id")
 }
 
+// TestMockPaginationNotTruncatedByMalformedRecord verifies that a malformed
+// (non-object) record on an otherwise-full page does not make the page look
+// short and end the walk early: pagination continues and every valid incident on
+// later pages still ships. Regression test for paginating on the raw page length.
+func TestMockPaginationNotTruncatedByMalformedRecord(t *testing.T) {
+	const apiKey = "k"
+	// page_size 3. Page 0 carries 3 raw records but one is junk (2 kept); without
+	// raw-length pagination the 2 kept would look like a short page and stop the
+	// walk, dropping pages 1+.
+	inc := func(id, modified string) string { return mustJSON(t, realisticIncident(id, modified)) }
+	pages := map[int]string{
+		0: fmt.Sprintf(`{"data":[%s,"junk-not-an-object",%s],"total":5}`,
+			inc("a", "2026-05-21T10:00:00Z"), inc("b", "2026-05-21T10:01:00Z")),
+		1: fmt.Sprintf(`{"data":[%s,%s,%s],"total":5}`,
+			inc("c", "2026-05-21T10:02:00Z"), inc("d", "2026-05-21T10:03:00Z"), inc("e", "2026-05-21T10:04:00Z")),
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != apiKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		body := decodeRequestBody(t, r)
+		filter, _ := body["filter"].(map[string]interface{})
+		page := 0
+		if v, ok := filter["page"].(float64); ok {
+			page = int(v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if resp, ok := pages[page]; ok {
+			_, _ = io.WriteString(w, resp)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[],"total":5}`)
+	}))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := baseConf(t, server.URL, apiKey)
+	conf.PageSize = 3
+	adapter, _, err := newXSOARAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// All 5 valid incidents (across both pages) must ship; the junk record on the
+	// full first page must not have ended the walk.
+	require.Eventually(t, func() bool { return sink.count() == 5 },
+		5*time.Second, 20*time.Millisecond, "all valid incidents across pages should ship despite a malformed record")
+	require.Never(t, func() bool { return sink.count() != 5 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[payload(msg).FindOneString("id")] = true
+	}
+	assert.Equal(t, map[string]bool{"a": true, "b": true, "c": true, "d": true, "e": true}, ids)
+}
+
+// TestMockFutureDatedIncidentDoesNotStallCursor verifies the cursor is capped at
+// "now": a single incident with a far-future "modified" must not jump the cursor
+// ahead and starve collection of normal incidents that arrive afterward.
+func TestMockFutureDatedIncidentDoesNotStallCursor(t *testing.T) {
+	const apiKey = "k"
+
+	mock := newMockXSOAR(apiKey)
+	// A bad/clock-skewed incident dated a year in the future.
+	mock.setIncidents([]utils.Dict{
+		realisticIncident("future", time.Now().UTC().Add(365*24*time.Hour).Format(time.RFC3339)),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newXSOARAdapter(ctx, baseConf(t, server.URL, apiKey), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "the future-dated incident ships once")
+
+	// A normal incident arrives shortly after, dated slightly ahead of now (but
+	// far before the future one). With the cursor capped at now it is collected;
+	// without the cap the cursor would sit a year ahead and this would be skipped.
+	mock.appendIncident(realisticIncident("normal", time.Now().UTC().Add(10*time.Minute).Format(time.RFC3339)))
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "a normal incident must still be collected after a future-dated one")
+	require.Never(t, func() bool { return sink.count() > 2 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[payload(msg).FindOneString("id")] = true
+	}
+	assert.Equal(t, map[string]bool{"future": true, "normal": true}, ids)
+}
+
 // TestMockRejectsBadKey verifies the adapter warns, ships nothing, and does NOT
 // stop when the API rejects the key. A rejected key is a source-side problem a
 // restart cannot fix, so the adapter must stay up and retry (an operator fixing

--- a/cortex_xsoar/mock_test.go
+++ b/cortex_xsoar/mock_test.go
@@ -1,0 +1,633 @@
+package usp_cortex_xsoar
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock Cortex XSOAR API that
+// reproduces the real contract: API-key auth (standard and advanced), the
+// /incidents/search filter/sort/pagination, and the {"data":[...],"total":N}
+// envelope. It captures the exact messages shipped so their content -- event
+// type, timestamp and verbatim payload -- can be asserted.
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Cortex XSOAR API --------------------------------------------------
+
+var modifiedClauseRe = regexp.MustCompile(`modified:>="([^"]+)"`)
+
+// mockXSOAR is an in-memory stand-in for the Cortex XSOAR REST API. It honours
+// the /incidents/search contract: authenticates the way the real API does,
+// filters the dataset by the modified-time clause in the query, sorts ascending
+// on modified, paginates by 0-based page/size, and returns {"data":[...],"total":N}.
+type mockXSOAR struct {
+	mu        sync.Mutex
+	apiKey    string
+	apiKeyID  string
+	advanced  bool
+	incidents []utils.Dict
+	requests  int
+	lastPath  string
+	lastAuth  string // x-xdr-auth-id of the most recent request
+}
+
+func newMockXSOAR(apiKey string) *mockXSOAR {
+	return &mockXSOAR{apiKey: apiKey}
+}
+
+func (m *mockXSOAR) setIncidents(incs []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.incidents = incs
+}
+
+// appendIncident adds (or, when an incident with the same id exists, replaces) an
+// incident, as the real API would when an incident is created or updated.
+func (m *mockXSOAR) appendIncident(inc utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id := inc.FindOneString("id")
+	for i := range m.incidents {
+		if m.incidents[i].FindOneString("id") == id {
+			m.incidents[i] = inc
+			return
+		}
+	}
+	m.incidents = append(m.incidents, inc)
+}
+
+func (m *mockXSOAR) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.requests
+}
+
+func (m *mockXSOAR) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.requests++
+		m.lastPath = r.URL.Path
+		m.lastAuth = r.Header.Get("x-xdr-auth-id")
+		m.mu.Unlock()
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if !strings.HasSuffix(r.URL.Path, "/incidents/search") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		if !m.authOK(r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"Authorization failed"}`))
+			return
+		}
+
+		body := decodeRequestBody(t, r)
+		filter, _ := body["filter"].(map[string]interface{})
+		query, _ := filter["query"].(string)
+		page := 0
+		if v, ok := filter["page"].(float64); ok {
+			page = int(v)
+		}
+		size := defaultPageSize
+		if v, ok := filter["size"].(float64); ok && v > 0 {
+			size = int(v)
+		}
+
+		matched := m.matching(query)
+
+		var pageItems []utils.Dict
+		if start := page * size; start < len(matched) {
+			end := start + size
+			if end > len(matched) {
+				end = len(matched)
+			}
+			pageItems = matched[start:end]
+		}
+		if pageItems == nil {
+			pageItems = []utils.Dict{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":  pageItems,
+			"total": len(matched),
+		})
+	}
+}
+
+// authOK reproduces XSOAR's authentication checks for the configured key type.
+func (m *mockXSOAR) authOK(r *http.Request) bool {
+	if m.advanced {
+		ts := r.Header.Get("x-xdr-timestamp")
+		nonce := r.Header.Get("x-xdr-nonce")
+		authID := r.Header.Get("x-xdr-auth-id")
+		got := r.Header.Get("Authorization")
+		if ts == "" || nonce == "" || authID != m.apiKeyID {
+			return false
+		}
+		return got == signAdvanced(m.apiKey, nonce, ts)
+	}
+	return r.Header.Get("Authorization") == m.apiKey
+}
+
+// matching returns the incidents satisfying the query's modified clause, sorted
+// ascending by modified -- exactly what the adapter requests.
+func (m *mockXSOAR) matching(query string) []utils.Dict {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var since time.Time
+	if mm := modifiedClauseRe.FindStringSubmatch(query); mm != nil {
+		since, _ = parseTimestamp(mm[1])
+	}
+
+	out := make([]utils.Dict, 0, len(m.incidents))
+	for _, inc := range m.incidents {
+		mt, ok := incidentModified(inc)
+		if !ok {
+			continue
+		}
+		if !since.IsZero() && mt.Before(since) {
+			continue
+		}
+		out = append(out, inc)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		ti, _ := incidentModified(out[i])
+		tj, _ := incidentModified(out[j])
+		return ti.Before(tj)
+	})
+	return out
+}
+
+// --- realistic fixture ------------------------------------------------------
+
+// realisticIncident returns a record shaped like a real Cortex XSOAR incident:
+// the documented top-level fields with numeric severity/status, RFC3339 times
+// (fractional seconds and a Go zero-time for an unset "closed"), a labels array,
+// the capitalized CustomFields/ShardID keys, and a large integer autime to prove
+// integer precision is preserved.
+func realisticIncident(id, modified string) utils.Dict {
+	return utils.Dict{
+		"id":              id,
+		"version":         7,
+		"name":            "Suspicious login - case " + id,
+		"type":            "Phishing",
+		"severity":        3,
+		"status":          1,
+		"owner":           "analyst1",
+		"created":         "2026-05-21T13:45:30.162034Z",
+		"modified":        modified,
+		"occurred":        "2026-05-21T13:45:30.162034Z",
+		"closed":          "0001-01-01T00:00:00Z",
+		"category":        "",
+		"labels":          []interface{}{utils.Dict{"type": "Email/from", "value": "attacker@evil.example"}},
+		"CustomFields":    utils.Dict{"sourceip": "203.0.113.10", "verdict": "malicious"},
+		"rawJSON":         "",
+		"sourceBrand":     "Mail Listener v2",
+		"sourceInstance":  "EWS_O365_instance",
+		"investigationId": id,
+		"playbookId":      "Phishing Investigation - Generic v2",
+		"autime":          1601389784162034000,
+		"ShardID":         0,
+	}
+}
+
+// payload views a shipped message's JSON payload as a utils.Dict so the same
+// field helpers used in the adapter can be used in assertions.
+func payload(msg *protocol.DataMessage) utils.Dict {
+	return utils.Dict(msg.JsonPayload)
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// decodeRequestBody decodes a JSON request body. It runs inside httptest handler
+// goroutines, so it must not use require (whose FailNow/Goexit is only valid on
+// the test goroutine); assert reports failures safely from any goroutine.
+func decodeRequestBody(t *testing.T, r *http.Request) map[string]interface{} {
+	t.Helper()
+	m := map[string]interface{}{}
+	body, err := io.ReadAll(r.Body)
+	if !assert.NoError(t, err) {
+		return m
+	}
+	assert.NoError(t, json.Unmarshal(body, &m))
+	return m
+}
+
+// baseConf returns a config pointed at the mock server, with a long lookback so
+// fixtures dated in 2026 are inside the first poll's window, and a fast poll.
+func baseConf(t *testing.T, serverURL, apiKey string) XSOARConfig {
+	return XSOARConfig{
+		ClientOptions:   testClientOptions(t),
+		URL:             serverURL,
+		APIKey:          apiKey,
+		InitialLookback: 3650 * 24 * time.Hour,
+		PollInterval:    40 * time.Millisecond,
+	}
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestMockSearchIncidentsEndToEnd drives the adapter against the mock API and
+// asserts the exact events shipped: event type, timestamp parsed from "modified",
+// and the payload preserved verbatim (nested objects and arrays included).
+func TestMockSearchIncidentsEndToEnd(t *testing.T) {
+	const apiKey = "xsoar-api-key-xyz"
+
+	mock := newMockXSOAR(apiKey)
+	want := []utils.Dict{
+		realisticIncident("101", "2026-05-21T13:45:30.162034Z"),
+		realisticIncident("102", "2026-05-21T13:50:05.001Z"),
+		realisticIncident("103", "2026-05-21T14:02:11.9Z"),
+	}
+	mock.setIncidents(want)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newXSOARAdapter(ctx, baseConf(t, server.URL, apiKey), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 incidents to ship")
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "incidents were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		assert.Equal(t, "incident", msg.EventType)
+		require.NotNil(t, msg.JsonPayload)
+		byID[payload(msg).FindOneString("id")] = msg
+	}
+	require.Len(t, byID, 3)
+
+	for _, src := range want {
+		id := src["id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "incident %s was not shipped", id)
+
+		// The event time is parsed from the incident's modified field.
+		ts, ok := parseTimestamp(src["modified"].(string))
+		require.True(t, ok)
+		assert.Equal(t, uint64(ts.UnixMilli()), msg.TimestampMs,
+			"event time should come from the incident's modified field")
+
+		// The payload is shipped verbatim -- nested objects and arrays included.
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original XSOAR incident")
+	}
+}
+
+// TestMockNewIncidentShippedOnce verifies an incident that appears mid-run is
+// shipped exactly once, and already-shipped incidents are never re-sent.
+func TestMockNewIncidentShippedOnce(t *testing.T) {
+	const apiKey = "k"
+
+	mock := newMockXSOAR(apiKey)
+	mock.setIncidents([]utils.Dict{
+		realisticIncident("a", "2026-05-21T10:00:00Z"),
+		realisticIncident("b", "2026-05-21T10:01:00Z"),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newXSOARAdapter(ctx, baseConf(t, server.URL, apiKey), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new incident appears, with a modified time after the current cursor.
+	mock.appendIncident(realisticIncident("c", "2026-05-21T10:05:00Z"))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new incident should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[payload(msg).FindOneString("id")]++
+	}
+	assert.Equal(t, map[string]int{"a": 1, "b": 1, "c": 1}, shippedPerID,
+		"every incident must ship exactly once")
+}
+
+// TestMockUpdatedIncidentReshipped verifies that when an incident is updated (its
+// modified time advances) the new version is re-collected, while the unchanged
+// version is not re-shipped. Deduplication is on id+modified.
+func TestMockUpdatedIncidentReshipped(t *testing.T) {
+	const apiKey = "k"
+
+	mock := newMockXSOAR(apiKey)
+	mock.setIncidents([]utils.Dict{
+		realisticIncident("evt-1", "2026-05-21T10:00:00Z"),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	adapter, _, err := newXSOARAdapter(ctx, baseConf(t, server.URL, apiKey), sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond)
+
+	// The same incident is updated: same id, newer modified time.
+	updated := realisticIncident("evt-1", "2026-05-21T10:07:30Z")
+	updated["status"] = 2 // closed
+	mock.appendIncident(updated)
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "the updated version should re-ship")
+	require.Never(t, func() bool { return sink.count() > 2 },
+		300*time.Millisecond, 30*time.Millisecond, "only the two distinct versions should ship")
+
+	versions := sink.snapshot()
+	require.Len(t, versions, 2)
+	// Both carry the same id; the second reflects the update.
+	for _, msg := range versions {
+		assert.Equal(t, "evt-1", payload(msg).FindOneString("id"))
+	}
+	statuses := map[uint64]bool{}
+	for _, msg := range versions {
+		if v, ok := payload(msg).GetInt("status"); ok {
+			statuses[v] = true
+		}
+	}
+	assert.True(t, statuses[1] && statuses[2], "should have shipped both the open and the closed version, got %v", statuses)
+}
+
+// TestMockPaginationFullDataset verifies a dataset larger than one page is walked
+// completely and every incident is shipped exactly once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const apiKey = "k"
+	const total = 250
+
+	mock := newMockXSOAR(apiKey)
+	records := make([]utils.Dict, total)
+	for i := 0; i < total; i++ {
+		records[i] = realisticIncident(
+			fmt.Sprintf("inc-%03d", i),
+			time.Date(2026, 5, 21, 0, 0, 0, i*int(time.Millisecond), time.UTC).Format(time.RFC3339Nano))
+	}
+	mock.setIncidents(records)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conf := baseConf(t, server.URL, apiKey)
+	conf.PageSize = 100 // 250 incidents => 3 pages
+	conf.PollInterval = 50 * time.Millisecond
+	adapter, _, err := newXSOARAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 25*time.Millisecond, "all paginated incidents should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[payload(msg).FindOneString("id")] = true
+	}
+	assert.Len(t, ids, total, "every distinct incident should be shipped once")
+}
+
+// TestMockCursorWindowExcludesOld verifies the modified-time cursor scopes the
+// first poll: an incident older than initial_lookback is not collected, a recent
+// one is.
+func TestMockCursorWindowExcludesOld(t *testing.T) {
+	const apiKey = "k"
+
+	mock := newMockXSOAR(apiKey)
+	now := time.Now().UTC()
+	mock.setIncidents([]utils.Dict{
+		realisticIncident("old", now.Add(-48*time.Hour).Format(time.RFC3339)),
+		realisticIncident("recent", now.Add(-10*time.Minute).Format(time.RFC3339)),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := baseConf(t, server.URL, apiKey)
+	conf.InitialLookback = 1 * time.Hour // old (-48h) is outside, recent (-10m) is inside
+	adapter, _, err := newXSOARAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond, "only the recent incident should ship")
+	require.Never(t, func() bool { return sink.count() != 1 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	assert.Equal(t, "recent", payload(sink.snapshot()[0]).FindOneString("id"))
+}
+
+// TestMockAdvancedKeyAuth verifies the advanced (signed) API key scheme: the
+// adapter sends the x-xdr-* headers and a valid SHA-256 signature the mock
+// accepts, and incidents flow.
+func TestMockAdvancedKeyAuth(t *testing.T) {
+	const apiKey = "advanced-secret"
+	const keyID = "42"
+
+	mock := newMockXSOAR(apiKey)
+	mock.advanced = true
+	mock.apiKeyID = keyID
+	mock.setIncidents([]utils.Dict{
+		realisticIncident("x", "2026-05-21T10:00:00Z"),
+		realisticIncident("y", "2026-05-21T10:01:00Z"),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := baseConf(t, server.URL, apiKey)
+	conf.APIKeyID = keyID
+	conf.Advanced = true
+	adapter, _, err := newXSOARAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond, "advanced-key requests should authenticate and ship")
+}
+
+// TestMockXSOAR8PathAndAuthID verifies that for api_version 8 the adapter targets
+// the /xsoar/public/v1 prefix and sends the x-xdr-auth-id header.
+func TestMockXSOAR8PathAndAuthID(t *testing.T) {
+	const apiKey = "k8"
+	const keyID = "99"
+
+	mock := newMockXSOAR(apiKey)
+	mock.setIncidents([]utils.Dict{realisticIncident("v8", "2026-05-21T10:00:00Z")})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := baseConf(t, server.URL, apiKey)
+	conf.APIVersion = "8"
+	conf.APIKeyID = keyID
+	adapter, _, err := newXSOARAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 20*time.Millisecond)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	assert.Equal(t, "/xsoar/public/v1/incidents/search", mock.lastPath,
+		"XSOAR 8 requests must target the /xsoar/public/v1 prefix")
+	assert.Equal(t, keyID, mock.lastAuth, "XSOAR 8 requests must carry x-xdr-auth-id")
+}
+
+// TestMockRejectsBadKey verifies the adapter warns, ships nothing, and does NOT
+// stop when the API rejects the key. A rejected key is a source-side problem a
+// restart cannot fix, so the adapter must stay up and retry (an operator fixing
+// the key should see it recover on its own) rather than letting the cloud-sensor
+// host tear it down and eventually disable it.
+func TestMockRejectsBadKey(t *testing.T) {
+	mock := newMockXSOAR("correct-key")
+	mock.setIncidents([]utils.Dict{realisticIncident("a", "2026-05-21T10:00:00Z")})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var warnings, fatalErrors atomic.Int32
+	opts := testClientOptions(t)
+	opts.OnWarning = func(msg string) { warnings.Add(1); t.Logf("WRN: %s", msg) }
+	opts.OnError = func(err error) { fatalErrors.Add(1); t.Logf("ERR: %v", err) }
+
+	conf := baseConf(t, server.URL, "wrong-key")
+	conf.ClientOptions = opts
+	conf.PollInterval = 50 * time.Millisecond
+	adapter, chStopped, err := newXSOARAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return warnings.Load() > 0 },
+		3*time.Second, 20*time.Millisecond, "expected a warning when the key is rejected")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter must not stop when the API rejects the key")
+	case <-time.After(300 * time.Millisecond):
+	}
+	assert.False(t, adapter.doStop.IsSet(), "doStop must not be set on a rejected key")
+	assert.Equal(t, int32(0), fatalErrors.Load(), "a rejected key must warn, not fatally error")
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	assert.GreaterOrEqual(t, mock.requestCount(), 1, "the adapter should have called the API")
+}


### PR DESCRIPTION
## What

Adds a USP adapter that ingests **incidents** from Palo Alto Networks **Cortex XSOAR** (formerly Demisto) into LimaCharlie. Incidents are shipped verbatim (LimaCharlie parses/maps in the cloud). Closes the XSOAR connectivity gap — XSOAR had no existing adapter or extension.

Works against **both Cortex XSOAR 6 (on-prem) and 8 (cloud)** — the request/response shapes are identical; only the API path prefix (`/xsoar/public/v1` on v8) and the auth headers differ, both selected from config.

## API

Built entirely from the official/SDK-sourced API shapes (no live instance available to me):

- **Endpoint:** `POST /incidents/search` — [demisto-py swagger](https://github.com/demisto/demisto-py/blob/master/server_api_swagger.json) (`searchIncidents`, `SearchIncidentsData`, `IncidentFilter`, `Order`); sample payload from [`SearchIncidentsV2`](https://github.com/demisto/content/blob/master/Packs/CommonScripts/Scripts/SearchIncidentsV2/README.md).
- **Auth:** standard key (`Authorization: <key>`), XSOAR 8 adds `x-xdr-auth-id`; advanced key is signed — `Authorization = sha256hex(apiKey + nonce + timestamp)` with `x-xdr-nonce` / `x-xdr-timestamp` / `x-xdr-auth-id` (plain SHA-256, not HMAC). Per the [demisto-py auth client](https://github.com/demisto/demisto-py/blob/master/demisto_client/__init__.py) and [XSOAR 8 API docs](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSOAR/8/Cortex-XSOAR-Administrator-Guide/Get-Started-with-APIs).

## How it works

- **Incremental by `modified` time** with a high-water cursor (`modified:>="<cursor>"`, ascending sort). Updated/reopened incidents are re-collected so the platform sees the incident's evolution.
- **Exactly-once per version:** dedup keyed on `id` + `modified` (re-fetched boundary records and unchanged re-polls suppressed; genuine updates re-ship). First poll bounded by `initial_lookback`.
- **Pagination:** 0-indexed `page`/`size` over `{"data":[...],"total":N}`, walked to a short page / `total`, capped by `max_pages`.
- **Errors:** source-side failures are non-fatal warnings (skip + retry next poll, matching the cloud-sensor host's restart semantics); 5xx/429 retried with backoff. Only failures delivering to LimaCharlie are fatal.

## Testing

`go test ./cortex_xsoar/...` — passes (also `-race`). End-to-end against an in-memory mock that reproduces standard + advanced auth, the `modified` filter, ascending sort, 0-indexed pagination and the `{data,total}` envelope, plus unit tests for validation, URL/version resolution, query/body building, parsing (precision, zero-time, offsets), id resolution, dedup-by-version, and the advanced signature.

⚠️ **Not yet live-verified** against a real Cortex XSOAR instance (no credentials available); the mock and fixtures mirror the documented shapes. Worth a live smoke-test against a 6.x and an 8.x tenant before GA, and confirming the `modified:>=` Lucene query behaves as expected on a real instance.

## Follow-ups (not in scope here)

- Optional: ingest other XSOAR objects (war-room entries, indicators) — same pattern.
- Optional: push/response back into XSOAR (the customer ask is ingest-only for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)