### PR TITLE
defender: add endpoint option for Microsoft national clouds (GCC, GCC High, DoD)

### DIFF
--- a/defender/client.go
+++ b/defender/client.go
@@ -18,44 +18,53 @@ import (
 	"github.com/refractionPOINT/usp-adapters/utils"
 )
 
-// Microsoft Graph national cloud deployments. Each environment has its own MS
-// Graph service root and Azure AD token host, and the OAuth2 scope must match
-// the Graph root. gcc-gov (US Government GCC / moderate) uses the worldwide
+// environment describes one Microsoft national cloud deployment. Keeping the
+// three values that must move together (alerts endpoint, token host and scope)
+// in a single struct makes a partial/desynced configuration impossible -- the
+// alertsURL, tokenHost and scope for an environment can never disagree.
+type environment struct {
+	// alertsURL is the MS Graph security alerts_v2 endpoint.
+	alertsURL string
+	// tokenHost is the Azure AD token host; the full token endpoint is
+	// <tokenHost>/<tenant_id>/oauth2/v2.0/token.
+	tokenHost string
+	// scope is the OAuth2 scope, which must match the MS Graph service root.
+	scope string
+}
+
+// environments maps an endpoint name to its Microsoft national cloud
+// deployment. gcc-gov (US Government GCC / moderate) uses the worldwide
 // endpoints -- identical to enterprise -- and is kept as a named option for
 // parity with the o365 adapter, which exposes the same four names.
 // Reference: https://learn.microsoft.com/en-us/graph/deployments
+var environments = map[string]environment{
+	"enterprise": {
+		alertsURL: "https://graph.microsoft.com/v1.0/security/alerts_v2",
+		tokenHost: "https://login.microsoftonline.com",
+		scope:     "https://graph.microsoft.com/.default",
+	},
+	"gcc-gov": {
+		alertsURL: "https://graph.microsoft.com/v1.0/security/alerts_v2",
+		tokenHost: "https://login.microsoftonline.com",
+		scope:     "https://graph.microsoft.com/.default",
+	},
+	"gcc-high-gov": {
+		alertsURL: "https://graph.microsoft.us/v1.0/security/alerts_v2",
+		tokenHost: "https://login.microsoftonline.us",
+		scope:     "https://graph.microsoft.us/.default",
+	},
+	"dod-gov": {
+		alertsURL: "https://dod-graph.microsoft.us/v1.0/security/alerts_v2",
+		tokenHost: "https://login.microsoftonline.us",
+		scope:     "https://dod-graph.microsoft.us/.default",
+	},
+}
 
 // defaultEndpoint is the environment used when Endpoint is left empty.
 const defaultEndpoint = "enterprise"
 
-// URL maps an environment name to its MS Graph security alerts_v2 endpoint.
-var URL = map[string]string{
-	"enterprise":   "https://graph.microsoft.com/v1.0/security/alerts_v2",
-	"gcc-gov":      "https://graph.microsoft.com/v1.0/security/alerts_v2",
-	"gcc-high-gov": "https://graph.microsoft.us/v1.0/security/alerts_v2",
-	"dod-gov":      "https://dod-graph.microsoft.us/v1.0/security/alerts_v2",
-}
-
-// TokenURL maps an environment name to its Azure AD token host. The full token
-// endpoint is <host>/<tenant_id>/oauth2/v2.0/token.
-var TokenURL = map[string]string{
-	"enterprise":   "https://login.microsoftonline.com",
-	"gcc-gov":      "https://login.microsoftonline.com",
-	"gcc-high-gov": "https://login.microsoftonline.us",
-	"dod-gov":      "https://login.microsoftonline.us",
-}
-
-// Scope maps an environment name to its OAuth2 scope, which must match that
-// environment's MS Graph service root.
-var Scope = map[string]string{
-	"enterprise":   "https://graph.microsoft.com/.default",
-	"gcc-gov":      "https://graph.microsoft.com/.default",
-	"gcc-high-gov": "https://graph.microsoft.us/.default",
-	"dod-gov":      "https://dod-graph.microsoft.us/.default",
-}
-
 const (
-	// defaultTokenURLTemplate is the Azure AD token endpoint host template,
+	// defaultTokenURLTemplate is the Azure AD token endpoint template,
 	// parameterized by the token host and tenant id.
 	defaultTokenURLTemplate = "%s/%s/oauth2/v2.0/token"
 
@@ -104,12 +113,16 @@ type DefenderConfig struct {
 
 	// TokenURL overrides the Azure AD token endpoint derived from Endpoint and
 	// TenantID (e.g. https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/token
-	// for the enterprise endpoint).
+	// for the enterprise endpoint). It only overrides the token URL; the OAuth2
+	// scope still follows Endpoint, so a token_url pointed at a gov host without
+	// also setting endpoint sends the commercial scope and will fail auth.
 	TokenURL string `json:"token_url" yaml:"token_url"`
 
 	// AlertsURL overrides the MS Graph security alerts endpoint derived from
 	// Endpoint (e.g. https://graph.microsoft.com/v1.0/security/alerts_v2 for
-	// the enterprise endpoint).
+	// the enterprise endpoint). It only overrides the alerts URL; the OAuth2
+	// scope still follows Endpoint, so an alerts_url pointed at a gov host
+	// without also setting endpoint sends the commercial scope and will 401.
 	AlertsURL string `json:"alerts_url" yaml:"alerts_url"`
 
 	// PollInterval overrides how long the adapter waits between polls of the
@@ -134,7 +147,7 @@ func (c *DefenderConfig) tokenURL() string {
 	if c.TokenURL != "" {
 		return c.TokenURL
 	}
-	return fmt.Sprintf(defaultTokenURLTemplate, TokenURL[c.endpoint()], c.TenantID)
+	return fmt.Sprintf(defaultTokenURLTemplate, environments[c.endpoint()].tokenHost, c.TenantID)
 }
 
 // alertsURL returns the alerts endpoint to use: the configured override, or
@@ -143,13 +156,13 @@ func (c *DefenderConfig) alertsURL() string {
 	if c.AlertsURL != "" {
 		return c.AlertsURL
 	}
-	return URL[c.endpoint()]
+	return environments[c.endpoint()].alertsURL
 }
 
 // scope returns the OAuth2 scope for the configured environment, which must
 // match that environment's MS Graph service root.
 func (c *DefenderConfig) scope() string {
-	return Scope[c.endpoint()]
+	return environments[c.endpoint()].scope
 }
 
 func (c *DefenderConfig) Validate() error {
@@ -166,7 +179,7 @@ func (c *DefenderConfig) Validate() error {
 		return errors.New("missing client_secret")
 	}
 	if c.Endpoint != "" {
-		if _, ok := URL[c.Endpoint]; !ok {
+		if _, ok := environments[c.Endpoint]; !ok {
 			return fmt.Errorf("invalid endpoint %q, must be one of: enterprise, gcc-gov, gcc-high-gov, dod-gov", c.Endpoint)
 		}
 	}
@@ -182,10 +195,20 @@ func NewDefenderAdapter(ctx context.Context, conf DefenderConfig) (*DefenderAdap
 // tests use to capture shipped events.
 func newDefenderAdapter(ctx context.Context, conf DefenderConfig, sink uspSink) (*DefenderAdapter, chan struct{}, error) {
 	var err error
+
+	// Resolve and validate the endpoint up front. Nothing on the runtime path
+	// (containers/general/tool.go) calls Validate(), so guard here too: a
+	// non-empty but unknown endpoint would otherwise resolve to empty URLs and
+	// scope and silently poll nothing.
+	if _, ok := environments[conf.endpoint()]; !ok {
+		return nil, nil, fmt.Errorf("not a valid api endpoint: %s", conf.Endpoint)
+	}
+
 	a := &DefenderAdapter{
 		conf:         conf,
 		ctx:          context.Background(),
 		doStop:       utils.NewEvent(),
+		endpoint:     conf.endpoint(),
 		pollInterval: conf.PollInterval,
 	}
 	if a.pollInterval <= 0 {
@@ -256,8 +279,10 @@ func (a *DefenderAdapter) fetchToken() (string, error) {
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	// Use the adapter's httpClient (10s timeout): a bare http.Client{} has no
+	// timeout, so a token host that accepts the TCP connection but never
+	// responds would hang the poll goroutine forever.
+	resp, err := a.httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("no bearer token returned: %s", err)
 	}
@@ -357,8 +382,10 @@ func (a *DefenderAdapter) makeOneListRequest(eventsUrl string, since string, las
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
 		req.Header.Set("Content-Type", "application/json")
 
-		client := &http.Client{}
-		resp, err := client.Do(req)
+		// Use the adapter's httpClient (10s timeout) rather than a bare
+		// http.Client{}, which has no timeout and would hang the poll goroutine
+		// forever against an endpoint that never responds.
+		resp, err := a.httpClient.Do(req)
 		if err != nil {
 			a.conf.ClientOptions.OnError(fmt.Errorf("Error making request: %s\n", err))
 			return nil, since, "", err

--- a/defender/client.go
+++ b/defender/client.go
@@ -1,7 +1,6 @@
 package usp_defender
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +8,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -18,15 +18,46 @@ import (
 	"github.com/refractionPOINT/usp-adapters/utils"
 )
 
-var scope = "https://graph.microsoft.com/.default"
+// Microsoft Graph national cloud deployments. Each environment has its own MS
+// Graph service root and Azure AD token host, and the OAuth2 scope must match
+// the Graph root. gcc-gov (US Government GCC / moderate) uses the worldwide
+// endpoints -- identical to enterprise -- and is kept as a named option for
+// parity with the o365 adapter, which exposes the same four names.
+// Reference: https://learn.microsoft.com/en-us/graph/deployments
+
+// defaultEndpoint is the environment used when Endpoint is left empty.
+const defaultEndpoint = "enterprise"
+
+// URL maps an environment name to its MS Graph security alerts_v2 endpoint.
 var URL = map[string]string{
-	"get_alerts": "https://graph.microsoft.com/v1.0/security/alerts_v2",
+	"enterprise":   "https://graph.microsoft.com/v1.0/security/alerts_v2",
+	"gcc-gov":      "https://graph.microsoft.com/v1.0/security/alerts_v2",
+	"gcc-high-gov": "https://graph.microsoft.us/v1.0/security/alerts_v2",
+	"dod-gov":      "https://dod-graph.microsoft.us/v1.0/security/alerts_v2",
+}
+
+// TokenURL maps an environment name to its Azure AD token host. The full token
+// endpoint is <host>/<tenant_id>/oauth2/v2.0/token.
+var TokenURL = map[string]string{
+	"enterprise":   "https://login.microsoftonline.com",
+	"gcc-gov":      "https://login.microsoftonline.com",
+	"gcc-high-gov": "https://login.microsoftonline.us",
+	"dod-gov":      "https://login.microsoftonline.us",
+}
+
+// Scope maps an environment name to its OAuth2 scope, which must match that
+// environment's MS Graph service root.
+var Scope = map[string]string{
+	"enterprise":   "https://graph.microsoft.com/.default",
+	"gcc-gov":      "https://graph.microsoft.com/.default",
+	"gcc-high-gov": "https://graph.microsoft.us/.default",
+	"dod-gov":      "https://dod-graph.microsoft.us/.default",
 }
 
 const (
-	// defaultTokenURLTemplate is the Microsoft identity platform token endpoint,
-	// parameterized by tenant id.
-	defaultTokenURLTemplate = "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
+	// defaultTokenURLTemplate is the Azure AD token endpoint host template,
+	// parameterized by the token host and tenant id.
+	defaultTokenURLTemplate = "%s/%s/oauth2/v2.0/token"
 
 	// defaultPollInterval is how long the adapter waits between polls of the
 	// alerts endpoint.
@@ -63,12 +94,22 @@ type DefenderConfig struct {
 	ClientID      string                  `json:"client_id" yaml:"client_id"`
 	ClientSecret  string                  `json:"client_secret" yaml:"client_secret"`
 
-	// TokenURL overrides the Microsoft identity platform token endpoint
-	// (default: https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/token).
+	// Endpoint selects the Microsoft national cloud deployment. Valid values:
+	// "enterprise" (default, global/commercial), "gcc-gov" (US Government GCC /
+	// moderate), "gcc-high-gov" (US Government GCC High / L4) and "dod-gov"
+	// (US Government DoD / L5). An empty value defaults to "enterprise", so
+	// existing configs keep talking to the commercial cloud unchanged.
+	// Reference: https://learn.microsoft.com/en-us/graph/deployments
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
+
+	// TokenURL overrides the Azure AD token endpoint derived from Endpoint and
+	// TenantID (e.g. https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/token
+	// for the enterprise endpoint).
 	TokenURL string `json:"token_url" yaml:"token_url"`
 
-	// AlertsURL overrides the MS Graph security alerts endpoint
-	// (default: https://graph.microsoft.com/v1.0/security/alerts_v2).
+	// AlertsURL overrides the MS Graph security alerts endpoint derived from
+	// Endpoint (e.g. https://graph.microsoft.com/v1.0/security/alerts_v2 for
+	// the enterprise endpoint).
 	AlertsURL string `json:"alerts_url" yaml:"alerts_url"`
 
 	// PollInterval overrides how long the adapter waits between polls of the
@@ -78,22 +119,37 @@ type DefenderConfig struct {
 	PollInterval time.Duration `json:"-" yaml:"-"`
 }
 
+// endpoint returns the configured Microsoft national cloud deployment name,
+// defaulting to "enterprise" when unset.
+func (c *DefenderConfig) endpoint() string {
+	if c.Endpoint == "" {
+		return defaultEndpoint
+	}
+	return c.Endpoint
+}
+
 // tokenURL returns the token endpoint to use: the configured override, or the
-// default Microsoft identity platform endpoint for the configured tenant.
+// Azure AD token endpoint for the configured environment and tenant.
 func (c *DefenderConfig) tokenURL() string {
 	if c.TokenURL != "" {
 		return c.TokenURL
 	}
-	return fmt.Sprintf(defaultTokenURLTemplate, c.TenantID)
+	return fmt.Sprintf(defaultTokenURLTemplate, TokenURL[c.endpoint()], c.TenantID)
 }
 
 // alertsURL returns the alerts endpoint to use: the configured override, or
-// the default MS Graph security alerts endpoint.
+// the MS Graph security alerts endpoint for the configured environment.
 func (c *DefenderConfig) alertsURL() string {
 	if c.AlertsURL != "" {
 		return c.AlertsURL
 	}
-	return URL["get_alerts"]
+	return URL[c.endpoint()]
+}
+
+// scope returns the OAuth2 scope for the configured environment, which must
+// match that environment's MS Graph service root.
+func (c *DefenderConfig) scope() string {
+	return Scope[c.endpoint()]
 }
 
 func (c *DefenderConfig) Validate() error {
@@ -108,6 +164,11 @@ func (c *DefenderConfig) Validate() error {
 	}
 	if c.ClientSecret == "" {
 		return errors.New("missing client_secret")
+	}
+	if c.Endpoint != "" {
+		if _, ok := URL[c.Endpoint]; !ok {
+			return fmt.Errorf("invalid endpoint %q, must be one of: enterprise, gcc-gov, gcc-high-gov, dod-gov", c.Endpoint)
+		}
 	}
 	return nil
 }
@@ -181,10 +242,14 @@ func (a *DefenderAdapter) Close() error {
 
 func (a *DefenderAdapter) fetchToken() (string, error) {
 
-	url := a.conf.tokenURL()
-	payload := fmt.Sprintf("client_id=%s&scope=%s&grant_type=%s&client_secret=%s", a.conf.ClientID, scope, "client_credentials", a.conf.ClientSecret)
+	tokenURL := a.conf.tokenURL()
+	form := url.Values{}
+	form.Set("client_id", a.conf.ClientID)
+	form.Set("scope", a.conf.scope())
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_secret", a.conf.ClientSecret)
 
-	req, err := http.NewRequest("POST", url, bytes.NewBufferString(payload))
+	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return "", fmt.Errorf("no bearer token returned: %s", err)
 	}

--- a/defender/client_test.go
+++ b/defender/client_test.go
@@ -59,6 +59,26 @@ func TestValidate(t *testing.T) {
 		c.ClientSecret = ""
 		assert.Error(t, c.Validate())
 	})
+
+	t.Run("empty endpoint is valid (defaults to enterprise)", func(t *testing.T) {
+		c := valid()
+		c.Endpoint = ""
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("known endpoints are valid", func(t *testing.T) {
+		for _, ep := range []string{"enterprise", "gcc-gov", "gcc-high-gov", "dod-gov"} {
+			c := valid()
+			c.Endpoint = ep
+			assert.NoErrorf(t, c.Validate(), "endpoint %q should be valid", ep)
+		}
+	})
+
+	t.Run("rejects an unknown endpoint", func(t *testing.T) {
+		c := valid()
+		c.Endpoint = "china"
+		assert.Error(t, c.Validate())
+	})
 }
 
 func TestEndpointDefaults(t *testing.T) {
@@ -86,6 +106,70 @@ func TestEndpointDefaults(t *testing.T) {
 		c := DefenderConfig{AlertsURL: "https://mock.example.com/v1.0/security/alerts_v2"}
 		assert.Equal(t, "https://mock.example.com/v1.0/security/alerts_v2", c.alertsURL())
 	})
+
+	t.Run("scope defaults to the commercial MS Graph root", func(t *testing.T) {
+		c := DefenderConfig{}
+		assert.Equal(t, "https://graph.microsoft.com/.default", c.scope())
+	})
+
+	t.Run("empty endpoint resolves to the commercial cloud", func(t *testing.T) {
+		c := DefenderConfig{TenantID: "11111111-1111-1111-1111-111111111111"}
+		assert.Equal(t, "https://graph.microsoft.com/v1.0/security/alerts_v2", c.alertsURL())
+		assert.Equal(t,
+			"https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/oauth2/v2.0/token",
+			c.tokenURL())
+		assert.Equal(t, "https://graph.microsoft.com/.default", c.scope())
+	})
+}
+
+// TestEndpointEnvironments pins the alerts URL, token URL and OAuth2 scope
+// each named Microsoft national cloud deployment resolves to. Sources are the
+// MS Graph deployments doc (https://learn.microsoft.com/en-us/graph/deployments):
+// gcc-gov shares the worldwide endpoints with enterprise; gcc-high-gov (L4)
+// uses graph.microsoft.us; dod-gov (L5) uses dod-graph.microsoft.us; both L4
+// and L5 authenticate against login.microsoftonline.us. The scope always
+// matches the Graph service root.
+func TestEndpointEnvironments(t *testing.T) {
+	const tenant = "11111111-1111-1111-1111-111111111111"
+	cases := []struct {
+		endpoint  string
+		alertsURL string
+		tokenURL  string
+		scope     string
+	}{
+		{
+			endpoint:  "enterprise",
+			alertsURL: "https://graph.microsoft.com/v1.0/security/alerts_v2",
+			tokenURL:  "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/token",
+			scope:     "https://graph.microsoft.com/.default",
+		},
+		{
+			endpoint:  "gcc-gov",
+			alertsURL: "https://graph.microsoft.com/v1.0/security/alerts_v2",
+			tokenURL:  "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/token",
+			scope:     "https://graph.microsoft.com/.default",
+		},
+		{
+			endpoint:  "gcc-high-gov",
+			alertsURL: "https://graph.microsoft.us/v1.0/security/alerts_v2",
+			tokenURL:  "https://login.microsoftonline.us/" + tenant + "/oauth2/v2.0/token",
+			scope:     "https://graph.microsoft.us/.default",
+		},
+		{
+			endpoint:  "dod-gov",
+			alertsURL: "https://dod-graph.microsoft.us/v1.0/security/alerts_v2",
+			tokenURL:  "https://login.microsoftonline.us/" + tenant + "/oauth2/v2.0/token",
+			scope:     "https://dod-graph.microsoft.us/.default",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.endpoint, func(t *testing.T) {
+			c := DefenderConfig{TenantID: tenant, Endpoint: tc.endpoint}
+			assert.Equal(t, tc.alertsURL, c.alertsURL(), "alerts URL")
+			assert.Equal(t, tc.tokenURL, c.tokenURL(), "token URL")
+			assert.Equal(t, tc.scope, c.scope(), "scope")
+		})
+	}
 }
 
 // TestPollIntervalDefault verifies an unset poll_interval falls back to the

--- a/defender/mock_test.go
+++ b/defender/mock_test.go
@@ -99,6 +99,11 @@ type mockMicrosoft struct {
 	alerts   []map[string]interface{} // ascending createdDateTime
 	pageSize int                      // 0 = no truncation
 
+	// expectedScope is the OAuth2 scope the token endpoint requires. It varies
+	// by Microsoft cloud (commercial vs. gov), so tests set it to match the
+	// adapter's configured Endpoint. Set once before the server starts.
+	expectedScope string
+
 	tokenRequests int
 	alertRequests int
 	nextLinks     int
@@ -109,7 +114,9 @@ type mockMicrosoft struct {
 }
 
 func newMockMicrosoft() *mockMicrosoft {
-	return &mockMicrosoft{}
+	return &mockMicrosoft{
+		expectedScope: "https://graph.microsoft.com/.default",
+	}
 }
 
 // appendAlert appends an alert at the end of the dataset (newest last),
@@ -199,7 +206,7 @@ func (m *mockMicrosoft) handleToken(t *testing.T, w http.ResponseWriter, r *http
 	// All ids here are clearly fake; the adapter only cares that no
 	// access_token is present.
 	if form.Get("grant_type") != "client_credentials" ||
-		form.Get("scope") != "https://graph.microsoft.com/.default" ||
+		form.Get("scope") != m.expectedScope ||
 		form.Get("client_id") != mockClientID {
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -545,6 +552,50 @@ func TestMockAlertsEndToEnd(t *testing.T) {
 	// A token is fetched for every poll of the alerts endpoint.
 	assert.GreaterOrEqual(t, mock.tokenRequestCount(), 1)
 	assert.GreaterOrEqual(t, mock.alertRequestCount(), 1)
+}
+
+// TestMockAlertsGovEndpoint drives the full mock flow with Endpoint set to a
+// US Government cloud (gcc-high-gov) and proves the adapter sends that
+// environment's OAuth2 scope end-to-end. The TokenURL/AlertsURL overrides still
+// point at the mock server (there is no real gov host in a unit test), but the
+// scope must follow Endpoint: the mock's token handler is told to require the
+// gov scope, so a commercial scope would fail the token grant and nothing would
+// ship. This pins scope-follows-endpoint through the actual token request, not
+// just the config helper.
+func TestMockAlertsGovEndpoint(t *testing.T) {
+	const govScope = "https://graph.microsoft.us/.default"
+	base := time.Now().Add(1 * time.Hour)
+
+	mock := newMockMicrosoft()
+	mock.expectedScope = govScope
+	mock.appendAlert(realisticAlert("da637551227677560813_-5555555551", base))
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	conf := DefenderConfig{
+		ClientOptions: testClientOptions(t),
+		TenantID:      mockTenantID,
+		ClientID:      mockClientID,
+		ClientSecret:  mockClientSecret,
+		Endpoint:      "gcc-high-gov",
+		TokenURL:      server.URL + tokenPath,
+		AlertsURL:     server.URL + alertsPath,
+		PollInterval:  30 * time.Millisecond,
+	}
+	require.NoError(t, conf.Validate())
+	adapter, _, err := newDefenderAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 1 },
+		5*time.Second, 10*time.Millisecond, "the alert must ship under the gov endpoint")
+
+	// The token endpoint saw the gov scope, not the commercial one.
+	form := mock.lastSeenTokenForm()
+	require.NotNil(t, form)
+	assert.Equal(t, govScope, form.Get("scope"),
+		"the gov endpoint's scope must be sent to the token endpoint")
 }
 
 // TestMockNewAlertMidRunShipsOnce verifies an alert appearing while the


### PR DESCRIPTION
## Summary

The Microsoft Defender adapter (`defender/client.go`) hardcoded the commercial-cloud MS Graph and Azure AD endpoints, so it could not talk to Microsoft's national cloud deployments. This adds an `endpoint` config option that selects the deployment, mirroring the pattern already used by the o365 adapter (which exposes the same four named environments).

## New `endpoint` config values

| `endpoint` | Deployment | MS Graph root | Azure AD token host |
|---|---|---|---|
| `enterprise` (default) | Global / commercial | `graph.microsoft.com` | `login.microsoftonline.com` |
| `gcc-gov` | US Government GCC (moderate) | `graph.microsoft.com` | `login.microsoftonline.com` |
| `gcc-high-gov` | US Government GCC High (L4) | `graph.microsoft.us` | `login.microsoftonline.us` |
| `dod-gov` | US Government DoD (L5) | `dod-graph.microsoft.us` | `login.microsoftonline.us` |

`gcc-gov` uses the worldwide endpoints (identical to `enterprise`) per the Microsoft docs; it is kept as a named option for parity with the o365 adapter.

## Behavior

- The alerts URL, token URL, and OAuth2 scope are all derived from the configured environment. The scope must match the Graph service root (e.g. `https://graph.microsoft.us/.default` for GCC High), which this handles.
- **Backward compatible:** an empty `endpoint` defaults to `enterprise`, so existing configs keep talking to the commercial cloud unchanged.
- The existing `token_url` / `alerts_url` overrides still take precedence over the derived values (they are test seams / escape hatches).
- `Validate()` now rejects an `endpoint` that is non-empty and not one of the four known names.
- The token request form body is now built with `url.Values` so the scope value is properly URL-encoded.

The `/v1.0/security/alerts_v2` API used by this adapter is available in US Gov L4 and L5. The China cloud is intentionally not added (the API is not available there).

Reference: https://learn.microsoft.com/en-us/graph/deployments

## Tests

`go build ./...` and `go test ./defender/...` pass. Added coverage: default endpoint resolves to commercial URLs/scope; each named environment resolves to the correct alerts URL + token URL + scope (table test); `Validate` rejects an unknown endpoint; existing end-to-end mock flow still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)