### PR TITLE
Add AWS IAM Roles Anywhere authentication to s3, sqs and sqs-files adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ journalctl -f -q | netcat 127.0.0.1 4444
 ./general s3 client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=carbon_black client_options.sensor_seed_key=tests3 bucket_name=lc-cb-test access_key=YYYYYYYYYY secret_key=XXXXXXXX  "prefix=events/org_key=NKZFDWEM/"
 ```
 
+The `s3`, `sqs` and `sqs-files` adapters can authenticate with
+[AWS IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html)
+instead of long-lived access keys. Provide the PEM-encoded X.509 certificate
+(optionally followed by its chain) and private key issued under your trust
+anchor's CA, along with the trust anchor, profile and role ARNs, in place of
+`access_key`/`secret_key`. The adapter obtains temporary session credentials
+and refreshes them automatically before they expire. PEM values may be passed
+on a single line with `\n` escapes.
+
+```
+./general s3 client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=carbon_black client_options.sensor_seed_key=tests3 bucket_name=lc-cb-test "roles_anywhere.certificate=$(cat client.pem)" "roles_anywhere.private_key=$(cat client.key)" roles_anywhere.trust_anchor_arn=arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/UUID roles_anywhere.profile_arn=arn:aws:rolesanywhere:us-east-1:123456789012:profile/UUID roles_anywhere.role_arn=arn:aws:iam::123456789012:role/lc-adapter "prefix=events/org_key=NKZFDWEM/"
+```
+
 ### Stdin
 
 ```

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -138,7 +138,36 @@ func printUsage() {
 
 func printConfig(method string, c interface{}) {
 	b, _ := yaml.Marshal(c)
+	var redacted interface{}
+	if err := yaml.Unmarshal(b, &redacted); err == nil {
+		redactSecrets(redacted)
+		if rb, err := yaml.Marshal(redacted); err == nil {
+			b = rb
+		}
+	}
 	log("Configs in use (%s):\n----------------------------------\n%s----------------------------------\n", method, string(b))
+}
+
+// redactSecrets masks secret material in a config tree so it never
+// lands in logs.
+func redactSecrets(v interface{}) {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		for k, val := range t {
+			switch k {
+			case "secret_key", "private_key":
+				if s, ok := val.(string); ok && s != "" {
+					t[k] = "<redacted>"
+				}
+			default:
+				redactSecrets(val)
+			}
+		}
+	case []interface{}:
+		for _, e := range t {
+			redactSecrets(e)
+		}
+	}
 }
 
 func main() {

--- a/s3/client.go
+++ b/s3/client.go
@@ -64,6 +64,7 @@ type S3Adapter struct {
 
 	ctx context.Context
 
+	awsCreds      *credentials.Credentials
 	awsConfig     *aws.Config
 	awsSession    *session.Session
 	awsS3         *s3.S3
@@ -76,14 +77,15 @@ type S3Adapter struct {
 }
 
 type S3Config struct {
-	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
-	BucketName    string                  `json:"bucket_name" yaml:"bucket_name"`
-	AccessKey     string                  `json:"access_key" yaml:"access_key"`
-	SecretKey     string                  `json:"secret_key,omitempty" yaml:"secret_key,omitempty"`
-	IsOneTimeLoad bool                    `json:"single_load" yaml:"single_load"`
-	Prefix        string                  `json:"prefix" yaml:"prefix"`
-	ParallelFetch int                     `json:"parallel_fetch" yaml:"parallel_fetch"`
-	Region        string                  `json:"region" yaml:"region"`
+	ClientOptions uspclient.ClientOptions      `json:"client_options" yaml:"client_options"`
+	BucketName    string                       `json:"bucket_name" yaml:"bucket_name"`
+	AccessKey     string                       `json:"access_key" yaml:"access_key"`
+	SecretKey     string                       `json:"secret_key,omitempty" yaml:"secret_key,omitempty"`
+	RolesAnywhere utils.AWSRolesAnywhereConfig `json:"roles_anywhere,omitempty" yaml:"roles_anywhere,omitempty"`
+	IsOneTimeLoad bool                         `json:"single_load" yaml:"single_load"`
+	Prefix        string                       `json:"prefix" yaml:"prefix"`
+	ParallelFetch int                          `json:"parallel_fetch" yaml:"parallel_fetch"`
+	Region        string                       `json:"region" yaml:"region"`
 }
 
 func (c *S3Config) Validate() error {
@@ -93,11 +95,8 @@ func (c *S3Config) Validate() error {
 	if c.BucketName == "" {
 		return errors.New("missing bucket_name")
 	}
-	if c.AccessKey == "" {
-		return errors.New("missing access_key")
-	}
-	if c.SecretKey == "" {
-		return errors.New("missing secret_key")
+	if err := utils.ValidateAWSAuth(c.AccessKey, c.SecretKey, c.RolesAnywhere); err != nil {
+		return err
 	}
 	return nil
 }
@@ -125,6 +124,10 @@ func NewS3Adapter(ctx context.Context, conf S3Config) (*S3Adapter, chan struct{}
 
 	var err error
 	var region string
+
+	if a.awsCreds, err = utils.NewAWSCredentials(conf.AccessKey, conf.SecretKey, conf.RolesAnywhere); err != nil {
+		return nil, nil, fmt.Errorf("aws credentials: %v", err)
+	}
 
 	if conf.Region != "" {
 		region = conf.Region
@@ -161,7 +164,7 @@ func NewS3Adapter(ctx context.Context, conf S3Config) (*S3Adapter, chan struct{}
 
 	a.awsConfig = &aws.Config{
 		Region:      aws.String(region),
-		Credentials: credentials.NewStaticCredentials(conf.AccessKey, conf.SecretKey, ""),
+		Credentials: a.awsCreds,
 		HTTPClient:  httpClient,
 		Retryer: connResetRetryer{
 			DefaultRetryer: client.DefaultRetryer{NumMaxRetries: 8},
@@ -215,7 +218,7 @@ func (a *S3Adapter) getRegion() (string, error) {
 	// Try commercial partition first
 	sess, err := session.NewSession(&aws.Config{
 		Region:           aws.String("us-east-1"),
-		Credentials:      credentials.NewStaticCredentials(a.conf.AccessKey, a.conf.SecretKey, ""),
+		Credentials:      a.awsCreds,
 		S3ForcePathStyle: aws.Bool(false),
 	})
 	if err != nil {
@@ -235,7 +238,7 @@ func (a *S3Adapter) getRegion() (string, error) {
 		// Try GovCloud partition
 		govSess, govErr := session.NewSession(&aws.Config{
 			Region:           aws.String("us-gov-west-1"),
-			Credentials:      credentials.NewStaticCredentials(a.conf.AccessKey, a.conf.SecretKey, ""),
+			Credentials:      a.awsCreds,
 			S3ForcePathStyle: aws.Bool(false),
 		})
 		if govErr != nil {

--- a/s3/client_test.go
+++ b/s3/client_test.go
@@ -1,0 +1,74 @@
+package usp_s3
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+func testClientOptions() uspclient.ClientOptions {
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "00000000-0000-0000-0000-000000000000",
+			InstallationKey: "00000000-0000-0000-0000-000000000000",
+		},
+		Platform: "aws",
+	}
+}
+
+func TestS3ConfigValidate(t *testing.T) {
+	rolesAnywhere := utils.AWSRolesAnywhereConfig{
+		Certificate:    "cert",
+		PrivateKey:     "key",
+		TrustAnchorARN: "arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/abc",
+		ProfileARN:     "arn:aws:rolesanywhere:us-east-1:123456789012:profile/abc",
+		RoleARN:        "arn:aws:iam::123456789012:role/abc",
+	}
+	for _, c := range []struct {
+		name    string
+		conf    S3Config
+		errPart string
+	}{
+		{
+			name: "static keys",
+			conf: S3Config{ClientOptions: testClientOptions(), BucketName: "b", AccessKey: "ak", SecretKey: "sk"},
+		},
+		{
+			name: "roles anywhere",
+			conf: S3Config{ClientOptions: testClientOptions(), BucketName: "b", RolesAnywhere: rolesAnywhere},
+		},
+		{
+			name:    "missing bucket",
+			conf:    S3Config{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk"},
+			errPart: "missing bucket_name",
+		},
+		{
+			name:    "no auth",
+			conf:    S3Config{ClientOptions: testClientOptions(), BucketName: "b"},
+			errPart: "missing access_key",
+		},
+		{
+			name:    "both auth methods",
+			conf:    S3Config{ClientOptions: testClientOptions(), BucketName: "b", AccessKey: "ak", SecretKey: "sk", RolesAnywhere: rolesAnywhere},
+			errPart: "not both",
+		},
+		{
+			name:    "partial roles anywhere",
+			conf:    S3Config{ClientOptions: testClientOptions(), BucketName: "b", RolesAnywhere: utils.AWSRolesAnywhereConfig{Certificate: "cert"}},
+			errPart: "missing roles_anywhere.private_key",
+		},
+	} {
+		err := c.conf.Validate()
+		if c.errPart == "" {
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", c.name, err)
+			}
+			continue
+		}
+		if err == nil || !strings.Contains(err.Error(), c.errPart) {
+			t.Errorf("%s: expected error containing %q, got: %v", c.name, c.errPart, err)
+		}
+	}
+}

--- a/s3/client_test.go
+++ b/s3/client_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/refractionPOINT/usp-adapters/utils"
 )
 
-func testClientOptions() uspclient.ClientOptions {
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
 	return uspclient.ClientOptions{
 		Identity: uspclient.Identity{
 			Oid:             "00000000-0000-0000-0000-000000000000",
@@ -33,30 +34,30 @@ func TestS3ConfigValidate(t *testing.T) {
 	}{
 		{
 			name: "static keys",
-			conf: S3Config{ClientOptions: testClientOptions(), BucketName: "b", AccessKey: "ak", SecretKey: "sk"},
+			conf: S3Config{ClientOptions: testClientOptions(t), BucketName: "b", AccessKey: "ak", SecretKey: "sk"},
 		},
 		{
 			name: "roles anywhere",
-			conf: S3Config{ClientOptions: testClientOptions(), BucketName: "b", RolesAnywhere: rolesAnywhere},
+			conf: S3Config{ClientOptions: testClientOptions(t), BucketName: "b", RolesAnywhere: rolesAnywhere},
 		},
 		{
 			name:    "missing bucket",
-			conf:    S3Config{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk"},
+			conf:    S3Config{ClientOptions: testClientOptions(t), AccessKey: "ak", SecretKey: "sk"},
 			errPart: "missing bucket_name",
 		},
 		{
 			name:    "no auth",
-			conf:    S3Config{ClientOptions: testClientOptions(), BucketName: "b"},
+			conf:    S3Config{ClientOptions: testClientOptions(t), BucketName: "b"},
 			errPart: "missing access_key",
 		},
 		{
 			name:    "both auth methods",
-			conf:    S3Config{ClientOptions: testClientOptions(), BucketName: "b", AccessKey: "ak", SecretKey: "sk", RolesAnywhere: rolesAnywhere},
+			conf:    S3Config{ClientOptions: testClientOptions(t), BucketName: "b", AccessKey: "ak", SecretKey: "sk", RolesAnywhere: rolesAnywhere},
 			errPart: "not both",
 		},
 		{
 			name:    "partial roles anywhere",
-			conf:    S3Config{ClientOptions: testClientOptions(), BucketName: "b", RolesAnywhere: utils.AWSRolesAnywhereConfig{Certificate: "cert"}},
+			conf:    S3Config{ClientOptions: testClientOptions(t), BucketName: "b", RolesAnywhere: utils.AWSRolesAnywhereConfig{Certificate: "cert"}},
 			errPart: "missing roles_anywhere.private_key",
 		},
 	} {

--- a/sqs-files/client.go
+++ b/sqs-files/client.go
@@ -31,6 +31,8 @@ type SQSFilesAdapter struct {
 
 	chFiles chan fileInfo
 
+	awsCreds *credentials.Credentials
+
 	// SQS
 	awsConfig  *aws.Config
 	awsSession *session.Session
@@ -52,10 +54,11 @@ type SQSFilesConfig struct {
 	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
 
 	// SQS specific
-	AccessKey string `json:"access_key" yaml:"access_key"`
-	SecretKey string `json:"secret_key,omitempty" yaml:"secret_key,omitempty"`
-	QueueURL  string `json:"queue_url" yaml:"queue_url"`
-	Region    string `json:"region" yaml:"region"`
+	AccessKey     string                       `json:"access_key" yaml:"access_key"`
+	SecretKey     string                       `json:"secret_key,omitempty" yaml:"secret_key,omitempty"`
+	RolesAnywhere utils.AWSRolesAnywhereConfig `json:"roles_anywhere,omitempty" yaml:"roles_anywhere,omitempty"`
+	QueueURL      string                       `json:"queue_url" yaml:"queue_url"`
+	Region        string                       `json:"region" yaml:"region"`
 
 	// S3 specific
 	ParallelFetch     int    `json:"parallel_fetch" yaml:"parallel_fetch"`
@@ -75,11 +78,8 @@ func (c *SQSFilesConfig) Validate() error {
 	if err := c.ClientOptions.Validate(); err != nil {
 		return fmt.Errorf("client_options: %v", err)
 	}
-	if c.AccessKey == "" {
-		return errors.New("missing access_key")
-	}
-	if c.SecretKey == "" {
-		return errors.New("missing secret_key")
+	if err := utils.ValidateAWSAuth(c.AccessKey, c.SecretKey, c.RolesAnywhere); err != nil {
+		return err
 	}
 	if c.Region == "" {
 		return errors.New("missing region")
@@ -108,10 +108,14 @@ func NewSQSFilesAdapter(ctx context.Context, conf SQSFilesConfig) (*SQSFilesAdap
 
 	var err error
 
+	if a.awsCreds, err = utils.NewAWSCredentials(conf.AccessKey, conf.SecretKey, conf.RolesAnywhere); err != nil {
+		return nil, nil, fmt.Errorf("aws credentials: %v", err)
+	}
+
 	// SQS
 	a.awsConfig = &aws.Config{
 		Region:      aws.String(conf.Region),
-		Credentials: credentials.NewStaticCredentials(conf.AccessKey, conf.SecretKey, ""),
+		Credentials: a.awsCreds,
 	}
 
 	if a.awsSession, err = session.NewSession(a.awsConfig); err != nil {
@@ -179,7 +183,7 @@ func (a *SQSFilesAdapter) initS3SDKs(bucket string) error {
 	}
 	a.awsS3Config = &aws.Config{
 		Region:      aws.String(region),
-		Credentials: credentials.NewStaticCredentials(a.conf.AccessKey, a.conf.SecretKey, ""),
+		Credentials: a.awsCreds,
 	}
 
 	if a.awsS3Session, err = session.NewSession(a.awsS3Config); err != nil {

--- a/sqs-files/client.go
+++ b/sqs-files/client.go
@@ -190,13 +190,20 @@ func (a *SQSFilesAdapter) initS3SDKs(bucket string) error {
 		return fmt.Errorf("s3.NewSession(): %v", err)
 	}
 
-	a.awsS3 = s3.New(a.awsSession)
+	a.awsS3 = s3.New(a.awsS3Session)
 	a.awsDownloader = s3manager.NewDownloader(a.awsS3Session)
+	a.isS3Inited = true
 	return nil
 }
 
 func (a *SQSFilesAdapter) getBucketRegion(bucket string) (string, error) {
-	return s3manager.GetBucketRegion(a.ctx, session.Must(session.NewSession(&aws.Config{})), bucket, "us-east-1")
+	sess, err := session.NewSession(&aws.Config{
+		Credentials: a.awsCreds,
+	})
+	if err != nil {
+		return "", err
+	}
+	return s3manager.GetBucketRegion(a.ctx, sess, bucket, "us-east-1")
 }
 
 func (a *SQSFilesAdapter) receiveEvents() error {

--- a/sqs-files/client_test.go
+++ b/sqs-files/client_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/refractionPOINT/usp-adapters/utils"
 )
 
-func testClientOptions() uspclient.ClientOptions {
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
 	return uspclient.ClientOptions{
 		Identity: uspclient.Identity{
 			Oid:             "00000000-0000-0000-0000-000000000000",
@@ -33,25 +34,25 @@ func TestSQSFilesConfigValidate(t *testing.T) {
 	}{
 		{
 			name: "static keys",
-			conf: SQSFilesConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			conf: SQSFilesConfig{ClientOptions: testClientOptions(t), AccessKey: "ak", SecretKey: "sk", Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
 		},
 		{
 			name: "roles anywhere",
-			conf: SQSFilesConfig{ClientOptions: testClientOptions(), RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			conf: SQSFilesConfig{ClientOptions: testClientOptions(t), RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
 		},
 		{
 			name:    "no auth",
-			conf:    SQSFilesConfig{ClientOptions: testClientOptions(), Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			conf:    SQSFilesConfig{ClientOptions: testClientOptions(t), Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
 			errPart: "missing access_key",
 		},
 		{
 			name:    "both auth methods",
-			conf:    SQSFilesConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			conf:    SQSFilesConfig{ClientOptions: testClientOptions(t), AccessKey: "ak", SecretKey: "sk", RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
 			errPart: "not both",
 		},
 		{
 			name:    "missing queue",
-			conf:    SQSFilesConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", Region: "us-east-1"},
+			conf:    SQSFilesConfig{ClientOptions: testClientOptions(t), AccessKey: "ak", SecretKey: "sk", Region: "us-east-1"},
 			errPart: "missing queue_url",
 		},
 	} {

--- a/sqs-files/client_test.go
+++ b/sqs-files/client_test.go
@@ -1,0 +1,69 @@
+package usp_sqs_files
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+func testClientOptions() uspclient.ClientOptions {
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "00000000-0000-0000-0000-000000000000",
+			InstallationKey: "00000000-0000-0000-0000-000000000000",
+		},
+		Platform: "aws",
+	}
+}
+
+func TestSQSFilesConfigValidate(t *testing.T) {
+	rolesAnywhere := utils.AWSRolesAnywhereConfig{
+		Certificate:    "cert",
+		PrivateKey:     "key",
+		TrustAnchorARN: "arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/abc",
+		ProfileARN:     "arn:aws:rolesanywhere:us-east-1:123456789012:profile/abc",
+		RoleARN:        "arn:aws:iam::123456789012:role/abc",
+	}
+	for _, c := range []struct {
+		name    string
+		conf    SQSFilesConfig
+		errPart string
+	}{
+		{
+			name: "static keys",
+			conf: SQSFilesConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+		},
+		{
+			name: "roles anywhere",
+			conf: SQSFilesConfig{ClientOptions: testClientOptions(), RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+		},
+		{
+			name:    "no auth",
+			conf:    SQSFilesConfig{ClientOptions: testClientOptions(), Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			errPart: "missing access_key",
+		},
+		{
+			name:    "both auth methods",
+			conf:    SQSFilesConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			errPart: "not both",
+		},
+		{
+			name:    "missing queue",
+			conf:    SQSFilesConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", Region: "us-east-1"},
+			errPart: "missing queue_url",
+		},
+	} {
+		err := c.conf.Validate()
+		if c.errPart == "" {
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", c.name, err)
+			}
+			continue
+		}
+		if err == nil || !strings.Contains(err.Error(), c.errPart) {
+			t.Errorf("%s: expected error containing %q, got: %v", c.name, c.errPart, err)
+		}
+	}
+}

--- a/sqs/client.go
+++ b/sqs/client.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 
 	"github.com/refractionPOINT/go-uspclient"
 	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
 )
 
 const (
@@ -32,22 +32,20 @@ type SQSAdapter struct {
 }
 
 type SQSConfig struct {
-	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
-	AccessKey     string                  `json:"access_key" yaml:"access_key"`
-	SecretKey     string                  `json:"secret_key,omitempty" yaml:"secret_key,omitempty"`
-	QueueURL      string                  `json:"queue_url" yaml:"queue_url"`
-	Region        string                  `json:"region" yaml:"region"`
+	ClientOptions uspclient.ClientOptions      `json:"client_options" yaml:"client_options"`
+	AccessKey     string                       `json:"access_key" yaml:"access_key"`
+	SecretKey     string                       `json:"secret_key,omitempty" yaml:"secret_key,omitempty"`
+	RolesAnywhere utils.AWSRolesAnywhereConfig `json:"roles_anywhere,omitempty" yaml:"roles_anywhere,omitempty"`
+	QueueURL      string                       `json:"queue_url" yaml:"queue_url"`
+	Region        string                       `json:"region" yaml:"region"`
 }
 
 func (c *SQSConfig) Validate() error {
 	if err := c.ClientOptions.Validate(); err != nil {
 		return fmt.Errorf("client_options: %v", err)
 	}
-	if c.AccessKey == "" {
-		return errors.New("missing access_key")
-	}
-	if c.SecretKey == "" {
-		return errors.New("missing secret_key")
+	if err := utils.ValidateAWSAuth(c.AccessKey, c.SecretKey, c.RolesAnywhere); err != nil {
+		return err
 	}
 	if c.Region == "" {
 		return errors.New("missing region")
@@ -64,10 +62,13 @@ func NewSQSAdapter(ctx context.Context, conf SQSConfig) (*SQSAdapter, chan struc
 		ctx:  context.Background(),
 	}
 
-	var err error
+	awsCreds, err := utils.NewAWSCredentials(conf.AccessKey, conf.SecretKey, conf.RolesAnywhere)
+	if err != nil {
+		return nil, nil, fmt.Errorf("aws credentials: %v", err)
+	}
 	a.awsConfig = &aws.Config{
 		Region:      aws.String(conf.Region),
-		Credentials: credentials.NewStaticCredentials(conf.AccessKey, conf.SecretKey, ""),
+		Credentials: awsCreds,
 	}
 
 	if a.awsSession, err = session.NewSession(a.awsConfig); err != nil {

--- a/sqs/client_test.go
+++ b/sqs/client_test.go
@@ -1,0 +1,69 @@
+package usp_sqs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+func testClientOptions() uspclient.ClientOptions {
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "00000000-0000-0000-0000-000000000000",
+			InstallationKey: "00000000-0000-0000-0000-000000000000",
+		},
+		Platform: "aws",
+	}
+}
+
+func TestSQSConfigValidate(t *testing.T) {
+	rolesAnywhere := utils.AWSRolesAnywhereConfig{
+		Certificate:    "cert",
+		PrivateKey:     "key",
+		TrustAnchorARN: "arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/abc",
+		ProfileARN:     "arn:aws:rolesanywhere:us-east-1:123456789012:profile/abc",
+		RoleARN:        "arn:aws:iam::123456789012:role/abc",
+	}
+	for _, c := range []struct {
+		name    string
+		conf    SQSConfig
+		errPart string
+	}{
+		{
+			name: "static keys",
+			conf: SQSConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+		},
+		{
+			name: "roles anywhere",
+			conf: SQSConfig{ClientOptions: testClientOptions(), RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+		},
+		{
+			name:    "no auth",
+			conf:    SQSConfig{ClientOptions: testClientOptions(), Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			errPart: "missing access_key",
+		},
+		{
+			name:    "both auth methods",
+			conf:    SQSConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			errPart: "not both",
+		},
+		{
+			name:    "missing region",
+			conf:    SQSConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			errPart: "missing region",
+		},
+	} {
+		err := c.conf.Validate()
+		if c.errPart == "" {
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", c.name, err)
+			}
+			continue
+		}
+		if err == nil || !strings.Contains(err.Error(), c.errPart) {
+			t.Errorf("%s: expected error containing %q, got: %v", c.name, c.errPart, err)
+		}
+	}
+}

--- a/sqs/client_test.go
+++ b/sqs/client_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/refractionPOINT/usp-adapters/utils"
 )
 
-func testClientOptions() uspclient.ClientOptions {
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
 	return uspclient.ClientOptions{
 		Identity: uspclient.Identity{
 			Oid:             "00000000-0000-0000-0000-000000000000",
@@ -33,25 +34,25 @@ func TestSQSConfigValidate(t *testing.T) {
 	}{
 		{
 			name: "static keys",
-			conf: SQSConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			conf: SQSConfig{ClientOptions: testClientOptions(t), AccessKey: "ak", SecretKey: "sk", Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
 		},
 		{
 			name: "roles anywhere",
-			conf: SQSConfig{ClientOptions: testClientOptions(), RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			conf: SQSConfig{ClientOptions: testClientOptions(t), RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
 		},
 		{
 			name:    "no auth",
-			conf:    SQSConfig{ClientOptions: testClientOptions(), Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			conf:    SQSConfig{ClientOptions: testClientOptions(t), Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
 			errPart: "missing access_key",
 		},
 		{
 			name:    "both auth methods",
-			conf:    SQSConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			conf:    SQSConfig{ClientOptions: testClientOptions(t), AccessKey: "ak", SecretKey: "sk", RolesAnywhere: rolesAnywhere, Region: "us-east-1", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
 			errPart: "not both",
 		},
 		{
 			name:    "missing region",
-			conf:    SQSConfig{ClientOptions: testClientOptions(), AccessKey: "ak", SecretKey: "sk", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
+			conf:    SQSConfig{ClientOptions: testClientOptions(t), AccessKey: "ak", SecretKey: "sk", QueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/q"},
 			errPart: "missing region",
 		},
 	} {

--- a/utils/aws_roles_anywhere.go
+++ b/utils/aws_roles_anywhere.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -19,13 +21,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 )
 
 // AWSRolesAnywhereConfig holds the parameters needed to obtain temporary
 // AWS credentials through IAM Roles Anywhere instead of long-lived
 // access keys. The certificate and private key are PEM encoded; the
-// certificate value may contain the full chain, leaf first.
+// certificate value may contain the full chain in any order, the leaf
+// is identified by matching the private key.
 type AWSRolesAnywhereConfig struct {
 	Certificate    string `json:"certificate,omitempty" yaml:"certificate,omitempty"`
 	PrivateKey     string `json:"private_key,omitempty" yaml:"private_key,omitempty"`
@@ -74,7 +79,7 @@ func ValidateAWSAuth(accessKey string, secretKey string, ra AWSRolesAnywhereConf
 		return ra.Validate()
 	}
 	if accessKey == "" {
-		return errors.New("missing access_key")
+		return errors.New("missing access_key (provide access_key/secret_key or roles_anywhere)")
 	}
 	if secretKey == "" {
 		return errors.New("missing secret_key")
@@ -85,6 +90,11 @@ func ValidateAWSAuth(accessKey string, secretKey string, ra AWSRolesAnywhereConf
 // NewAWSCredentials returns aws-sdk-go credentials backed by either the
 // static access keys or, when configured, IAM Roles Anywhere.
 func NewAWSCredentials(accessKey string, secretKey string, ra AWSRolesAnywhereConfig) (*credentials.Credentials, error) {
+	// Not all runners call Config.Validate() before building the
+	// adapter, so enforce the auth rules here too.
+	if err := ValidateAWSAuth(accessKey, secretKey, ra); err != nil {
+		return nil, err
+	}
 	if !ra.IsEnabled() {
 		return credentials.NewStaticCredentials(accessKey, secretKey, ""), nil
 	}
@@ -101,6 +111,7 @@ const (
 	// Refresh credentials a bit before they actually expire so requests
 	// in flight never race the expiration.
 	rolesAnywhereExpiryWindow = 5 * time.Minute
+	rolesAnywhereMaxAttempts  = 3
 )
 
 // rolesAnywhereProvider implements credentials.Provider by calling the
@@ -111,66 +122,106 @@ const (
 type rolesAnywhereProvider struct {
 	credentials.Expiry
 
-	conf AWSRolesAnywhereConfig
-
-	cert      *x509.Certificate
-	chain     []*x509.Certificate
 	key       crypto.Signer
 	algorithm string
+	serial    string
+
+	// Immutable request components, precomputed at construction.
+	certHeader  string
+	chainHeader string
+	body        []byte
 
 	region   string
 	endpoint string
 
 	httpClient *http.Client
-	now        func() time.Time
 }
 
 func newRolesAnywhereProvider(conf AWSRolesAnywhereConfig) (*rolesAnywhereProvider, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, err
 	}
-	cert, chain, err := parsePEMCertificates(conf.Certificate)
-	if err != nil {
-		return nil, fmt.Errorf("roles_anywhere.certificate: %v", err)
-	}
 	key, algorithm, err := parsePEMPrivateKey(conf.PrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("roles_anywhere.private_key: %v", err)
+	}
+	cert, chain, err := parsePEMCertificates(conf.Certificate, key)
+	if err != nil {
+		return nil, fmt.Errorf("roles_anywhere.certificate: %v", err)
 	}
 	region, endpoint, err := rolesAnywhereEndpoint(conf.TrustAnchorARN)
 	if err != nil {
 		return nil, fmt.Errorf("roles_anywhere.trust_anchor_arn: %v", err)
 	}
+	body, err := json.Marshal(map[string]interface{}{
+		"durationSeconds": rolesAnywhereSessionSeconds,
+		"profileArn":      conf.ProfileARN,
+		"roleArn":         conf.RoleARN,
+		"trustAnchorArn":  conf.TrustAnchorARN,
+	})
+	if err != nil {
+		return nil, err
+	}
+	chainHeader := ""
+	if len(chain) != 0 {
+		encoded := make([]string, 0, len(chain))
+		for _, c := range chain {
+			encoded = append(encoded, base64.StdEncoding.EncodeToString(c.Raw))
+		}
+		chainHeader = strings.Join(encoded, ",")
+	}
 	return &rolesAnywhereProvider{
-		conf:       conf,
-		cert:       cert,
-		chain:      chain,
-		key:        key,
-		algorithm:  algorithm,
-		region:     region,
-		endpoint:   endpoint,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
-		now:        time.Now,
+		key:         key,
+		algorithm:   algorithm,
+		serial:      cert.SerialNumber.String(),
+		certHeader:  base64.StdEncoding.EncodeToString(cert.Raw),
+		chainHeader: chainHeader,
+		body:        body,
+		region:      region,
+		endpoint:    endpoint,
+		httpClient:  &http.Client{Timeout: 30 * time.Second},
 	}, nil
 }
 
 func (p *rolesAnywhereProvider) Retrieve() (credentials.Value, error) {
-	body, err := json.Marshal(map[string]interface{}{
-		"durationSeconds": rolesAnywhereSessionSeconds,
-		"profileArn":      p.conf.ProfileARN,
-		"roleArn":         p.conf.RoleARN,
-		"trustAnchorArn":  p.conf.TrustAnchorARN,
-	})
-	if err != nil {
-		return credentials.Value{}, err
-	}
+	return p.RetrieveWithContext(context.Background())
+}
 
+// RetrieveWithContext implements credentials.ProviderWithContext so the
+// SDK propagates request contexts into the credential fetch. Transient
+// CreateSession failures are retried since a mid-run credential refresh
+// error is surfaced to the adapter as a non-retryable request failure.
+func (p *rolesAnywhereProvider) RetrieveWithContext(ctx context.Context) (credentials.Value, error) {
+	var lastErr error
+	for attempt := 0; attempt < rolesAnywhereMaxAttempts; attempt++ {
+		if attempt != 0 {
+			select {
+			case <-ctx.Done():
+				return credentials.Value{}, ctx.Err()
+			case <-time.After(time.Duration(attempt) * time.Second):
+			}
+		}
+		v, isRetryable, err := p.createSession(ctx)
+		if err == nil {
+			return v, nil
+		}
+		lastErr = err
+		if !isRetryable {
+			break
+		}
+	}
+	return credentials.Value{}, lastErr
+}
+
+// createSession performs one signed CreateSession call. The second
+// return value indicates whether the error is worth retrying.
+func (p *rolesAnywhereProvider) createSession(ctx context.Context) (credentials.Value, bool, error) {
 	u, err := url.Parse(p.endpoint)
 	if err != nil {
-		return credentials.Value{}, fmt.Errorf("rolesanywhere endpoint: %v", err)
+		return credentials.Value{}, false, fmt.Errorf("rolesanywhere endpoint: %v", err)
 	}
 
-	now := p.now().UTC()
+	now := time.Now().UTC()
 	amzDate := now.Format("20060102T150405Z")
 	scope := fmt.Sprintf("%s/%s/rolesanywhere/aws4_request", now.Format("20060102"), p.region)
 
@@ -180,14 +231,10 @@ func (p *rolesAnywhereProvider) Retrieve() (credentials.Value, error) {
 		{"content-type", "application/json"},
 		{"host", u.Host},
 		{"x-amz-date", amzDate},
-		{"x-amz-x509", base64.StdEncoding.EncodeToString(p.cert.Raw)},
+		{"x-amz-x509", p.certHeader},
 	}
-	if len(p.chain) != 0 {
-		encoded := make([]string, 0, len(p.chain))
-		for _, c := range p.chain {
-			encoded = append(encoded, base64.StdEncoding.EncodeToString(c.Raw))
-		}
-		headers = append(headers, [2]string{"x-amz-x509-chain", strings.Join(encoded, ",")})
+	if p.chainHeader != "" {
+		headers = append(headers, [2]string{"x-amz-x509-chain", p.chainHeader})
 	}
 
 	canonicalHeaders := strings.Builder{}
@@ -198,7 +245,7 @@ func (p *rolesAnywhereProvider) Retrieve() (credentials.Value, error) {
 	}
 	signedHeaders := strings.Join(signedNames, ";")
 
-	payloadHash := sha256.Sum256(body)
+	payloadHash := sha256.Sum256(p.body)
 	canonicalRequest := strings.Join([]string{
 		"POST",
 		"/sessions",
@@ -227,12 +274,12 @@ func (p *rolesAnywhereProvider) Retrieve() (credentials.Value, error) {
 		err = fmt.Errorf("unsupported private key type %T", p.key)
 	}
 	if err != nil {
-		return credentials.Value{}, fmt.Errorf("rolesanywhere signing: %v", err)
+		return credentials.Value{}, false, fmt.Errorf("rolesanywhere signing: %v", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, p.endpoint+"/sessions", strings.NewReader(string(body)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint+"/sessions", bytes.NewReader(p.body))
 	if err != nil {
-		return credentials.Value{}, err
+		return credentials.Value{}, false, err
 	}
 	for _, h := range headers {
 		if h[0] == "host" {
@@ -242,19 +289,22 @@ func (p *rolesAnywhereProvider) Retrieve() (credentials.Value, error) {
 	}
 	req.Header.Set("Authorization", fmt.Sprintf(
 		"%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
-		p.algorithm, p.cert.SerialNumber.String(), scope, signedHeaders, hex.EncodeToString(signature)))
+		p.algorithm, p.serial, scope, signedHeaders, hex.EncodeToString(signature)))
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
-		return credentials.Value{}, fmt.Errorf("rolesanywhere CreateSession: %v", err)
+		return credentials.Value{}, true, fmt.Errorf("rolesanywhere CreateSession: %v", err)
 	}
 	defer resp.Body.Close()
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	if err != nil {
-		return credentials.Value{}, fmt.Errorf("rolesanywhere CreateSession: %v", err)
+		return credentials.Value{}, true, fmt.Errorf("rolesanywhere CreateSession: %v", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return credentials.Value{}, fmt.Errorf("rolesanywhere CreateSession status %d: %s", resp.StatusCode, string(respBody))
+		// Throttling and server-side errors are transient; auth and
+		// validation failures are not.
+		isRetryable := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
+		return credentials.Value{}, isRetryable, fmt.Errorf("rolesanywhere CreateSession status %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	session := struct {
@@ -268,23 +318,34 @@ func (p *rolesAnywhereProvider) Retrieve() (credentials.Value, error) {
 		} `json:"credentialSet"`
 	}{}
 	if err := json.Unmarshal(respBody, &session); err != nil {
-		return credentials.Value{}, fmt.Errorf("rolesanywhere CreateSession response: %v", err)
+		return credentials.Value{}, false, fmt.Errorf("rolesanywhere CreateSession response: %v", err)
 	}
 	if len(session.CredentialSet) == 0 {
-		return credentials.Value{}, errors.New("rolesanywhere CreateSession response: empty credentialSet")
+		return credentials.Value{}, false, errors.New("rolesanywhere CreateSession response: empty credentialSet")
 	}
 	creds := session.CredentialSet[0].Credentials
 	if creds.AccessKeyID == "" || creds.SecretAccessKey == "" {
-		return credentials.Value{}, errors.New("rolesanywhere CreateSession response: missing credentials")
+		return credentials.Value{}, false, errors.New("rolesanywhere CreateSession response: missing credentials")
 	}
 
 	expiration, err := time.Parse(time.RFC3339, creds.Expiration)
 	if err != nil {
-		return credentials.Value{}, fmt.Errorf("rolesanywhere CreateSession expiration: %v", err)
+		return credentials.Value{}, false, fmt.Errorf("rolesanywhere CreateSession expiration: %v", err)
 	}
 	window := rolesAnywhereExpiryWindow
 	if remaining := expiration.Sub(now); remaining < 2*window {
 		window = remaining / 2
+		if window < 0 {
+			window = 0
+		}
+	}
+	if expiration.Before(now.Add(time.Minute)) {
+		// The expiration can land in the past when the local clock is
+		// badly skewed from AWS. Keep the credentials for a minute so
+		// a skewed host refreshes periodically instead of calling
+		// CreateSession for every single request.
+		expiration = now.Add(time.Minute)
+		window = 0
 	}
 	p.SetExpiration(expiration, window)
 
@@ -293,23 +354,27 @@ func (p *rolesAnywhereProvider) Retrieve() (credentials.Value, error) {
 		SecretAccessKey: creds.SecretAccessKey,
 		SessionToken:    creds.SessionToken,
 		ProviderName:    rolesAnywhereProviderName,
-	}, nil
+	}, false, nil
 }
 
 // rolesAnywhereEndpoint derives the region and API endpoint from the
 // trust anchor ARN, like:
 // arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/uuid
+// The endpoint comes from the SDK endpoint data so partition domains
+// (GovCloud, CN, ISO...) resolve correctly.
 func rolesAnywhereEndpoint(trustAnchorARN string) (string, string, error) {
-	parts := strings.Split(trustAnchorARN, ":")
-	if len(parts) < 6 || parts[0] != "arn" || parts[2] != "rolesanywhere" || parts[3] == "" {
+	a, err := arn.Parse(trustAnchorARN)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid trust anchor ARN %q: %v", trustAnchorARN, err)
+	}
+	if a.Service != "rolesanywhere" || a.Region == "" {
 		return "", "", fmt.Errorf("invalid trust anchor ARN %q", trustAnchorARN)
 	}
-	region := parts[3]
-	domain := "amazonaws.com"
-	if parts[1] == "aws-cn" {
-		domain = "amazonaws.com.cn"
+	resolved, err := endpoints.DefaultResolver().EndpointFor("rolesanywhere", a.Region, endpoints.ResolveUnknownServiceOption)
+	if err != nil {
+		return "", "", fmt.Errorf("no rolesanywhere endpoint for region %q: %v", a.Region, err)
 	}
-	return region, fmt.Sprintf("https://rolesanywhere.%s.%s", region, domain), nil
+	return a.Region, resolved.URL, nil
 }
 
 // normalizePEM allows PEM values pasted as a single line with literal
@@ -319,9 +384,11 @@ func normalizePEM(data string) []byte {
 	return []byte(strings.TrimSpace(strings.ReplaceAll(data, "\\n", "\n")))
 }
 
-// parsePEMCertificates returns the leaf certificate and, if the PEM
-// contains more than one certificate, the rest of the chain in order.
-func parsePEMCertificates(pemData string) (*x509.Certificate, []*x509.Certificate, error) {
+// parsePEMCertificates returns the leaf certificate matching the
+// private key, plus the rest of the certificates as the chain. The
+// leaf is identified by public key so the PEM bundle can be in any
+// order (leaf-first, CA-first...).
+func parsePEMCertificates(pemData string, key crypto.Signer) (*x509.Certificate, []*x509.Certificate, error) {
 	rest := normalizePEM(pemData)
 	certs := []*x509.Certificate{}
 	for {
@@ -342,7 +409,20 @@ func parsePEMCertificates(pemData string) (*x509.Certificate, []*x509.Certificat
 	if len(certs) == 0 {
 		return nil, nil, errors.New("no certificate found in PEM data")
 	}
-	return certs[0], certs[1:], nil
+	pub, ok := key.Public().(interface{ Equal(crypto.PublicKey) bool })
+	if !ok {
+		return certs[0], certs[1:], nil
+	}
+	for i, c := range certs {
+		if !pub.Equal(c.PublicKey) {
+			continue
+		}
+		chain := make([]*x509.Certificate, 0, len(certs)-1)
+		chain = append(chain, certs[:i]...)
+		chain = append(chain, certs[i+1:]...)
+		return c, chain, nil
+	}
+	return nil, nil, errors.New("private key does not match any certificate in PEM data")
 }
 
 // parsePEMPrivateKey parses an RSA or ECDSA private key in PKCS#8,

--- a/utils/aws_roles_anywhere.go
+++ b/utils/aws_roles_anywhere.go
@@ -1,0 +1,373 @@
+package utils
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+// AWSRolesAnywhereConfig holds the parameters needed to obtain temporary
+// AWS credentials through IAM Roles Anywhere instead of long-lived
+// access keys. The certificate and private key are PEM encoded; the
+// certificate value may contain the full chain, leaf first.
+type AWSRolesAnywhereConfig struct {
+	Certificate    string `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	PrivateKey     string `json:"private_key,omitempty" yaml:"private_key,omitempty"`
+	TrustAnchorARN string `json:"trust_anchor_arn,omitempty" yaml:"trust_anchor_arn,omitempty"`
+	ProfileARN     string `json:"profile_arn,omitempty" yaml:"profile_arn,omitempty"`
+	RoleARN        string `json:"role_arn,omitempty" yaml:"role_arn,omitempty"`
+}
+
+// IsEnabled reports whether the user provided any Roles Anywhere
+// parameter at all, which selects this authentication method.
+func (c AWSRolesAnywhereConfig) IsEnabled() bool {
+	return c.Certificate != "" ||
+		c.PrivateKey != "" ||
+		c.TrustAnchorARN != "" ||
+		c.ProfileARN != "" ||
+		c.RoleARN != ""
+}
+
+func (c AWSRolesAnywhereConfig) Validate() error {
+	if c.Certificate == "" {
+		return errors.New("missing roles_anywhere.certificate")
+	}
+	if c.PrivateKey == "" {
+		return errors.New("missing roles_anywhere.private_key")
+	}
+	if c.TrustAnchorARN == "" {
+		return errors.New("missing roles_anywhere.trust_anchor_arn")
+	}
+	if c.ProfileARN == "" {
+		return errors.New("missing roles_anywhere.profile_arn")
+	}
+	if c.RoleARN == "" {
+		return errors.New("missing roles_anywhere.role_arn")
+	}
+	return nil
+}
+
+// ValidateAWSAuth validates that exactly one of the two supported AWS
+// authentication methods is fully configured: static access keys or
+// IAM Roles Anywhere.
+func ValidateAWSAuth(accessKey string, secretKey string, ra AWSRolesAnywhereConfig) error {
+	if ra.IsEnabled() {
+		if accessKey != "" || secretKey != "" {
+			return errors.New("provide either access_key/secret_key or roles_anywhere, not both")
+		}
+		return ra.Validate()
+	}
+	if accessKey == "" {
+		return errors.New("missing access_key")
+	}
+	if secretKey == "" {
+		return errors.New("missing secret_key")
+	}
+	return nil
+}
+
+// NewAWSCredentials returns aws-sdk-go credentials backed by either the
+// static access keys or, when configured, IAM Roles Anywhere.
+func NewAWSCredentials(accessKey string, secretKey string, ra AWSRolesAnywhereConfig) (*credentials.Credentials, error) {
+	if !ra.IsEnabled() {
+		return credentials.NewStaticCredentials(accessKey, secretKey, ""), nil
+	}
+	p, err := newRolesAnywhereProvider(ra)
+	if err != nil {
+		return nil, err
+	}
+	return credentials.NewCredentials(p), nil
+}
+
+const (
+	rolesAnywhereProviderName   = "AWSRolesAnywhere"
+	rolesAnywhereSessionSeconds = 3600
+	// Refresh credentials a bit before they actually expire so requests
+	// in flight never race the expiration.
+	rolesAnywhereExpiryWindow = 5 * time.Minute
+)
+
+// rolesAnywhereProvider implements credentials.Provider by calling the
+// Roles Anywhere CreateSession API, authenticated with the configured
+// X.509 certificate. CreateSession uses a SigV4 variant (SigV4-X509)
+// that no AWS SDK implements natively, so the signing is done here.
+// Reference: https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-sign-process.html
+type rolesAnywhereProvider struct {
+	credentials.Expiry
+
+	conf AWSRolesAnywhereConfig
+
+	cert      *x509.Certificate
+	chain     []*x509.Certificate
+	key       crypto.Signer
+	algorithm string
+
+	region   string
+	endpoint string
+
+	httpClient *http.Client
+	now        func() time.Time
+}
+
+func newRolesAnywhereProvider(conf AWSRolesAnywhereConfig) (*rolesAnywhereProvider, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, err
+	}
+	cert, chain, err := parsePEMCertificates(conf.Certificate)
+	if err != nil {
+		return nil, fmt.Errorf("roles_anywhere.certificate: %v", err)
+	}
+	key, algorithm, err := parsePEMPrivateKey(conf.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("roles_anywhere.private_key: %v", err)
+	}
+	region, endpoint, err := rolesAnywhereEndpoint(conf.TrustAnchorARN)
+	if err != nil {
+		return nil, fmt.Errorf("roles_anywhere.trust_anchor_arn: %v", err)
+	}
+	return &rolesAnywhereProvider{
+		conf:       conf,
+		cert:       cert,
+		chain:      chain,
+		key:        key,
+		algorithm:  algorithm,
+		region:     region,
+		endpoint:   endpoint,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		now:        time.Now,
+	}, nil
+}
+
+func (p *rolesAnywhereProvider) Retrieve() (credentials.Value, error) {
+	body, err := json.Marshal(map[string]interface{}{
+		"durationSeconds": rolesAnywhereSessionSeconds,
+		"profileArn":      p.conf.ProfileARN,
+		"roleArn":         p.conf.RoleARN,
+		"trustAnchorArn":  p.conf.TrustAnchorARN,
+	})
+	if err != nil {
+		return credentials.Value{}, err
+	}
+
+	u, err := url.Parse(p.endpoint)
+	if err != nil {
+		return credentials.Value{}, fmt.Errorf("rolesanywhere endpoint: %v", err)
+	}
+
+	now := p.now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	scope := fmt.Sprintf("%s/%s/rolesanywhere/aws4_request", now.Format("20060102"), p.region)
+
+	// Headers included in the signature, already in the sorted order
+	// required by the canonical request.
+	headers := [][2]string{
+		{"content-type", "application/json"},
+		{"host", u.Host},
+		{"x-amz-date", amzDate},
+		{"x-amz-x509", base64.StdEncoding.EncodeToString(p.cert.Raw)},
+	}
+	if len(p.chain) != 0 {
+		encoded := make([]string, 0, len(p.chain))
+		for _, c := range p.chain {
+			encoded = append(encoded, base64.StdEncoding.EncodeToString(c.Raw))
+		}
+		headers = append(headers, [2]string{"x-amz-x509-chain", strings.Join(encoded, ",")})
+	}
+
+	canonicalHeaders := strings.Builder{}
+	signedNames := make([]string, 0, len(headers))
+	for _, h := range headers {
+		canonicalHeaders.WriteString(h[0] + ":" + h[1] + "\n")
+		signedNames = append(signedNames, h[0])
+	}
+	signedHeaders := strings.Join(signedNames, ";")
+
+	payloadHash := sha256.Sum256(body)
+	canonicalRequest := strings.Join([]string{
+		"POST",
+		"/sessions",
+		"", // no query string
+		canonicalHeaders.String(),
+		signedHeaders,
+		hex.EncodeToString(payloadHash[:]),
+	}, "\n")
+
+	canonicalHash := sha256.Sum256([]byte(canonicalRequest))
+	stringToSign := strings.Join([]string{
+		p.algorithm,
+		amzDate,
+		scope,
+		hex.EncodeToString(canonicalHash[:]),
+	}, "\n")
+
+	digest := sha256.Sum256([]byte(stringToSign))
+	var signature []byte
+	switch k := p.key.(type) {
+	case *rsa.PrivateKey:
+		signature, err = rsa.SignPKCS1v15(rand.Reader, k, crypto.SHA256, digest[:])
+	case *ecdsa.PrivateKey:
+		signature, err = ecdsa.SignASN1(rand.Reader, k, digest[:])
+	default:
+		err = fmt.Errorf("unsupported private key type %T", p.key)
+	}
+	if err != nil {
+		return credentials.Value{}, fmt.Errorf("rolesanywhere signing: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, p.endpoint+"/sessions", strings.NewReader(string(body)))
+	if err != nil {
+		return credentials.Value{}, err
+	}
+	for _, h := range headers {
+		if h[0] == "host" {
+			continue
+		}
+		req.Header.Set(h[0], h[1])
+	}
+	req.Header.Set("Authorization", fmt.Sprintf(
+		"%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		p.algorithm, p.cert.SerialNumber.String(), scope, signedHeaders, hex.EncodeToString(signature)))
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return credentials.Value{}, fmt.Errorf("rolesanywhere CreateSession: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return credentials.Value{}, fmt.Errorf("rolesanywhere CreateSession: %v", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return credentials.Value{}, fmt.Errorf("rolesanywhere CreateSession status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	session := struct {
+		CredentialSet []struct {
+			Credentials struct {
+				AccessKeyID     string `json:"accessKeyId"`
+				SecretAccessKey string `json:"secretAccessKey"`
+				SessionToken    string `json:"sessionToken"`
+				Expiration      string `json:"expiration"`
+			} `json:"credentials"`
+		} `json:"credentialSet"`
+	}{}
+	if err := json.Unmarshal(respBody, &session); err != nil {
+		return credentials.Value{}, fmt.Errorf("rolesanywhere CreateSession response: %v", err)
+	}
+	if len(session.CredentialSet) == 0 {
+		return credentials.Value{}, errors.New("rolesanywhere CreateSession response: empty credentialSet")
+	}
+	creds := session.CredentialSet[0].Credentials
+	if creds.AccessKeyID == "" || creds.SecretAccessKey == "" {
+		return credentials.Value{}, errors.New("rolesanywhere CreateSession response: missing credentials")
+	}
+
+	expiration, err := time.Parse(time.RFC3339, creds.Expiration)
+	if err != nil {
+		return credentials.Value{}, fmt.Errorf("rolesanywhere CreateSession expiration: %v", err)
+	}
+	window := rolesAnywhereExpiryWindow
+	if remaining := expiration.Sub(now); remaining < 2*window {
+		window = remaining / 2
+	}
+	p.SetExpiration(expiration, window)
+
+	return credentials.Value{
+		AccessKeyID:     creds.AccessKeyID,
+		SecretAccessKey: creds.SecretAccessKey,
+		SessionToken:    creds.SessionToken,
+		ProviderName:    rolesAnywhereProviderName,
+	}, nil
+}
+
+// rolesAnywhereEndpoint derives the region and API endpoint from the
+// trust anchor ARN, like:
+// arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/uuid
+func rolesAnywhereEndpoint(trustAnchorARN string) (string, string, error) {
+	parts := strings.Split(trustAnchorARN, ":")
+	if len(parts) < 6 || parts[0] != "arn" || parts[2] != "rolesanywhere" || parts[3] == "" {
+		return "", "", fmt.Errorf("invalid trust anchor ARN %q", trustAnchorARN)
+	}
+	region := parts[3]
+	domain := "amazonaws.com"
+	if parts[1] == "aws-cn" {
+		domain = "amazonaws.com.cn"
+	}
+	return region, fmt.Sprintf("https://rolesanywhere.%s.%s", region, domain), nil
+}
+
+// normalizePEM allows PEM values pasted as a single line with literal
+// "\n" sequences, which is common when configs are edited in a UI.
+// Backslashes never appear in real PEM content so this is safe.
+func normalizePEM(data string) []byte {
+	return []byte(strings.TrimSpace(strings.ReplaceAll(data, "\\n", "\n")))
+}
+
+// parsePEMCertificates returns the leaf certificate and, if the PEM
+// contains more than one certificate, the rest of the chain in order.
+func parsePEMCertificates(pemData string) (*x509.Certificate, []*x509.Certificate, error) {
+	rest := normalizePEM(pemData)
+	certs := []*x509.Certificate{}
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		c, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid certificate: %v", err)
+		}
+		certs = append(certs, c)
+	}
+	if len(certs) == 0 {
+		return nil, nil, errors.New("no certificate found in PEM data")
+	}
+	return certs[0], certs[1:], nil
+}
+
+// parsePEMPrivateKey parses an RSA or ECDSA private key in PKCS#8,
+// PKCS#1 or SEC1 PEM form and returns it along with the matching
+// Roles Anywhere signing algorithm identifier.
+func parsePEMPrivateKey(pemData string) (crypto.Signer, string, error) {
+	block, _ := pem.Decode(normalizePEM(pemData))
+	if block == nil {
+		return nil, "", errors.New("no private key found in PEM data")
+	}
+	var key interface{}
+	var err error
+	if key, err = x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+		if key, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+			if key, err = x509.ParseECPrivateKey(block.Bytes); err != nil {
+				return nil, "", errors.New("invalid private key: expecting PKCS#8, PKCS#1 or SEC1 PEM")
+			}
+		}
+	}
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		return k, "AWS4-X509-RSA-SHA256", nil
+	case *ecdsa.PrivateKey:
+		return k, "AWS4-X509-ECDSA-SHA256", nil
+	default:
+		return nil, "", fmt.Errorf("unsupported private key type %T, expecting RSA or ECDSA", key)
+	}
+}

--- a/utils/aws_roles_anywhere_test.go
+++ b/utils/aws_roles_anywhere_test.go
@@ -89,7 +89,12 @@ func makeTestCert(t *testing.T, keyType string, serial int64, issuerKey crypto.S
 // key of the certificate presented in X-Amz-X509.
 func newFakeRolesAnywhereServer(t *testing.T, expiration time.Time, onRequest func(r *http.Request, body []byte)) *httptest.Server {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(makeFakeRolesAnywhereHandler(t, expiration, onRequest)))
+}
+
+func makeFakeRolesAnywhereHandler(t *testing.T, expiration time.Time, onRequest func(r *http.Request, body []byte)) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/sessions" {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -201,7 +206,7 @@ func newFakeRolesAnywhereServer(t *testing.T, expiration time.Time, onRequest fu
 				},
 			}},
 		})
-	}))
+	}
 }
 
 func parseTestAuthorization(auth string) (algorithm string, credential string, signedHeaders string, signature string, err error) {
@@ -289,6 +294,73 @@ func TestRolesAnywhereRetrieveECDSA(t *testing.T) {
 	testRetrieve(t, "ec")
 }
 
+func TestRolesAnywhereRetryOnServerError(t *testing.T) {
+	pair, _ := makeTestCert(t, "rsa", 21, nil, nil)
+
+	failuresLeft := 1
+	handler := makeFakeRolesAnywhereHandler(t, time.Now().Add(time.Hour), nil)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if failuresLeft > 0 {
+			failuresLeft--
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		handler(w, r)
+	}))
+	defer server.Close()
+
+	conf := AWSRolesAnywhereConfig{
+		Certificate:    pair.certPEM,
+		PrivateKey:     pair.keyPEM,
+		TrustAnchorARN: testTrustAnchorARN,
+		ProfileARN:     testProfileARN,
+		RoleARN:        testRoleARN,
+	}
+	p, err := newRolesAnywhereProvider(conf)
+	if err != nil {
+		t.Fatalf("newRolesAnywhereProvider: %v", err)
+	}
+	p.endpoint = server.URL
+
+	v, err := p.Retrieve()
+	if err != nil {
+		t.Fatalf("Retrieve should have retried past the 503: %v", err)
+	}
+	if v.AccessKeyID != "ASIAEXAMPLE" {
+		t.Errorf("unexpected credentials: %+v", v)
+	}
+}
+
+func TestRolesAnywhereClockSkew(t *testing.T) {
+	pair, _ := makeTestCert(t, "rsa", 23, nil, nil)
+
+	// Simulate a local clock far ahead of AWS: the returned expiration
+	// is already in the past. The provider must not enter a state where
+	// every SDK call triggers a new CreateSession.
+	server := newFakeRolesAnywhereServer(t, time.Now().Add(-2*time.Hour), nil)
+	defer server.Close()
+
+	conf := AWSRolesAnywhereConfig{
+		Certificate:    pair.certPEM,
+		PrivateKey:     pair.keyPEM,
+		TrustAnchorARN: testTrustAnchorARN,
+		ProfileARN:     testProfileARN,
+		RoleARN:        testRoleARN,
+	}
+	p, err := newRolesAnywhereProvider(conf)
+	if err != nil {
+		t.Fatalf("newRolesAnywhereProvider: %v", err)
+	}
+	p.endpoint = server.URL
+
+	if _, err := p.Retrieve(); err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	if p.IsExpired() {
+		t.Errorf("credentials should be kept for a minimum period despite a skewed expiration")
+	}
+}
+
 func TestRolesAnywhereCertificateChain(t *testing.T) {
 	caPair, caKey := makeTestCert(t, "rsa", 1, nil, nil)
 	leafPair, _ := makeTestCert(t, "rsa", 2, caKey, caPair.cert)
@@ -318,6 +390,50 @@ func TestRolesAnywhereCertificateChain(t *testing.T) {
 	expectedChain := base64.StdEncoding.EncodeToString(caPair.cert.Raw)
 	if chainSeen != expectedChain {
 		t.Errorf("x-amz-x509-chain = %q, expected %q", chainSeen, expectedChain)
+	}
+}
+
+func TestRolesAnywhereCertificateChainCAFirst(t *testing.T) {
+	caPair, caKey := makeTestCert(t, "rsa", 3, nil, nil)
+	leafPair, _ := makeTestCert(t, "rsa", 4, caKey, caPair.cert)
+
+	// The fake server asserts that the Credential serial matches the
+	// certificate presented in X-Amz-X509, so this passing proves the
+	// leaf was correctly identified despite the CA coming first.
+	server := newFakeRolesAnywhereServer(t, time.Now().Add(time.Hour), nil)
+	defer server.Close()
+
+	conf := AWSRolesAnywhereConfig{
+		Certificate:    caPair.certPEM + leafPair.certPEM,
+		PrivateKey:     leafPair.keyPEM,
+		TrustAnchorARN: testTrustAnchorARN,
+		ProfileARN:     testProfileARN,
+		RoleARN:        testRoleARN,
+	}
+	p, err := newRolesAnywhereProvider(conf)
+	if err != nil {
+		t.Fatalf("newRolesAnywhereProvider: %v", err)
+	}
+	p.endpoint = server.URL
+
+	if _, err := p.Retrieve(); err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+}
+
+func TestRolesAnywhereKeyCertificateMismatch(t *testing.T) {
+	pairA, _ := makeTestCert(t, "rsa", 5, nil, nil)
+	pairB, _ := makeTestCert(t, "rsa", 6, nil, nil)
+
+	conf := AWSRolesAnywhereConfig{
+		Certificate:    pairA.certPEM,
+		PrivateKey:     pairB.keyPEM,
+		TrustAnchorARN: testTrustAnchorARN,
+		ProfileARN:     testProfileARN,
+		RoleARN:        testRoleARN,
+	}
+	if _, err := newRolesAnywhereProvider(conf); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected key/certificate mismatch error, got: %v", err)
 	}
 }
 

--- a/utils/aws_roles_anywhere_test.go
+++ b/utils/aws_roles_anywhere_test.go
@@ -1,0 +1,481 @@
+package utils
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testTrustAnchorARN = "arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/6d4f4c6f-8b3a-4c22-9d1e-000000000000"
+	testProfileARN     = "arn:aws:rolesanywhere:us-east-1:123456789012:profile/2f9c8a10-1111-2222-3333-000000000000"
+	testRoleARN        = "arn:aws:iam::123456789012:role/lc-adapter"
+)
+
+type testKeyPair struct {
+	certPEM string
+	keyPEM  string
+	cert    *x509.Certificate
+}
+
+func makeTestCert(t *testing.T, keyType string, serial int64, issuerKey crypto.Signer, issuerCert *x509.Certificate) (testKeyPair, crypto.Signer) {
+	t.Helper()
+	var key crypto.Signer
+	var err error
+	switch keyType {
+	case "rsa":
+		key, err = rsa.GenerateKey(rand.Reader, 2048)
+	case "ec":
+		key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	default:
+		t.Fatalf("unknown key type %s", keyType)
+	}
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: fmt.Sprintf("test-%s-%d", keyType, serial)},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:         true,
+	}
+	parent := template
+	signKey := key
+	if issuerCert != nil {
+		parent = issuerCert
+		signKey = issuerKey
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, parent, key.Public(), signKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return testKeyPair{certPEM: string(certPEM), keyPEM: string(keyPEM), cert: cert}, key
+}
+
+// newFakeRolesAnywhereServer returns an httptest server that validates
+// incoming CreateSession requests exactly like the real service: it
+// rebuilds the canonical request from the headers listed in the
+// Authorization header and verifies the signature against the public
+// key of the certificate presented in X-Amz-X509.
+func newFakeRolesAnywhereServer(t *testing.T, expiration time.Time, onRequest func(r *http.Request, body []byte)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/sessions" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		auth := r.Header.Get("Authorization")
+		algorithm, credential, signedHeaders, signature, err := parseTestAuthorization(auth)
+		if err != nil {
+			t.Errorf("authorization header %q: %v", auth, err)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		certDER, err := base64.StdEncoding.DecodeString(r.Header.Get("X-Amz-X509"))
+		if err != nil {
+			t.Errorf("x-amz-x509 decode: %v", err)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		cert, err := x509.ParseCertificate(certDER)
+		if err != nil {
+			t.Errorf("x-amz-x509 parse: %v", err)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		serialAndScope := strings.SplitN(credential, "/", 2)
+		if serialAndScope[0] != cert.SerialNumber.String() {
+			t.Errorf("credential serial %q does not match certificate serial %q", serialAndScope[0], cert.SerialNumber.String())
+		}
+
+		// Rebuild the canonical request from what was actually received.
+		canonicalHeaders := strings.Builder{}
+		for _, h := range strings.Split(signedHeaders, ";") {
+			v := r.Header.Get(h)
+			if h == "host" {
+				v = r.Host
+			}
+			canonicalHeaders.WriteString(h + ":" + v + "\n")
+		}
+		payloadHash := sha256.Sum256(body)
+		canonicalRequest := strings.Join([]string{
+			"POST",
+			"/sessions",
+			"",
+			canonicalHeaders.String(),
+			signedHeaders,
+			hex.EncodeToString(payloadHash[:]),
+		}, "\n")
+		canonicalHash := sha256.Sum256([]byte(canonicalRequest))
+		stringToSign := strings.Join([]string{
+			algorithm,
+			r.Header.Get("X-Amz-Date"),
+			serialAndScope[1],
+			hex.EncodeToString(canonicalHash[:]),
+		}, "\n")
+		digest := sha256.Sum256([]byte(stringToSign))
+
+		sig, err := hex.DecodeString(signature)
+		if err != nil {
+			t.Errorf("signature decode: %v", err)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		switch pub := cert.PublicKey.(type) {
+		case *rsa.PublicKey:
+			if algorithm != "AWS4-X509-RSA-SHA256" {
+				t.Errorf("algorithm %q does not match RSA key", algorithm)
+			}
+			if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, digest[:], sig); err != nil {
+				t.Errorf("RSA signature verification failed: %v", err)
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+		case *ecdsa.PublicKey:
+			if algorithm != "AWS4-X509-ECDSA-SHA256" {
+				t.Errorf("algorithm %q does not match ECDSA key", algorithm)
+			}
+			if !ecdsa.VerifyASN1(pub, digest[:], sig) {
+				t.Errorf("ECDSA signature verification failed")
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+		default:
+			t.Errorf("unexpected public key type %T", pub)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		if onRequest != nil {
+			onRequest(r, body)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"credentialSet": []map[string]interface{}{{
+				"credentials": map[string]interface{}{
+					"accessKeyId":     "ASIAEXAMPLE",
+					"secretAccessKey": "secretExample",
+					"sessionToken":    "tokenExample",
+					"expiration":      expiration.UTC().Format(time.RFC3339),
+				},
+			}},
+		})
+	}))
+}
+
+func parseTestAuthorization(auth string) (algorithm string, credential string, signedHeaders string, signature string, err error) {
+	algoAndRest := strings.SplitN(auth, " ", 2)
+	if len(algoAndRest) != 2 {
+		return "", "", "", "", fmt.Errorf("malformed header")
+	}
+	algorithm = algoAndRest[0]
+	for _, part := range strings.Split(algoAndRest[1], ", ") {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return "", "", "", "", fmt.Errorf("malformed component %q", part)
+		}
+		switch kv[0] {
+		case "Credential":
+			credential = kv[1]
+		case "SignedHeaders":
+			signedHeaders = kv[1]
+		case "Signature":
+			signature = kv[1]
+		}
+	}
+	if credential == "" || signedHeaders == "" || signature == "" {
+		return "", "", "", "", fmt.Errorf("missing component")
+	}
+	return algorithm, credential, signedHeaders, signature, nil
+}
+
+func testRetrieve(t *testing.T, keyType string) {
+	pair, _ := makeTestCert(t, keyType, 424242, nil, nil)
+
+	var gotBody map[string]interface{}
+	server := newFakeRolesAnywhereServer(t, time.Now().Add(time.Hour), func(r *http.Request, body []byte) {
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Errorf("request body: %v", err)
+		}
+	})
+	defer server.Close()
+
+	conf := AWSRolesAnywhereConfig{
+		Certificate:    pair.certPEM,
+		PrivateKey:     pair.keyPEM,
+		TrustAnchorARN: testTrustAnchorARN,
+		ProfileARN:     testProfileARN,
+		RoleARN:        testRoleARN,
+	}
+	p, err := newRolesAnywhereProvider(conf)
+	if err != nil {
+		t.Fatalf("newRolesAnywhereProvider: %v", err)
+	}
+	p.endpoint = server.URL
+
+	v, err := p.Retrieve()
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	if v.AccessKeyID != "ASIAEXAMPLE" || v.SecretAccessKey != "secretExample" || v.SessionToken != "tokenExample" {
+		t.Errorf("unexpected credentials: %+v", v)
+	}
+	if v.ProviderName != rolesAnywhereProviderName {
+		t.Errorf("unexpected provider name: %s", v.ProviderName)
+	}
+	if p.IsExpired() {
+		t.Errorf("credentials should not be expired right after retrieval")
+	}
+	for k, expected := range map[string]string{
+		"profileArn":     testProfileARN,
+		"roleArn":        testRoleARN,
+		"trustAnchorArn": testTrustAnchorARN,
+	} {
+		if gotBody[k] != expected {
+			t.Errorf("request body %s = %v, expected %s", k, gotBody[k], expected)
+		}
+	}
+	if gotBody["durationSeconds"] != float64(rolesAnywhereSessionSeconds) {
+		t.Errorf("request body durationSeconds = %v", gotBody["durationSeconds"])
+	}
+}
+
+func TestRolesAnywhereRetrieveRSA(t *testing.T) {
+	testRetrieve(t, "rsa")
+}
+
+func TestRolesAnywhereRetrieveECDSA(t *testing.T) {
+	testRetrieve(t, "ec")
+}
+
+func TestRolesAnywhereCertificateChain(t *testing.T) {
+	caPair, caKey := makeTestCert(t, "rsa", 1, nil, nil)
+	leafPair, _ := makeTestCert(t, "rsa", 2, caKey, caPair.cert)
+
+	chainSeen := ""
+	server := newFakeRolesAnywhereServer(t, time.Now().Add(time.Hour), func(r *http.Request, body []byte) {
+		chainSeen = r.Header.Get("X-Amz-X509-Chain")
+	})
+	defer server.Close()
+
+	conf := AWSRolesAnywhereConfig{
+		Certificate:    leafPair.certPEM + caPair.certPEM,
+		PrivateKey:     leafPair.keyPEM,
+		TrustAnchorARN: testTrustAnchorARN,
+		ProfileARN:     testProfileARN,
+		RoleARN:        testRoleARN,
+	}
+	p, err := newRolesAnywhereProvider(conf)
+	if err != nil {
+		t.Fatalf("newRolesAnywhereProvider: %v", err)
+	}
+	p.endpoint = server.URL
+
+	if _, err := p.Retrieve(); err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	expectedChain := base64.StdEncoding.EncodeToString(caPair.cert.Raw)
+	if chainSeen != expectedChain {
+		t.Errorf("x-amz-x509-chain = %q, expected %q", chainSeen, expectedChain)
+	}
+}
+
+func TestRolesAnywhereEscapedPEM(t *testing.T) {
+	pair, _ := makeTestCert(t, "rsa", 7, nil, nil)
+
+	server := newFakeRolesAnywhereServer(t, time.Now().Add(time.Hour), nil)
+	defer server.Close()
+
+	// Simulate a PEM pasted as a single line in a UI.
+	conf := AWSRolesAnywhereConfig{
+		Certificate:    strings.ReplaceAll(pair.certPEM, "\n", "\\n"),
+		PrivateKey:     strings.ReplaceAll(pair.keyPEM, "\n", "\\n"),
+		TrustAnchorARN: testTrustAnchorARN,
+		ProfileARN:     testProfileARN,
+		RoleARN:        testRoleARN,
+	}
+	p, err := newRolesAnywhereProvider(conf)
+	if err != nil {
+		t.Fatalf("newRolesAnywhereProvider: %v", err)
+	}
+	p.endpoint = server.URL
+	if _, err := p.Retrieve(); err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+}
+
+func TestRolesAnywhereErrorResponse(t *testing.T) {
+	pair, _ := makeTestCert(t, "rsa", 9, nil, nil)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"message":"AccessDeniedException"}`)
+	}))
+	defer server.Close()
+
+	conf := AWSRolesAnywhereConfig{
+		Certificate:    pair.certPEM,
+		PrivateKey:     pair.keyPEM,
+		TrustAnchorARN: testTrustAnchorARN,
+		ProfileARN:     testProfileARN,
+		RoleARN:        testRoleARN,
+	}
+	p, err := newRolesAnywhereProvider(conf)
+	if err != nil {
+		t.Fatalf("newRolesAnywhereProvider: %v", err)
+	}
+	p.endpoint = server.URL
+	if _, err := p.Retrieve(); err == nil || !strings.Contains(err.Error(), "status 403") {
+		t.Fatalf("expected 403 error, got: %v", err)
+	}
+}
+
+func TestRolesAnywhereEndpointFromARN(t *testing.T) {
+	for _, c := range []struct {
+		arn      string
+		region   string
+		endpoint string
+		isError  bool
+	}{
+		{arn: testTrustAnchorARN, region: "us-east-1", endpoint: "https://rolesanywhere.us-east-1.amazonaws.com"},
+		{arn: "arn:aws-us-gov:rolesanywhere:us-gov-west-1:123456789012:trust-anchor/abc", region: "us-gov-west-1", endpoint: "https://rolesanywhere.us-gov-west-1.amazonaws.com"},
+		{arn: "arn:aws-cn:rolesanywhere:cn-north-1:123456789012:trust-anchor/abc", region: "cn-north-1", endpoint: "https://rolesanywhere.cn-north-1.amazonaws.com.cn"},
+		{arn: "arn:aws:iam::123456789012:role/some-role", isError: true},
+		{arn: "not-an-arn", isError: true},
+		{arn: "arn:aws:rolesanywhere::123456789012:trust-anchor/abc", isError: true},
+	} {
+		region, endpoint, err := rolesAnywhereEndpoint(c.arn)
+		if c.isError {
+			if err == nil {
+				t.Errorf("expected error for %q", c.arn)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("unexpected error for %q: %v", c.arn, err)
+			continue
+		}
+		if region != c.region || endpoint != c.endpoint {
+			t.Errorf("arn %q: got (%s, %s), expected (%s, %s)", c.arn, region, endpoint, c.region, c.endpoint)
+		}
+	}
+}
+
+func TestValidateAWSAuth(t *testing.T) {
+	completeRA := AWSRolesAnywhereConfig{
+		Certificate:    "cert",
+		PrivateKey:     "key",
+		TrustAnchorARN: "arn:1",
+		ProfileARN:     "arn:2",
+		RoleARN:        "arn:3",
+	}
+	for _, c := range []struct {
+		name      string
+		accessKey string
+		secretKey string
+		ra        AWSRolesAnywhereConfig
+		errPart   string
+	}{
+		{name: "static keys", accessKey: "ak", secretKey: "sk"},
+		{name: "roles anywhere", ra: completeRA},
+		{name: "nothing", errPart: "missing access_key"},
+		{name: "missing secret", accessKey: "ak", errPart: "missing secret_key"},
+		{name: "both methods", accessKey: "ak", secretKey: "sk", ra: completeRA, errPart: "not both"},
+		{name: "partial roles anywhere", ra: AWSRolesAnywhereConfig{Certificate: "cert"}, errPart: "missing roles_anywhere.private_key"},
+		{name: "roles anywhere no role", ra: AWSRolesAnywhereConfig{Certificate: "cert", PrivateKey: "key", TrustAnchorARN: "a", ProfileARN: "b"}, errPart: "missing roles_anywhere.role_arn"},
+	} {
+		err := ValidateAWSAuth(c.accessKey, c.secretKey, c.ra)
+		if c.errPart == "" {
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", c.name, err)
+			}
+			continue
+		}
+		if err == nil || !strings.Contains(err.Error(), c.errPart) {
+			t.Errorf("%s: expected error containing %q, got: %v", c.name, c.errPart, err)
+		}
+	}
+}
+
+func TestNewAWSCredentialsStatic(t *testing.T) {
+	creds, err := NewAWSCredentials("ak", "sk", AWSRolesAnywhereConfig{})
+	if err != nil {
+		t.Fatalf("NewAWSCredentials: %v", err)
+	}
+	v, err := creds.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if v.AccessKeyID != "ak" || v.SecretAccessKey != "sk" {
+		t.Errorf("unexpected static credentials: %+v", v)
+	}
+}
+
+func TestNewAWSCredentialsBadInputs(t *testing.T) {
+	base := AWSRolesAnywhereConfig{
+		Certificate:    "-----BEGIN CERTIFICATE-----\nnotvalid\n-----END CERTIFICATE-----",
+		PrivateKey:     "-----BEGIN PRIVATE KEY-----\nnotvalid\n-----END PRIVATE KEY-----",
+		TrustAnchorARN: testTrustAnchorARN,
+		ProfileARN:     testProfileARN,
+		RoleARN:        testRoleARN,
+	}
+	if _, err := NewAWSCredentials("", "", base); err == nil {
+		t.Errorf("expected error for invalid certificate PEM")
+	}
+
+	pair, _ := makeTestCert(t, "rsa", 11, nil, nil)
+	badKey := base
+	badKey.Certificate = pair.certPEM
+	if _, err := NewAWSCredentials("", "", badKey); err == nil || !strings.Contains(err.Error(), "private_key") {
+		t.Errorf("expected private key error, got: %v", err)
+	}
+
+	badARN := base
+	badARN.Certificate = pair.certPEM
+	badARN.PrivateKey = pair.keyPEM
+	badARN.TrustAnchorARN = "arn:aws:s3:::bucket"
+	if _, err := NewAWSCredentials("", "", badARN); err == nil || !strings.Contains(err.Error(), "trust_anchor_arn") {
+		t.Errorf("expected trust anchor ARN error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for authenticating to AWS using [IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html) as an alternative to long-lived access keys, for the three adapters that talk to AWS: `s3`, `sqs` and `sqs-files` (which covers CloudTrail-style S3 bucket ingestion).

Instead of pasting a permanent `access_key`/`secret_key`, users can now provide an X.509 certificate + private key issued under a CA they registered as a Roles Anywhere trust anchor, along with the trust anchor / profile / role ARNs. The adapter exchanges the certificate for temporary session credentials via the Roles Anywhere `CreateSession` API and refreshes them automatically before expiry. The AWS credentials in use are always short-lived, the certificate is revocable and expiring, and no permanent IAM user is needed.

## Configuration

New optional `roles_anywhere` block on the three adapter configs, mutually exclusive with `access_key`/`secret_key`:

```yaml
roles_anywhere:
  certificate: <PEM leaf cert, optionally followed by its chain>
  private_key: <PEM RSA or ECDSA key (PKCS#8, PKCS#1 or SEC1)>
  trust_anchor_arn: arn:aws:rolesanywhere:us-east-1:123456789012:trust-anchor/UUID
  profile_arn: arn:aws:rolesanywhere:us-east-1:123456789012:profile/UUID
  role_arn: arn:aws:iam::123456789012:role/my-role
```

PEM values may also be passed on a single line with `\n` escapes (convenient for UI/CLI configs). The region and endpoint are derived from the trust anchor ARN, including GovCloud and CN partitions. Existing configs using access keys are unaffected.

## Implementation notes

- `CreateSession` uses a SigV4 variant (SigV4-X509) that is deliberately not implemented in any AWS SDK. The official `rolesanywhere-credential-helper` cannot be imported as a library without pulling in a cgo PKCS#11 dependency, which would break this repo's cross-compilation (AIX, Solaris, BSDs...). The signing process is small and publicly documented, so it is implemented directly in `utils/aws_roles_anywhere.go` per the [official signing spec](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-sign-process.html), using only the standard library.
- The provider plugs into the existing aws-sdk-go v1 `credentials.Provider` interface with expiry-based auto-refresh (5 minutes before expiration).
- Certificate chains are supported via the `X-Amz-X509-Chain` signed header for setups where the trust anchor is a root CA and the client cert is issued by an intermediate.

## Testing

- Mock Roles Anywhere server that validates requests exactly like the real service: it rebuilds the canonical request from the received headers and verifies the SigV4-X509 signature against the public key of the certificate presented in `X-Amz-X509`, for both RSA and ECDSA keys, including the serial-number credential field and algorithm/key-type match.
- Tests for certificate chain handling, single-line escaped PEM input, non-2xx API responses, endpoint derivation from ARNs across partitions, and invalid PEM/ARN inputs.
- Config validation tests for all three adapters covering the static-keys/Roles-Anywhere either-or logic.
- `go build ./...`, `go vet` and `go test` on all touched packages pass, plus cross-compile checks for `aix/ppc64` and `windows/amd64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiRyZ4DwMZtcpeYWh8oFFx