### PR TITLE
fix(sentinelone): fail fast on missing/malformed domain and stop retrying URL-scheme errors

### DIFF
--- a/sentinelone/s1.go
+++ b/sentinelone/s1.go
@@ -58,6 +58,16 @@ func isTransientError(err error) bool {
 
 	// Network-related errors are typically transient
 	errStr := err.Error()
+
+	// A missing/malformed protocol scheme means the base URL itself is empty or
+	// malformed (e.g. a domain with no https:// prefix): a permanent
+	// misconfiguration that retrying can never fix. Check this before the
+	// generic "failed to execute request" catch-all, which the SDK wraps such
+	// errors in.
+	if strings.Contains(errStr, "unsupported protocol scheme") || strings.Contains(errStr, "missing protocol scheme") {
+		return false
+	}
+
 	if strings.Contains(errStr, "failed to execute request") {
 		// This could be timeout, connection refused, DNS failure, etc.
 		return true
@@ -134,10 +144,6 @@ func (c *SentinelOneConfig) Validate() error {
 	if c.APIKey == "" {
 		return errors.New("missing api_key")
 	}
-	if !strings.HasPrefix(c.Domain, "https://") {
-		c.Domain = "https://" + c.Domain
-	}
-	c.Domain = strings.TrimSuffix(c.Domain, "/")
 	if _, err := time.Parse(s1TimeFormat, c.StartTime); c.StartTime != "" && err != nil {
 		return fmt.Errorf("invalid start_time: %v", err)
 	}
@@ -145,10 +151,22 @@ func (c *SentinelOneConfig) Validate() error {
 	return nil
 }
 
-// applyDefaults fills unset knobs and normalizes inputs. It runs both from
+// applyDefaults fills unset knobs and normalizes inputs, including the Domain
+// (prefixing https:// and trimming a trailing slash). It runs both from
 // Validate() and from the constructor, because the general adapter runner
-// constructs the adapter without calling Validate().
+// constructs the adapter without calling Validate(); normalizing here ensures
+// the base URL is well-formed on every launch path.
 func (c *SentinelOneConfig) applyDefaults() {
+	if c.Domain != "" {
+		// A bare domain ("example.sentinelone.net") gets the https:// scheme the
+		// SDK needs to build a usable base URL. Only add it when no scheme is
+		// present so an explicit scheme (e.g. an http:// endpoint) is preserved
+		// rather than turned into "https://http://...".
+		if !strings.Contains(c.Domain, "://") {
+			c.Domain = "https://" + c.Domain
+		}
+		c.Domain = strings.TrimSuffix(c.Domain, "/")
+	}
 	if c.TimeBetweenRequests == 0 {
 		c.TimeBetweenRequests = 1 * time.Minute
 	}
@@ -193,8 +211,21 @@ func NewSentinelOneAdapter(ctx context.Context, conf SentinelOneConfig) (*Sentin
 // seam tests use to capture shipped events.
 func newSentinelOneAdapter(ctx context.Context, conf SentinelOneConfig, sink uspSink) (*SentinelOneAdapter, chan struct{}, error) {
 	// Ensure defaults are set (these may not be set if Validate() wasn't called,
-	// e.g. when launched through the general adapter runner).
+	// e.g. when launched through the general adapter runner). applyDefaults also
+	// normalizes the Domain into a well-formed base URL.
 	conf.applyDefaults()
+
+	// Fail fast on the essentials the general adapter runner never validates.
+	// Without these the SDK builds a malformed base URL and every request fails
+	// with a cryptic "unsupported protocol scheme" that retries forever. We
+	// don't call full Validate() here because it also validates ClientOptions,
+	// which the test seam and some launch paths don't populate.
+	if conf.Domain == "" {
+		return nil, nil, errors.New("missing domain")
+	}
+	if conf.APIKey == "" {
+		return nil, nil, errors.New("missing api_key")
+	}
 
 	a := &SentinelOneAdapter{
 		conf:     conf,

--- a/sentinelone/s1_test.go
+++ b/sentinelone/s1_test.go
@@ -387,6 +387,15 @@ func TestIsTransientError(t *testing.T) {
 		// Network error (string-based)
 		{"network error", errors.New(`failed to execute request "http://test": connection refused`), true},
 
+		// A malformed/empty base URL surfaces as an "unsupported protocol
+		// scheme" (or "missing protocol scheme") wrapped in the SDK's "failed
+		// to execute request" text. This is a permanent misconfiguration, not a
+		// transient network blip, so it must not be retried forever.
+		{"unsupported protocol scheme", fmt.Errorf("failed to execute request %q: %v", "/web/api/v2.1/threats",
+			errors.New(`Get "/web/api/v2.1/threats": unsupported protocol scheme ""`)), false},
+		{"missing protocol scheme", fmt.Errorf("failed to execute request %q: %v", "//example.net/web",
+			errors.New(`parse "//example.net/web": missing protocol scheme`)), false},
+
 		// Permanent HTTP errors (using HTTPError type)
 		{"401 error", &HTTPError{StatusCode: 401, URL: "http://test", Body: "unauthorized"}, false},
 		{"403 error", &HTTPError{StatusCode: 403, URL: "http://test", Body: "forbidden"}, false},
@@ -888,4 +897,64 @@ func TestAgentsInventoryShipsAgentWithoutUpdatedAt(t *testing.T) {
 		5*time.Second, 10*time.Millisecond)
 	assert.Len(t, sink.byEventType(agentsEventType), 1,
 		"an unchanged agent without updatedAt must not be re-shipped")
+}
+
+// TestConstructorFailsFastOnMissingDomain verifies the constructor rejects an
+// empty domain up front, instead of building a malformed base URL that makes
+// every request fail with a cryptic "unsupported protocol scheme" it then
+// retries forever. This is the cloud-hosted launch path, which reaches the
+// constructor without ever calling Validate().
+func TestConstructorFailsFastOnMissingDomain(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conf := SentinelOneConfig{
+		Domain: "",
+		APIKey: "test-api-key",
+		URLs:   "/web/api/v2.1/activities",
+		ClientOptions: uspclient.ClientOptions{
+			TestSinkMode: true,
+			OnError:      func(err error) {},
+			DebugLog:     func(msg string) {},
+		},
+	}
+
+	adapter, chStopped, err := newSentinelOneAdapter(ctx, conf, &memorySink{})
+	require.Error(t, err, "constructor should reject an empty domain")
+	assert.EqualError(t, err, "missing domain")
+	assert.Nil(t, adapter)
+	assert.Nil(t, chStopped)
+}
+
+// TestConstructorNormalizesDomain verifies applyDefaults (run by the
+// constructor) prefixes https:// on a bare domain and strips a trailing slash,
+// so the SDK client is built with a well-formed base URL even when Validate()
+// was never called.
+func TestConstructorNormalizesDomain(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conf := SentinelOneConfig{
+		Domain:              "example.sentinelone.net/",
+		APIKey:              "test-api-key",
+		URLs:                "/web/api/v2.1/activities",
+		TimeBetweenRequests: 50 * time.Millisecond,
+		RetryBaseDelay:      50 * time.Millisecond,
+		MaxRetryAttempts:    3,
+		ClientOptions: uspclient.ClientOptions{
+			TestSinkMode: true,
+			OnError:      func(err error) {},
+			OnWarning:    func(msg string) {},
+			DebugLog:     func(msg string) {},
+		},
+	}
+
+	adapter, _, err := newSentinelOneAdapter(ctx, conf, &memorySink{})
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	assert.Equal(t, "https://example.sentinelone.net", adapter.conf.Domain,
+		"a bare domain should be prefixed with https:// and the trailing slash stripped")
+	assert.Equal(t, "https://example.sentinelone.net", adapter.s1Client.baseURL,
+		"the SDK client should be built with the normalized base URL")
 }


### PR DESCRIPTION
## Problem

When the adapter is constructed without `Validate()` having been called (e.g. via the general adapter runner), an empty `domain` — or one missing its `https://` prefix, which only `Validate()` added — reaches the SDK client. Every request then fails with the cryptic:

```
GetFromAPI(): failed after 3 attempts: failed to execute request "/web/api/v2.1/agents?...": Get "/web/api/v2.1/agents?...": unsupported protocol scheme ""
```

and `isTransientError` classifies it as transient, so the adapter retries this permanent misconfiguration forever.

## Fix

- Move domain normalization (scheme prefixing + trailing-slash trim) from `Validate()` into `applyDefaults()`, which runs on every launch path. Prefixing now only happens when no scheme is present at all, so an explicit scheme is preserved instead of being mangled into `https://http://...`.
- `newSentinelOneAdapter` now fails fast with clear `missing domain` / `missing api_key` errors before constructing anything.
- `isTransientError` now classifies `unsupported protocol scheme` / `missing protocol scheme` errors as permanent, so a malformed base URL stops the adapter with a clear error instead of retrying forever.

## Testing

- New tests: constructor rejects an empty domain; constructor normalizes a bare domain (`example.sentinelone.net/` → `https://example.sentinelone.net`) all the way into the SDK client's base URL; scheme errors are non-transient while plain network errors remain transient.
- `go vet ./sentinelone/` and `go test ./sentinelone/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEwHYeaDjXC495MeCqV2yT