### PR TITLE
fix(harmony): retry bare EOF and bound idle keep-alive connections

### DIFF
--- a/harmony/client.go
+++ b/harmony/client.go
@@ -576,6 +576,13 @@ func NewHarmonyAdapter(ctx context.Context, conf HarmonyConfig) (*HarmonyAdapter
 			Dial: (&net.Dialer{
 				Timeout: 10 * time.Second,
 			}).Dial,
+			// The Check Point gateway drops idle keep-alive connections
+			// server-side. Left unbounded (the default), the pool would hand
+			// a stale connection to the next poll and the POST would fail with
+			// a bare EOF. Closing our idle connections after 30s — comfortably
+			// under the poll cadence — keeps us from reusing one the gateway
+			// has already discarded.
+			IdleConnTimeout: 30 * time.Second,
 		},
 	}
 
@@ -1238,13 +1245,23 @@ func isTransientErr(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
+	// A dropped connection surfaces as io.EOF (bare `Post "…": EOF`) or
+	// io.ErrUnexpectedEOF. The Check Point gateway routinely kills an idle
+	// keep-alive connection this way; Go does not auto-replay a POST on a
+	// dead connection, so we must classify it transient and let the retry
+	// helper re-issue on a fresh connection. errors.Is covers the wrapped
+	// *url.Error; the "EOF" string fragment below covers any error that
+	// only carries the message.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
 	msg := err.Error()
 	for _, frag := range []string{
 		"context deadline exceeded",
 		"Client.Timeout",
 		"connection reset",
 		"connection refused",
-		"unexpected EOF",
+		"EOF",
 		"i/o timeout",
 		"TLS handshake timeout",
 		"server closed idle connection",

--- a/harmony/client_test.go
+++ b/harmony/client_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"strings"
 	"sync"
@@ -1432,6 +1434,15 @@ func TestTransientClassification(t *testing.T) {
 		fmt.Errorf("read tcp 1.2.3.4:5->6.7.8.9:443: connection reset by peer"),
 		fmt.Errorf("net/http: TLS handshake timeout"),
 		&net.DNSError{IsTimeout: true},
+		// A dropped keep-alive connection to the Check Point gateway: the
+		// real prod shape is a *url.Error wrapping io.EOF, whose message is a
+		// bare `Post "…": EOF`. Both the wrapped sentinel and a message-only
+		// reconstruction must classify transient so the POST is re-issued
+		// instead of tearing the hosted sensor down.
+		io.EOF,
+		io.ErrUnexpectedEOF,
+		&url.Error{Op: "Post", URL: "https://cloudinfra-gw-us.portal.checkpoint.com/app/laas-logs-api/api/logs_query", Err: io.EOF},
+		fmt.Errorf(`Post "https://cloudinfra-gw-us.portal.checkpoint.com/app/laas-logs-api/api/logs_query": EOF`),
 	}
 	for _, e := range transient {
 		if !isTransientErr(e) {


### PR DESCRIPTION
## Problem

A hosted Checkpoint Harmony sensor (events source scoped to *Harmony Email & Collaboration*) was seen in a continuous connect/disconnect loop, surfacing `submitEventsQuery: Post ".../logs_query": EOF` in the org error log.

Investigating the gateway traffic showed the Check Point Infinity Events gateway routinely kills idle keep-alive connections server-side. On the next poll the adapter reuses that dead connection and the POST fails with a **bare** `Post "…": EOF` — a `*url.Error` wrapping `io.EOF`. Go does not auto-replay a POST on a dead connection.

That error then escaped the adapter's own 4-attempt transient-retry helper: `isTransientErr` matched `"unexpected EOF"` but **not** bare `EOF`. So a single dropped connection escalated straight to `OnError`, which in the hosted cloud-sensor is fatal to the instance — hence the visible restart loop (and, plausibly, the re-auth churn that followed).

The rest of the failure in that specific tenant was Check Point-side (their LaaS never processed an E&C query at all), but these two adapter changes stop a routine gateway blip from cycling the sensor.

## Changes

- **`isTransientErr` now classifies `io.EOF` / `io.ErrUnexpectedEOF` as transient** — via `errors.Is` for the wrapped `*url.Error`, plus an `"EOF"` message fragment (subsumes the old `"unexpected EOF"`) for any message-only form. The retry helper re-issues on a fresh connection instead of escalating.
- **HTTP transport now sets `IdleConnTimeout: 30s`** (was unbounded). We close our own idle connections comfortably under the ~60s poll cadence rather than handing the next request a stale connection the gateway has already discarded.

## Tests

`TestTransientClassification` extended with the real prod shapes: `io.EOF`, `io.ErrUnexpectedEOF`, a `*url.Error{Op:"Post", Err: io.EOF}`, and a message-only `Post "…": EOF`. Verified the test fails without the classification change and passes with it. Full `go test ./harmony/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)