### PR TITLE
feat(sentinelone): single-tenant scoping + agent inventory collection

### DIFF
--- a/sentinelone/s1.go
+++ b/sentinelone/s1.go
@@ -20,6 +20,15 @@ const (
 	maxRetryAttempts = 3
 	baseRetryDelay   = 5 * time.Second
 	maxRetryDelay    = 30 * time.Second
+
+	agentsEndpoint            = "/web/api/v2.1/agents"
+	agentsEventType           = "agents"
+	agentsPageLimit           = "1000"
+	defaultAgentsPollInterval = 15 * time.Minute
+
+	// s1TimeFormat is the timestamp layout the Management API emits and
+	// accepts in createdAt/updatedAt style fields and filters.
+	s1TimeFormat = "2006-01-02T15:04:05.999999Z"
 )
 
 // isTransientError determines if an error is transient and should be retried.
@@ -62,9 +71,18 @@ func isTransientError(err error) bool {
 	return false
 }
 
+// uspSink is the subset of *uspclient.Client the adapter depends on.
+// Expressing it as an interface lets tests substitute an in-memory sink for
+// the real LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
 type SentinelOneAdapter struct {
 	conf       SentinelOneConfig
-	uspClient  *uspclient.Client
+	uspClient  uspSink
 	httpClient *http.Client
 	s1Client   *SentinelOneClient
 	urls       []string
@@ -86,6 +104,24 @@ type SentinelOneConfig struct {
 	RetryBaseDelay      time.Duration           `json:"retry_base_delay" yaml:"retry_base_delay"`
 	MaxRetryDelay       time.Duration           `json:"max_retry_delay" yaml:"max_retry_delay"`
 	MaxRetryAttempts    int                     `json:"max_retry_attempts" yaml:"max_retry_attempts"`
+
+	// SiteIDs / AccountIDs scope every API request to the given SentinelOne
+	// sites / accounts (comma-separated numeric ids, sent as the standard
+	// siteIds / accountIds query filters). Use them with a console-wide or
+	// MSP/partner token to pull in a single tenant instead of every tenant
+	// the token can see. Empty means no scoping (current behavior).
+	SiteIDs    string `json:"site_ids" yaml:"site_ids"`
+	AccountIDs string `json:"account_ids" yaml:"account_ids"`
+
+	// CollectAgents, when true, also polls the agent (endpoint) inventory and
+	// ships one "agents" record per agent, re-shipping a record whenever its
+	// updatedAt changes. Combined with the site/account scoping above this
+	// pulls a tenant's endpoints into LimaCharlie as individual sensors even
+	// before they produce any threat/alert/activity telemetry.
+	// Decommissioned agents are excluded so historical registrations do not
+	// create dead sensors.
+	CollectAgents      bool          `json:"collect_agents" yaml:"collect_agents"`
+	AgentsPollInterval time.Duration `json:"agents_poll_interval" yaml:"agents_poll_interval"`
 }
 
 func (c *SentinelOneConfig) Validate() error {
@@ -102,9 +138,17 @@ func (c *SentinelOneConfig) Validate() error {
 		c.Domain = "https://" + c.Domain
 	}
 	c.Domain = strings.TrimSuffix(c.Domain, "/")
-	if _, err := time.Parse("2006-01-02T15:04:05.999999Z", c.StartTime); c.StartTime != "" && err != nil {
+	if _, err := time.Parse(s1TimeFormat, c.StartTime); c.StartTime != "" && err != nil {
 		return fmt.Errorf("invalid start_time: %v", err)
 	}
+	c.applyDefaults()
+	return nil
+}
+
+// applyDefaults fills unset knobs and normalizes inputs. It runs both from
+// Validate() and from the constructor, because the general adapter runner
+// constructs the adapter without calling Validate().
+func (c *SentinelOneConfig) applyDefaults() {
 	if c.TimeBetweenRequests == 0 {
 		c.TimeBetweenRequests = 1 * time.Minute
 	}
@@ -117,25 +161,40 @@ func (c *SentinelOneConfig) Validate() error {
 	if c.MaxRetryAttempts == 0 {
 		c.MaxRetryAttempts = maxRetryAttempts
 	}
-	return nil
+	c.SiteIDs = normalizeCSV(c.SiteIDs)
+	c.AccountIDs = normalizeCSV(c.AccountIDs)
+	if c.AgentsPollInterval == 0 {
+		c.AgentsPollInterval = defaultAgentsPollInterval
+	}
+}
+
+// normalizeCSV trims whitespace around a comma-separated list's elements and
+// drops empty ones, so " 123, 456 " serializes as the "123,456" the API
+// expects.
+func normalizeCSV(s string) string {
+	if s == "" {
+		return ""
+	}
+	parts := []string{}
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return strings.Join(parts, ",")
 }
 
 func NewSentinelOneAdapter(ctx context.Context, conf SentinelOneConfig) (*SentinelOneAdapter, chan struct{}, error) {
+	return newSentinelOneAdapter(ctx, conf, nil)
+}
+
+// newSentinelOneAdapter is the implementation behind NewSentinelOneAdapter.
+// When sink is non-nil it is used in place of a real LimaCharlie client -- the
+// seam tests use to capture shipped events.
+func newSentinelOneAdapter(ctx context.Context, conf SentinelOneConfig, sink uspSink) (*SentinelOneAdapter, chan struct{}, error) {
 	// Ensure defaults are set (these may not be set if Validate() wasn't called,
 	// e.g. when launched through the general adapter runner).
-	if conf.TimeBetweenRequests == 0 {
-		conf.TimeBetweenRequests = 1 * time.Minute
-	}
-	// Ensure retry defaults are set (these may not be set if Validate() wasn't called)
-	if conf.RetryBaseDelay == 0 {
-		conf.RetryBaseDelay = baseRetryDelay
-	}
-	if conf.MaxRetryDelay == 0 {
-		conf.MaxRetryDelay = maxRetryDelay
-	}
-	if conf.MaxRetryAttempts == 0 {
-		conf.MaxRetryAttempts = maxRetryAttempts
-	}
+	conf.applyDefaults()
 
 	a := &SentinelOneAdapter{
 		conf:     conf,
@@ -144,10 +203,14 @@ func NewSentinelOneAdapter(ctx context.Context, conf SentinelOneConfig) (*Sentin
 		s1Client: NewSentinelOneClient(conf.Domain, conf.APIKey),
 	}
 
-	var err error
-	a.uspClient, err = uspclient.NewClient(ctx, conf.ClientOptions)
-	if err != nil {
-		return nil, nil, err
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
 	}
 
 	a.httpClient = &http.Client{
@@ -196,6 +259,13 @@ func NewSentinelOneAdapter(ctx context.Context, conf SentinelOneConfig) (*Sentin
 		go a.fetchEvents(ct)
 	}
 
+	if a.conf.CollectAgents {
+		a.conf.ClientOptions.DebugLog("starting to fetch the agents inventory")
+		nCollecting++
+		a.wgSenders.Add(1)
+		go a.fetchAgents()
+	}
+
 	if nCollecting == 0 {
 		a.Close()
 		return nil, nil, errors.New("no content types specified")
@@ -241,15 +311,15 @@ func (a *SentinelOneAdapter) fetchEvents(endpoint string) {
 		if isFirstRun {
 			start := a.conf.StartTime
 			if start == "" {
-				start = now.Add(-15 * time.Second).Format("2006-01-02T15:04:05.999999Z")
+				start = now.Add(-15 * time.Second).Format(s1TimeFormat)
 			}
 			lastCreatedAt = start
-			end := now.Format("2006-01-02T15:04:05.999999Z")
+			end := now.Format(s1TimeFormat)
 			qValues.Set("createdAt__gte", start)
 			qValues.Set("createdAt__lte", end)
 		} else {
 			qValues.Set("createdAt__gt", lastCreatedAt)
-			qValues.Set("createdAt__lte", now.Format("2006-01-02T15:04:05.999999Z"))
+			qValues.Set("createdAt__lte", now.Format(s1TimeFormat))
 		}
 		isFirstRun = false
 		nextPage := ""
@@ -259,69 +329,16 @@ func (a *SentinelOneAdapter) fetchEvents(endpoint string) {
 				qValues.Set("cursor", nextPage)
 			}
 
-			a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching from %s?%s", endpoint, qValues.Encode()))
-
-			// Retry loop for transient errors
-			var resp *SentinelOnePagedData
-			var err error
-			for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
-				if a.doStop.IsSet() {
-					return
-				}
-
-				resp, err = a.s1Client.GetFromAPI(a.ctx, endpoint, qValues)
-				if err == nil {
-					break // Success
-				}
-
-				// Check if this is a transient error worth retrying
-				if !isTransientError(err) {
-					// Permanent error (auth failure, bad request, etc.) - stop the adapter
-					if a.conf.ClientOptions.OnError != nil {
-						a.conf.ClientOptions.OnError(fmt.Errorf("GetFromAPI(): %v", err))
-					}
-					a.doStop.Set()
-					return
-				}
-
-				// Transient error - log and retry with exponential backoff
-				// Only retry if we haven't exhausted all attempts
-				if attempt+1 >= a.conf.MaxRetryAttempts {
-					break // Exit retry loop, will be handled below
-				}
-
-				// Exponential backoff: baseDelay * 2^attempt, capped at MaxRetryDelay
-				retryDelay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
-				if retryDelay > a.conf.MaxRetryDelay {
-					retryDelay = a.conf.MaxRetryDelay
-				}
-				if a.conf.ClientOptions.OnWarning != nil {
-					a.conf.ClientOptions.OnWarning(fmt.Sprintf(
-						"transient error (attempt %d/%d), waiting %v before retry: %v",
-						attempt+1, a.conf.MaxRetryAttempts, retryDelay, err))
-				}
-
-				// Wait before retry, but respect doStop
-				if a.doStop.WaitFor(retryDelay) {
-					return
-				}
+			resp, keepRunning := a.getWithRetry(endpoint, qValues)
+			if !keepRunning {
+				return
 			}
-
-			// If we exhausted all retries, report the error but continue
-			// (don't stop the entire adapter for persistent transient errors)
-			if err != nil {
-				if a.conf.ClientOptions.OnError != nil {
-					a.conf.ClientOptions.OnError(fmt.Errorf(
-						"GetFromAPI(): failed after %d attempts: %v", a.conf.MaxRetryAttempts, err))
-				}
-				// Break out of pagination loop to try again after TimeBetweenRequests
+			if resp == nil {
+				// Retries exhausted; break out of the pagination loop to try
+				// again after TimeBetweenRequests.
 				break
 			}
-			if resp.NextCursor != nil {
-				nextPage = *resp.NextCursor
-			} else {
-				nextPage = ""
-			}
+			nextPage = resp.NextPageCursor()
 			for _, event := range resp.Data {
 				isDataFound = true
 				nFetched++
@@ -331,7 +348,7 @@ func (a *SentinelOneAdapter) fetchEvents(endpoint string) {
 				lastCreatedAt, _ = getTimestampElement(event, "createdAt")
 				var ts uint64
 				if lastCreatedAt != "" {
-					if it, err := time.Parse("2006-01-02T15:04:05.999999Z", lastCreatedAt); err == nil {
+					if it, err := time.Parse(s1TimeFormat, lastCreatedAt); err == nil {
 						ts = uint64(it.UnixMilli())
 					} else {
 						lastCreatedAt = ""
@@ -340,25 +357,16 @@ func (a *SentinelOneAdapter) fetchEvents(endpoint string) {
 				if lastCreatedAt == "" {
 					a.conf.ClientOptions.OnError(fmt.Errorf("createdAt not found in event: %v", event))
 					now = time.Now()
-					lastCreatedAt = now.Format("2006-01-02T15:04:05.999999Z")
+					lastCreatedAt = now.Format(s1TimeFormat)
 					ts = uint64(now.UnixMilli())
 				}
 
-				msg := &protocol.DataMessage{
+				if !a.ship(&protocol.DataMessage{
 					EventType:   eventType,
 					JsonPayload: event,
 					TimestampMs: ts,
-				}
-				if err := a.uspClient.Ship(msg, 10*time.Second); err != nil {
-					if err == uspclient.ErrorBufferFull {
-						a.conf.ClientOptions.OnWarning("stream falling behind")
-						err = a.uspClient.Ship(msg, 1*time.Hour)
-					}
-					if err != nil {
-						a.conf.ClientOptions.OnError(fmt.Errorf("Ship(): %v", err))
-						a.doStop.Set()
-						break
-					}
+				}) {
+					break
 				}
 			}
 			if nextPage == "" {
@@ -367,6 +375,198 @@ func (a *SentinelOneAdapter) fetchEvents(endpoint string) {
 		}
 
 		a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetched %d events", nFetched))
+	}
+}
+
+// applyScope restricts a request to the configured sites/accounts. Every
+// Management API list endpoint accepts the same siteIds/accountIds filters.
+// It is called from getWithRetry — the single chokepoint every API request
+// goes through — so a future feed cannot forget the tenant scoping.
+func (a *SentinelOneAdapter) applyScope(qValues url.Values) {
+	if a.conf.SiteIDs != "" {
+		qValues.Set("siteIds", a.conf.SiteIDs)
+	}
+	if a.conf.AccountIDs != "" {
+		qValues.Set("accountIds", a.conf.AccountIDs)
+	}
+}
+
+// ship forwards one record to LimaCharlie, absorbing backpressure. It returns
+// false when delivery failed for good; the adapter is stopping at that point.
+func (a *SentinelOneAdapter) ship(msg *protocol.DataMessage) bool {
+	err := a.uspClient.Ship(msg, 10*time.Second)
+	if err == uspclient.ErrorBufferFull {
+		if a.conf.ClientOptions.OnWarning != nil {
+			a.conf.ClientOptions.OnWarning("stream falling behind")
+		}
+		err = a.uspClient.Ship(msg, 1*time.Hour)
+	}
+	if err != nil {
+		if a.conf.ClientOptions.OnError != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("Ship(): %v", err))
+		}
+		a.doStop.Set()
+		return false
+	}
+	return true
+}
+
+// getWithRetry fetches one page, retrying transient errors with exponential
+// backoff. The bool result is false when the calling goroutine should exit:
+// the adapter is stopping, or a permanent error (auth failure, bad request)
+// stopped it. A (nil, true) result means the retries were exhausted and the
+// caller should abandon the current poll and try again next interval.
+func (a *SentinelOneAdapter) getWithRetry(endpoint string, qValues url.Values) (*SentinelOnePagedData, bool) {
+	a.applyScope(qValues)
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf("fetching from %s?%s", endpoint, qValues.Encode()))
+
+	var resp *SentinelOnePagedData
+	var err error
+	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
+		if a.doStop.IsSet() {
+			return nil, false
+		}
+
+		resp, err = a.s1Client.GetFromAPI(a.ctx, endpoint, qValues)
+		if err == nil {
+			return resp, true
+		}
+
+		// Check if this is a transient error worth retrying
+		if !isTransientError(err) {
+			// Permanent error (auth failure, bad request, etc.) - stop the adapter
+			if a.conf.ClientOptions.OnError != nil {
+				a.conf.ClientOptions.OnError(fmt.Errorf("GetFromAPI(): %v", err))
+			}
+			a.doStop.Set()
+			return nil, false
+		}
+
+		// Transient error - log and retry with exponential backoff
+		// Only retry if we haven't exhausted all attempts
+		if attempt+1 >= a.conf.MaxRetryAttempts {
+			break // Exit retry loop, will be handled below
+		}
+
+		// Exponential backoff: baseDelay * 2^attempt, capped at MaxRetryDelay
+		retryDelay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
+		if retryDelay > a.conf.MaxRetryDelay {
+			retryDelay = a.conf.MaxRetryDelay
+		}
+		if a.conf.ClientOptions.OnWarning != nil {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"transient error (attempt %d/%d), waiting %v before retry: %v",
+				attempt+1, a.conf.MaxRetryAttempts, retryDelay, err))
+		}
+
+		// Wait before retry, but respect doStop
+		if a.doStop.WaitFor(retryDelay) {
+			return nil, false
+		}
+	}
+
+	// Retries exhausted; report the error but let the caller try again on the
+	// next interval (don't stop the entire adapter for persistent transient
+	// errors).
+	if a.conf.ClientOptions.OnError != nil {
+		a.conf.ClientOptions.OnError(fmt.Errorf(
+			"GetFromAPI(): failed after %d attempts: %v", a.conf.MaxRetryAttempts, err))
+	}
+	return nil, true
+}
+
+// fetchAgents polls the agent (endpoint) inventory and ships one "agents"
+// record per agent, re-shipping a record whenever its updatedAt changes. The
+// first poll walks the full inventory, which is what imports a tenant's
+// existing endpoints into LimaCharlie as individual sensors; later polls only
+// ship agents that changed. Decommissioned agents are filtered out so
+// historical registrations don't materialize as dead sensors.
+func (a *SentinelOneAdapter) fetchAgents() {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog("fetching of agents inventory exiting")
+
+	// Last shipped updatedAt per agent, to only ship changes. Replaced by the
+	// walk's own map after every completed walk so agents that left the
+	// inventory (deleted, decommissioned, moved out of scope) don't accumulate
+	// forever.
+	shippedAgents := map[string]string{}
+
+	isFirstRun := true
+	for isFirstRun || !a.doStop.WaitFor(a.conf.AgentsPollInterval) {
+		isFirstRun = false
+		nFetched := 0
+		nShipped := 0
+		seenAgents := make(map[string]string, len(shippedAgents))
+		completedWalk := false
+
+		qValues := url.Values{}
+		qValues.Set("limit", agentsPageLimit)
+		qValues.Set("isDecommissioned", "false")
+		for !a.doStop.IsSet() {
+			resp, keepRunning := a.getWithRetry(agentsEndpoint, qValues)
+			if !keepRunning {
+				return
+			}
+			if resp == nil {
+				// Retries exhausted; abandon this poll, try again next interval.
+				break
+			}
+
+			for _, agent := range resp.Data {
+				nFetched++
+				// The numeric id is the stable identity (same namespace the
+				// threats/alerts/activities events carry); fall back to the
+				// agent uuid so a missing id doesn't degrade to re-shipping
+				// the record every poll.
+				agentID, _ := agent["id"].(string)
+				if agentID == "" {
+					agentID, _ = agent["uuid"].(string)
+				}
+				updatedAt, _ := agent["updatedAt"].(string)
+				if agentID != "" {
+					seenAgents[agentID] = updatedAt
+					// Distinguish "never shipped" from "shipped with this
+					// exact updatedAt": a missing updatedAt must not read as
+					// already-shipped just because both are "".
+					if prev, ok := shippedAgents[agentID]; ok && prev == updatedAt {
+						continue
+					}
+				}
+
+				var ts uint64
+				if t, err := time.Parse(s1TimeFormat, updatedAt); err == nil {
+					ts = uint64(t.UnixMilli())
+				} else {
+					ts = uint64(time.Now().UnixMilli())
+				}
+
+				if !a.ship(&protocol.DataMessage{
+					EventType:   agentsEventType,
+					JsonPayload: agent,
+					TimestampMs: ts,
+				}) {
+					return
+				}
+				if agentID != "" {
+					shippedAgents[agentID] = updatedAt
+				}
+				nShipped++
+			}
+
+			cursor := resp.NextPageCursor()
+			if cursor == "" {
+				completedWalk = true
+				break
+			}
+			qValues.Set("cursor", cursor)
+		}
+
+		if completedWalk {
+			// The walk covered the whole inventory: what wasn't seen is gone.
+			shippedAgents = seenAgents
+		}
+
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf("agents inventory poll complete (seen=%d shipped=%d)", nFetched, nShipped))
 	}
 }
 

--- a/sentinelone/s1_test.go
+++ b/sentinelone/s1_test.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -603,4 +605,287 @@ func TestRetryExhaustion(t *testing.T) {
 		"doStop should NOT be set after exhausting retries - adapter should continue")
 
 	adapter.Close()
+}
+
+// memorySink is an in-memory uspSink that captures shipped messages so tests
+// can assert on what the adapter would have sent to LimaCharlie.
+type memorySink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *memorySink) Ship(message *protocol.DataMessage, timeout time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, message)
+	return nil
+}
+
+func (s *memorySink) Drain(timeout time.Duration) error { return nil }
+
+func (s *memorySink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *memorySink) byEventType(eventType string) []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := []*protocol.DataMessage{}
+	for _, m := range s.messages {
+		if m.EventType == eventType {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// TestSiteAndAccountScopingAppliedToRequests verifies that configured
+// site_ids/account_ids are sent as the standard siteIds/accountIds query
+// filters on every polled endpoint, with whitespace in the CSV normalized.
+func TestSiteAndAccountScopingAppliedToRequests(t *testing.T) {
+	var sawActivities, sawAgents atomic.Bool
+	var activitiesQuery, agentsQuery atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/web/api/v2.1/activities":
+			sawActivities.Store(true)
+			activitiesQuery.Store(r.URL.Query())
+		case "/web/api/v2.1/agents":
+			sawAgents.Store(true)
+			agentsQuery.Store(r.URL.Query())
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":       []map[string]interface{}{},
+			"nextCursor": nil,
+		})
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := SentinelOneConfig{
+		Domain:              server.URL,
+		APIKey:              "test-api-key",
+		URLs:                "/web/api/v2.1/activities",
+		SiteIDs:             " 1000000000000000201 , 1000000000000000202 ",
+		AccountIDs:          "1000000000000000301",
+		CollectAgents:       true,
+		AgentsPollInterval:  50 * time.Millisecond,
+		TimeBetweenRequests: 50 * time.Millisecond,
+		RetryBaseDelay:      50 * time.Millisecond,
+		MaxRetryAttempts:    3,
+		ClientOptions: uspclient.ClientOptions{
+			TestSinkMode: true,
+			OnError:      func(err error) { t.Logf("ERROR: %v", err) },
+			OnWarning:    func(msg string) { t.Logf("WARNING: %s", msg) },
+			DebugLog:     func(msg string) {},
+		},
+	}
+
+	adapter, _, err := NewSentinelOneAdapter(ctx, conf)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sawActivities.Load() && sawAgents.Load() },
+		5*time.Second, 10*time.Millisecond, "both endpoints should have been polled")
+
+	for name, q := range map[string]url.Values{
+		"activities": activitiesQuery.Load().(url.Values),
+		"agents":     agentsQuery.Load().(url.Values),
+	} {
+		assert.Equal(t, "1000000000000000201,1000000000000000202", q.Get("siteIds"),
+			"%s should be scoped to the configured sites", name)
+		assert.Equal(t, "1000000000000000301", q.Get("accountIds"),
+			"%s should be scoped to the configured accounts", name)
+	}
+
+	agentsQ := agentsQuery.Load().(url.Values)
+	assert.Equal(t, "false", agentsQ.Get("isDecommissioned"),
+		"agent inventory should exclude decommissioned agents")
+	assert.Equal(t, agentsPageLimit, agentsQ.Get("limit"))
+}
+
+// TestAgentsInventoryShipsOncePerUpdate verifies the agents inventory feed:
+// the first poll walks all pages and ships every agent, later polls only ship
+// agents whose updatedAt changed.
+func TestAgentsInventoryShipsOncePerUpdate(t *testing.T) {
+	agentA := map[string]interface{}{
+		"id":           "1000000000000000001",
+		"uuid":         "aaaaaaaa-1111-2222-3333-444444444444",
+		"computerName": "HOST-A",
+		"updatedAt":    "2026-07-07T10:00:00.000000Z",
+	}
+	agentB := map[string]interface{}{
+		"id":           "1000000000000000002",
+		"uuid":         "bbbbbbbb-1111-2222-3333-444444444444",
+		"computerName": "HOST-B",
+		"updatedAt":    "2026-07-07T10:00:00.000000Z",
+	}
+
+	var agentsPolls atomic.Int32
+	var updateB atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/web/api/v2.1/activities":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data":       []map[string]interface{}{},
+				"nextCursor": nil,
+			})
+		case "/web/api/v2.1/agents":
+			// Two pages: agent A with a cursor, then agent B. The cursor is
+			// nested under "pagination" exactly as the live API returns it —
+			// there is no top-level nextCursor.
+			if r.URL.Query().Get("cursor") == "" {
+				agentsPolls.Add(1)
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"data": []map[string]interface{}{agentA},
+					"pagination": map[string]interface{}{
+						"totalItems": 2,
+						"nextCursor": "next-page",
+					},
+				})
+				return
+			}
+			b := agentB
+			if updateB.Load() {
+				b = map[string]interface{}{}
+				for k, v := range agentB {
+					b[k] = v
+				}
+				b["updatedAt"] = "2026-07-07T11:00:00.000000Z"
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": []map[string]interface{}{b},
+				"pagination": map[string]interface{}{
+					"totalItems": 2,
+					"nextCursor": nil,
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sink := &memorySink{}
+	conf := SentinelOneConfig{
+		Domain:              server.URL,
+		APIKey:              "test-api-key",
+		URLs:                "/web/api/v2.1/activities",
+		CollectAgents:       true,
+		AgentsPollInterval:  50 * time.Millisecond,
+		TimeBetweenRequests: 50 * time.Millisecond,
+		RetryBaseDelay:      50 * time.Millisecond,
+		MaxRetryAttempts:    3,
+		ClientOptions: uspclient.ClientOptions{
+			TestSinkMode: true,
+			OnError:      func(err error) { t.Logf("ERROR: %v", err) },
+			OnWarning:    func(msg string) { t.Logf("WARNING: %s", msg) },
+			DebugLog:     func(msg string) {},
+		},
+	}
+
+	adapter, _, err := newSentinelOneAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// First poll: both agents (across two pages) ship exactly once.
+	require.Eventually(t, func() bool { return len(sink.byEventType(agentsEventType)) >= 2 },
+		5*time.Second, 10*time.Millisecond, "the initial inventory should ship every agent")
+
+	// Let a few more polls run: nothing new ships while updatedAt is stable.
+	require.Eventually(t, func() bool { return agentsPolls.Load() >= 3 },
+		5*time.Second, 10*time.Millisecond)
+	shipped := sink.byEventType(agentsEventType)
+	require.Len(t, shipped, 2, "unchanged agents must not be re-shipped on later polls")
+	hostnames := map[string]bool{}
+	for _, m := range shipped {
+		name, _ := m.JsonPayload["computerName"].(string)
+		hostnames[name] = true
+		assert.NotZero(t, m.TimestampMs)
+	}
+	assert.Equal(t, map[string]bool{"HOST-A": true, "HOST-B": true}, hostnames)
+
+	// Bump agent B's updatedAt: exactly that one agent ships again.
+	updateB.Store(true)
+	require.Eventually(t, func() bool { return len(sink.byEventType(agentsEventType)) == 3 },
+		5*time.Second, 10*time.Millisecond, "an updated agent should be re-shipped")
+	last := sink.byEventType(agentsEventType)[2]
+	name, _ := last.JsonPayload["computerName"].(string)
+	assert.Equal(t, "HOST-B", name)
+}
+
+// TestAgentsInventoryShipsAgentWithoutUpdatedAt guards against the dedup
+// zero-value collision: an agent whose updatedAt is missing must still ship on
+// the first walk ("" must not read as already-shipped), and must not be
+// re-shipped on later walks.
+func TestAgentsInventoryShipsAgentWithoutUpdatedAt(t *testing.T) {
+	var agentsPolls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/web/api/v2.1/activities":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"data": []map[string]interface{}{}})
+		case "/web/api/v2.1/agents":
+			agentsPolls.Add(1)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": []map[string]interface{}{{
+					"id":           "1000000000000000003",
+					"uuid":         "cccccccc-1111-2222-3333-444444444444",
+					"computerName": "HOST-C",
+					// no updatedAt
+				}},
+				"pagination": map[string]interface{}{"totalItems": 1, "nextCursor": nil},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sink := &memorySink{}
+	conf := SentinelOneConfig{
+		Domain:              server.URL,
+		APIKey:              "test-api-key",
+		URLs:                "/web/api/v2.1/activities",
+		CollectAgents:       true,
+		AgentsPollInterval:  50 * time.Millisecond,
+		TimeBetweenRequests: 50 * time.Millisecond,
+		RetryBaseDelay:      50 * time.Millisecond,
+		MaxRetryAttempts:    3,
+		ClientOptions: uspclient.ClientOptions{
+			TestSinkMode: true,
+			OnError:      func(err error) { t.Logf("ERROR: %v", err) },
+			OnWarning:    func(msg string) { t.Logf("WARNING: %s", msg) },
+			DebugLog:     func(msg string) {},
+		},
+	}
+
+	adapter, _, err := newSentinelOneAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// Ships once on the first walk...
+	require.Eventually(t, func() bool { return len(sink.byEventType(agentsEventType)) == 1 },
+		5*time.Second, 10*time.Millisecond, "an agent without updatedAt must still ship")
+
+	// ...and is not re-shipped on later walks.
+	require.Eventually(t, func() bool { return agentsPolls.Load() >= 3 },
+		5*time.Second, 10*time.Millisecond)
+	assert.Len(t, sink.byEventType(agentsEventType), 1,
+		"an unchanged agent without updatedAt must not be re-shipped")
 }

--- a/sentinelone/sdk.go
+++ b/sentinelone/sdk.go
@@ -39,11 +39,33 @@ func NewSentinelOneClient(baseURL, apiToken string) *SentinelOneClient {
 	}
 }
 
+// SentinelOnePagination is the envelope the Management API nests page state
+// under: {"pagination": {"totalItems": N, "nextCursor": "..."}, "data": [...]}.
+type SentinelOnePagination struct {
+	TotalItems int     `json:"totalItems"`
+	NextCursor *string `json:"nextCursor"`
+}
+
 // SentinelOnePagedData represents pagination information
 type SentinelOnePagedData struct {
 	Data       []map[string]interface{} `json:"data"`
 	TotalItems int                      `json:"totalItems"`
 	NextCursor *string                  `json:"nextCursor"`
+	Pagination *SentinelOnePagination   `json:"pagination"`
+}
+
+// NextPageCursor returns the cursor for the next page, or "" on the last
+// page. The live Management API nests the cursor under "pagination"; the
+// top-level "nextCursor" is kept as a fallback for older/other response
+// shapes.
+func (d *SentinelOnePagedData) NextPageCursor() string {
+	if d.Pagination != nil && d.Pagination.NextCursor != nil {
+		return *d.Pagination.NextCursor
+	}
+	if d.NextCursor != nil {
+		return *d.NextCursor
+	}
+	return ""
 }
 
 // GetFromAPI retrieves data from the API based on the provided options


### PR DESCRIPTION
## What

Two additions to the `sentinel_one` adapter, mirroring what the `threatlocker` adapter already offers for MSP-style deployments (`managed_organization_id` / child-org scoping):

1. **`site_ids` / `account_ids`** (comma-separated ids): applied as the standard `siteIds` / `accountIds` query filters on every API request. The scoping is injected at the `getWithRetry` chokepoint every request goes through, so a future feed cannot forget it. A partner/console-wide API token can now pull in a **single tenant** (SentinelOne site or account) instead of every tenant the token can see. Empty = unchanged behavior.
2. **`collect_agents`** (+ `agents_poll_interval`, default 15m): opt-in agent (endpoint) inventory feed. Walks `/web/api/v2.1/agents` and ships one `agents` record per agent, re-shipping only when the agent's `updatedAt` changes. The first poll ships the full inventory, so the scoped tenant's endpoints appear in LimaCharlie as individual sensors immediately. `isDecommissioned=false` is always applied so historical registrations don't materialize as dead sensors, and the dedupe state is swapped for the walk's own map after every completed walk so departed agents don't accumulate.

Plus one **bug fix surfaced while validating against a live console**: the Management API nests the page cursor under `pagination.nextCursor` — there is no top-level `nextCursor` in live responses, which is what the code decoded. `SentinelOnePagedData` now decodes both shapes and pagination follows `NextPageCursor()`. Without this the agents walk silently capped at the first page, and in-cycle pagination of the event endpoints never advanced (long-standing latent issue, masked by the watermark loop).

## Why

Customer request: when pointing the S1 adapter at a multi-tenant (MSP) console, pull in one specific tenant and get that tenant's endpoints as individual sensors — the same workflow already possible with the ThreatLocker adapter.

## Implementation notes

- The transient-error retry loop moved verbatim from `fetchEvents` into a shared `getWithRetry` helper; behavior is unchanged (permanent error stops the adapter, exhausted transient retries skip the poll). The Ship/backpressure block is likewise extracted into a nil-callback-safe `ship()` helper.
- The USP client is behind a small `uspSink` interface (same pattern as the threatlocker adapter) so tests can capture shipped events.
- Dedup distinguishes "never shipped" from "shipped with this exact updatedAt", so an agent with a missing `updatedAt` still ships on the first walk; identity falls back to the agent `uuid` when `id` is absent.
- `siteIds`, `accountIds`, `isDecommissioned` acceptance and the `pagination.nextCursor` response shape were all verified against a live SentinelOne console on all four endpoints (`activities`, `threats`, `cloud-detection/alerts`, `agents`).

## Caveats

- A token lacking Endpoints-view permission gets a 403 on the agents feed, which stops the adapter loudly — consistent with how this adapter already treats any permanent error on a polled endpoint.
- The scoping applies to custom `urls` entries too; documented accordingly.

## Testing

`go test ./sentinelone/` — covers: scoping params on both event and inventory requests (incl. CSV whitespace normalization), full-inventory first ship across cursor pages using the live API's nested-pagination shape, no re-ship while `updatedAt` is stable, re-ship of exactly the changed agent, first-walk ship of an agent with no `updatedAt`, plus the pre-existing retry/backoff suite unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGn3sabWCReDgbwFyQoDR1