### PR TITLE
mac_unified_logging: fix infinite json.Decoder error loop (sustained ~113% CPU, silent collection stall)

### DIFF
--- a/mac_unified_logging/client.go
+++ b/mac_unified_logging/client.go
@@ -101,7 +101,7 @@ func (a *MacUnifiedLoggingAdapter) handleEvent(predicate string) uintptr {
 
 	logs := NewLogs()
 
-	signalChannel := make(chan os.Signal)
+	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-signalChannel

--- a/mac_unified_logging/log.go
+++ b/mac_unified_logging/log.go
@@ -10,6 +10,10 @@ import (
 	"sync"
 )
 
+// log stream events can carry large payloads (eventMessage, backtraces),
+// well past bufio.Scanner's 64KB default line limit.
+const maxLogLineSize = 4 * 1024 * 1024
+
 type Log struct {
 	TraceID            int64       `json:"traceID"`
 	EventMessage       string      `json:"eventMessage"`
@@ -41,24 +45,26 @@ type Log struct {
 }
 
 type Logs struct {
-	m       sync.Mutex
-	Channel chan Log
-	exit    chan bool
+	m        sync.Mutex
+	Channel  chan Log
+	exit     chan struct{}
+	exitOnce sync.Once
 }
 
 func NewLogs() *Logs {
 	return &Logs{
 		Channel: make(chan Log),
-		exit:    make(chan bool),
+		exit:    make(chan struct{}),
 	}
 }
 
 func (logs *Logs) StartGathering(predicate string) error {
 
-	cmd := exec.Command("log", "stream", "--color=none", "--style=ndjson")
+	args := []string{"stream", "--color=none", "--style=ndjson"}
 	if predicate != "" {
-		cmd = exec.Command("log", "stream", "--color=none", "--style=ndjson", "--predicate", predicate)
+		args = append(args, "--predicate", predicate)
 	}
+	cmd := exec.Command("log", args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -70,42 +76,76 @@ func (logs *Logs) StartGathering(predicate string) error {
 		return err
 	}
 
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// Kill the subprocess on StopGathering so a reader blocked in
+	// Scan() unblocks and the gathering goroutine can exit.
+	go func() {
+		<-logs.exit
+		cmd.Process.Kill()
+	}()
+
 	go func() {
 		logs.m.Lock()
 		defer logs.m.Unlock()
 
-		cmd.Start()
 		defer cmd.Process.Kill()
+		// Closing the channel lets consumers terminate instead of
+		// waiting forever on a stream that has ended.
+		defer close(logs.Channel)
 
-		// drop first message
-		bufio.NewReader(stdout).ReadLine()
+		// Parse the ndjson output line by line. A json.Decoder is
+		// unsuitable here: it never advances past a SyntaxError, so a
+		// single bad line (like the non-JSON "Filtering the log data"
+		// header) would wedge it in a permanent error loop while the
+		// pipe fills up and `log stream` blocks forever.
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), maxLogLineSize)
 
-		dec := json.NewDecoder(stdout)
-
-		for {
+		for scanner.Scan() {
 			select {
 			case <-logs.exit:
 				return
 			default:
-				log := Log{}
-
-				if err := dec.Decode(&log); err != nil {
-					fmt.Println("error decoding json")
-					fmt.Println(err.Error())
-				} else {
-					logs.Channel <- log
-				}
 			}
+
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+
+			log := Log{}
+			if err := json.Unmarshal(line, &log); err != nil {
+				// Skip non-JSON lines (e.g. the header line) without
+				// stalling the stream.
+				fmt.Printf("skipping non-json line from log stream: %v\n", err)
+				continue
+			}
+
+			select {
+			case logs.Channel <- log:
+			case <-logs.exit:
+				return
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			fmt.Printf("error reading log stream output: %v\n", err)
 		}
 	}()
 
 	go func() {
 		stderrBuf := bufio.NewReader(stderr)
 		for {
-			line, _, _ := stderrBuf.ReadLine()
+			line, _, err := stderrBuf.ReadLine()
 			if len(line) > 0 {
 				logs.StopGathering()
-				panic(err)
+				panic(fmt.Errorf("log stream error: %s", string(line)))
+			}
+			if err != nil {
+				return
 			}
 		}
 	}()
@@ -114,5 +154,7 @@ func (logs *Logs) StartGathering(predicate string) error {
 }
 
 func (logs *Logs) StopGathering() {
-	logs.exit <- true
+	logs.exitOnce.Do(func() {
+		close(logs.exit)
+	})
 }


### PR DESCRIPTION
Fixes a bug in the `mac_unified_logging` adapter observed in the field as sustained ~113% CPU on macOS — with the worse side effect that the adapter had silently stopped collecting logs entirely. Tracked in refractionPOINT/tracking#4458.

## Root cause

`StartGathering` dropped the first line of `log stream --style=ndjson` output using a throwaway `bufio.Reader`, which buffers (and then discards) up to 64KB beyond that first line. Depending on startup timing, the `json.Decoder` created afterwards starts reading **mid-JSON-object** and returns a `SyntaxError`. Go's `json.Decoder` never advances its input past a syntax error, so the read loop degenerated into a permanent hot loop:

- failed `Decode` + two `fmt.Println` per iteration, forever → ~1 core pegged (plus GC churn)
- the stdout pipe is never read again → it fills → `log stream` blocks forever in `write()` → **zero events ingested** until the process is restarted

Diagnosed from a process sample (all on-CPU time under `StartGathering.func1` → `fmt.Fprintln`/`encoding/json.(*SyntaxError).Error`) and a spindump showing the `log` child's output thread blocked in `write()` since the moment it was forked, days earlier.

## Fix

- Parse the ndjson output **line by line** with a `bufio.Scanner` (4MB max line) and `json.Unmarshal` each line, skipping lines that fail to parse. The non-JSON `"Filtering the log data..."` header is skipped naturally, so the racy drop-first-line hack is gone. A bad line can now never wedge the stream.
- Close `logs.Channel` when the stream ends, so the adapter terminates (and can be restarted by its supervisor) instead of hanging silently if `log stream` dies.
- Make `StopGathering` close-based (`sync.Once` + `close(exit)`): idempotent and non-blocking, where the old unbuffered send could block forever if the gatherer wasn't at the `select`. A watcher goroutine kills the subprocess on stop so a reader blocked in `Scan()` unblocks.
- Check `cmd.Start()`'s error and return it from `StartGathering` (was previously ignored inside the goroutine).
- stderr watcher: panic with the actual stderr line instead of `panic(err)` on a stale `nil` error from the enclosing scope (which produced a meaningless `panic(nil)`).
- `client.go`: buffer the `signal.Notify` channel (pre-existing `go vet` finding; unbuffered signal channels can drop the signal).

## Verification

- `gofmt -l` clean; `go build` and `go vet` pass for `GOOS=darwin GOARCH=arm64` and `GOOS=linux` on the package.
- Behavior change on decode errors: instead of looping on the same error, the adapter skips the offending line and continues with the next one; if the stream itself ends, the adapter exits instead of spinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
