### PR TITLE
Adding Cloudflare access api

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,14 @@ restarts.
 ```
 ./general cato client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=cato client_options.sensor_seed_key=cato apikey=$CATO_API_KEY accountid=$CATO_ACCOUNT_ID
 ```
+
+### Cloudflare Access
+
+Pulls per-request Access authentication audit logs (policy evaluations, app
+logins, MFA challenges) from the Cloudflare API. It polls a `since`/`until`
+time window, paginating forward when a window holds more records than fit in
+one response. See [cloudflare_access/README.md](./cloudflare_access/README.md).
+
+```
+./general cloudflare_access client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=cloudflare_access api_token=$CF_API_TOKEN account_id=$CF_ACCOUNT_ID
+```

--- a/cloudflare_access/README.md
+++ b/cloudflare_access/README.md
@@ -1,0 +1,133 @@
+# Cloudflare Access Adapter
+
+Pulls [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/)
+per-request audit logs into LimaCharlie via the
+[Access Requests API](https://developers.cloudflare.com/cloudflare-one/insights/logs/dashboard-logs/access-authentication-logs/#per-request-audit-logs).
+Events are forwarded in their original Cloudflare JSON form — the adapter does
+not reshape payloads.
+
+## What it collects
+
+Every Access authentication event that results in a new HTTP request: policy
+evaluations, application logins, and MFA challenges served to Access
+applications. Per Cloudflare's docs, purely client-side interactions that never
+generate a request are **not** captured by this API — for full session-level
+data, see Cloudflare's Logpush (Enterprise-only), which this adapter does not
+use.
+
+Each shipped event has `EventType` `access_requests` and a JSON payload shaped
+like:
+
+```json
+{
+  "created_at": "2026-07-02T15:03:00Z",
+  "user_email": "user@example.com",
+  "user_id": "b4bf51f2-c72b-50b1-a179-20b76a49b18b",
+  "ip_address": "203.0.113.10",
+  "country": "US",
+  "app_domain": "kibana.example.com",
+  "app_name": "CFZT_App_kibana_example_com",
+  "app_uid": "968a35b8-def0-45de-9d2f-f65d514fa76c",
+  "app_type": "self_hosted",
+  "action": "login",
+  "allowed": true,
+  "connection": "azureAD",
+  "ray_id": "a1cbcd95da9aa9e9"
+}
+```
+
+## Authentication
+
+Create a Cloudflare API token (**My Profile → API Tokens**) scoped to
+**Account → Access: Audit Logs → Read** for the account that owns the Access
+applications. The token is sent as a bearer credential
+(`Authorization: Bearer <token>`).
+
+You also need the **Account ID**, found on the right sidebar of any zone/account
+overview page in the Cloudflare dashboard, or via `GET /accounts` /
+`wrangler whoami`.
+
+The legacy global API key (`X-Auth-Email` / `X-Auth-Key`) is not supported —
+use a scoped API token.
+
+## Configuration
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `client_options` | yes | Standard USP adapter options (see the repo README). |
+| `api_token` | yes | Cloudflare API token scoped to `Access: Audit Logs Read`. |
+| `account_id` | yes | Cloudflare account ID that owns the Access applications. |
+| `base_url` | no | Full API root override. Default `https://api.cloudflare.com/client/v4`. |
+| `poll_interval` | no | Wait between polls. Default `1m` (1 minute). |
+| `initial_lookback` | no | How far back the first poll reaches for historical events. Default `1h` (1 hour). |
+| `limit` | no | Records requested per API call. Cloudflare hard-caps this at `1000` server-side regardless of a higher value; the adapter clamps to that cap. Default `1000`. |
+| `max_pages` | no | Caps paginated calls made within a single poll, bounding the work done when a poll's window holds more records than fit in one response. Default `100`. |
+| `dedupe_ttl` | no | How long a request's `ray_id` is remembered to suppress re-shipping it across overlapping polls. Default `24h`. |
+| `retry_base_delay` / `max_retry_delay` / `max_retry_attempts` | no | Transient-failure retry tuning. Durations default to `5s` / `30s`; `max_retry_attempts` defaults to `3`. |
+
+> **Duration fields in a YAML config file** (`poll_interval`, `initial_lookback`, `dedupe_ttl`,
+> `retry_base_delay`, `max_retry_delay`) must be given as a **Go duration string**
+> (e.g. `6h`, `90s`, `1m30s`) — not a raw nanosecond integer. This repo's YAML loader
+> (`gopkg.in/yaml.v3`) intentionally refuses to decode a bare integer into a
+> `time.Duration` field (unlike `poll_interval=60000000000` passed as a CLI
+> `key=value` argument, which uses a different, integer-friendly decode path).
+> Using a raw integer in a YAML file fails with an error like
+> `cannot unmarshal !!int ... into time.Duration`.
+
+## How polling works
+
+The `access_requests` endpoint has no cursor — it is filtered by a
+`since`/`until` time window and capped at `limit` results per call
+(`direction` is always requested as `asc`, oldest-first, so pagination can walk
+forward in time). Each poll:
+
+1. Queries `[watermark, now)`, where `watermark` starts at
+   `now - initial_lookback` on adapter start.
+2. If the response is a full page (`== limit` records), advances `since` to
+   the last record's `created_at` and re-queries the same window — repeated
+   until a short page shows the window is exhausted, or `max_pages` is hit.
+3. Sets the watermark to `now` (the poll's `until`) for the next poll.
+
+Because windows can abut or overlap (e.g. after a `max_pages` cutoff, or a
+record repeated across the boundary), an in-memory deduper keyed on `ray_id`
+guarantees each request is shipped to LimaCharlie exactly once. Records lacking
+a `ray_id` fall back to a content hash so deduplication still works.
+
+Errors coming back from the Cloudflare API — including persistent 5xx, a
+malformed response, or an authentication failure (401/403) — are **logged as
+warnings and never stop the adapter**. The poll is skipped and retried on the
+next interval, since restarting the adapter cannot fix a problem on
+Cloudflare's side (and in the hosted cloud-adapter environment, a fatal error
+tears the adapter down and eventually disables it). Only a failure *delivering*
+events to LimaCharlie is fatal, because there a restart re-establishes the
+connection.
+
+Transient failures (HTTP 5xx, 429, network errors) are retried within a single
+poll with exponential backoff before the poll is skipped.
+
+## Example
+
+```
+./general cloudflare_access \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=json \
+  client_options.sensor_seed_key=cloudflare_access \
+  api_token=$CF_API_TOKEN \
+  account_id=$CF_ACCOUNT_ID
+```
+
+YAML:
+
+```yaml
+cloudflare_access:
+  client_options:
+    identity:
+      oid: $OID
+      installation_key: $INSTALLATION_KEY
+    platform: json
+    sensor_seed_key: cloudflare_access
+  api_token: $CF_API_TOKEN
+  account_id: $CF_ACCOUNT_ID
+  # initial_lookback: 6h   # duration string, not nanoseconds -- see note above
+```

--- a/cloudflare_access/api.go
+++ b/cloudflare_access/api.go
@@ -1,0 +1,199 @@
+package usp_cloudflare_access
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// HTTPError represents a non-2xx response from the Cloudflare API. It carries
+// the status code so callers can classify the error (retry vs. give up)
+// without having to parse error strings.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	body := e.Body
+	if len(body) > 512 {
+		body = body[:512] + "..."
+	}
+	return fmt.Sprintf("unexpected status code %d for %q: %s", e.StatusCode, e.URL, body)
+}
+
+// isTransientError reports whether an error is worth retrying.
+//
+// Transient (retry):
+//   - HTTP 5xx server errors
+//   - HTTP 429 Too Many Requests (rate limiting)
+//   - network errors (timeouts, connection refused, DNS failures, ...)
+//
+// Permanent (do not retry):
+//   - HTTP 4xx other than 429 (bad request, auth failure, not found, ...)
+//   - a well-formed response with "success": false (Cloudflare's own error
+//     envelope -- typically a bad parameter or a scope/permission problem)
+//   - context cancellation (intentional shutdown)
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 500 && httpErr.StatusCode <= 599 {
+			return true
+		}
+		if httpErr.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+		return false
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Anything that failed before we got a response (DNS, dial, timeout, ...)
+	// is reported by Do() and wrapped with this prefix; treat it as transient.
+	if strings.Contains(err.Error(), "failed to execute request") {
+		return true
+	}
+
+	return false
+}
+
+// cloudflareMessage is an entry in the Cloudflare API response envelope's
+// "errors" or "messages" array.
+type cloudflareMessage struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (m cloudflareMessage) String() string {
+	if m.Code != 0 {
+		return fmt.Sprintf("%d: %s", m.Code, m.Message)
+	}
+	return m.Message
+}
+
+// cloudflareEnvelope mirrors the standard Cloudflare API v4 response envelope.
+type cloudflareEnvelope struct {
+	Success  bool                `json:"success"`
+	Errors   []cloudflareMessage `json:"errors"`
+	Messages []cloudflareMessage `json:"messages"`
+	Result   []json.RawMessage   `json:"result"`
+}
+
+func formatMessages(msgs []cloudflareMessage) string {
+	if len(msgs) == 0 {
+		return "no error details returned"
+	}
+	parts := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		parts = append(parts, m.String())
+	}
+	return strings.Join(parts, "; ")
+}
+
+// CloudflareAccessClient is a thin wrapper around the Cloudflare Access
+// "per-request audit logs" API:
+// https://developers.cloudflare.com/cloudflare-one/insights/logs/dashboard-logs/access-authentication-logs/#per-request-audit-logs
+type CloudflareAccessClient struct {
+	baseURL    string
+	accountID  string
+	apiToken   string
+	httpClient *http.Client
+}
+
+// NewCloudflareAccessClient builds a client. baseURL is the API root, e.g.
+// "https://api.cloudflare.com/client/v4".
+func NewCloudflareAccessClient(baseURL, accountID, apiToken string) *CloudflareAccessClient {
+	return &CloudflareAccessClient{
+		baseURL:   strings.TrimRight(baseURL, "/"),
+		accountID: accountID,
+		apiToken:  apiToken,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout: 10 * time.Second,
+				}).Dial,
+			},
+		},
+	}
+}
+
+// FetchAccessRequests issues one GET to
+// /accounts/{account_id}/access/logs/access_requests for the half-open time
+// range [since, until), walking newest-to-oldest is not attempted here --
+// callers always request direction=asc so results page forward in time.
+func (c *CloudflareAccessClient) FetchAccessRequests(ctx context.Context, since, until time.Time, limit int) ([]json.RawMessage, error) {
+	reqURL := fmt.Sprintf("%s/accounts/%s/access/logs/access_requests", c.baseURL, url.PathEscape(c.accountID))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request %q: %v", reqURL, err)
+	}
+
+	q := req.URL.Query()
+	q.Set("since", since.UTC().Format(time.RFC3339))
+	q.Set("until", until.UTC().Format(time.RFC3339))
+	q.Set("limit", strconv.Itoa(limit))
+	// asc (oldest-first) is required so the adapter can walk forward through a
+	// window that holds more records than fit in one response.
+	q.Set("direction", "asc")
+	req.URL.RawQuery = q.Encode()
+
+	// The Cloudflare API authenticates with a scoped API token as a bearer
+	// credential (Account -> Access: Audit Logs Read).
+	req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request %q: %v", reqURL, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response %q: %v", reqURL, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &HTTPError{
+			StatusCode: resp.StatusCode,
+			URL:        reqURL,
+			Body:       string(body),
+		}
+	}
+
+	var env cloudflareEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, fmt.Errorf("invalid JSON response from %q: %v", reqURL, err)
+	}
+	if !env.Success {
+		// Cloudflare can return HTTP 200 with "success": false to carry a
+		// structured error (bad parameter, revoked token, missing scope, ...).
+		// Treated as permanent -- isTransientError does not match a plain
+		// error here, so the caller will not retry it.
+		return nil, fmt.Errorf("cloudflare API returned success=false: %s", formatMessages(env.Errors))
+	}
+
+	return env.Result, nil
+}
+
+// Close releases idle connections held by the underlying transport.
+func (c *CloudflareAccessClient) Close() {
+	c.httpClient.CloseIdleConnections()
+}

--- a/cloudflare_access/client.go
+++ b/cloudflare_access/client.go
@@ -1,0 +1,525 @@
+// Package usp_cloudflare_access implements a USP adapter for Cloudflare
+// Access's per-request audit logs (also called "access authentication logs"):
+// https://developers.cloudflare.com/cloudflare-one/insights/logs/dashboard-logs/access-authentication-logs/#per-request-audit-logs
+//
+// The API exposes a single endpoint,
+// GET /accounts/{account_id}/access/logs/access_requests, filtered by a
+// since/until time window and capped at a server-side result limit (~1000)
+// with no cursor. The adapter walks each poll's window forward in time
+// (direction=asc), re-querying with an advanced `since` whenever a response
+// comes back full, until a short page shows the window is exhausted. Records
+// are forwarded to LimaCharlie in their original Cloudflare JSON form; the
+// adapter does not reshape payloads.
+package usp_cloudflare_access
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	defaultBaseURL = "https://api.cloudflare.com/client/v4"
+
+	// eventTypeAccessRequests is the EventType every shipped event carries.
+	eventTypeAccessRequests = "access_requests"
+
+	// idField / timestampField are the record fields the adapter relies on for
+	// deduplication and event time, per the documented response shape.
+	idField        = "ray_id"
+	timestampField = "created_at"
+
+	defaultPollInterval     = 1 * time.Minute
+	defaultInitialLookback  = 1 * time.Hour
+	defaultLimit            = 1000
+	maxLimit                = 1000
+	defaultMaxPages         = 100
+	defaultDedupeTTL        = 24 * time.Hour
+	dedupeBucketWindow      = 30 * time.Minute
+	defaultMaxRetryAttempts = 3
+	defaultRetryBaseDelay   = 5 * time.Second
+	defaultMaxRetryDelay    = 30 * time.Second
+
+	shipTimeout = 10 * time.Second
+)
+
+// timestampLayouts are the time formats accepted for a record's created_at
+// field. Cloudflare documents RFC 3339 with a Z suffix; a couple of lenient
+// fallbacks are accepted in case of sub-second precision.
+var timestampLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05.999999999",
+	"2006-01-02T15:04:05",
+}
+
+// CloudflareAccessConfig is the adapter configuration.
+type CloudflareAccessConfig struct {
+	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+	// APIToken is a Cloudflare API token scoped to Account -> Access: Audit
+	// Logs Read, sent as a bearer credential.
+	APIToken string `json:"api_token" yaml:"api_token"`
+
+	// AccountID is the Cloudflare account ID that owns the Access application
+	// logs (Account Home -> right sidebar, or `wrangler whoami`).
+	AccountID string `json:"account_id" yaml:"account_id"`
+
+	// BaseURL overrides the Cloudflare API root (default
+	// "https://api.cloudflare.com/client/v4"). Exists as a seam for tests.
+	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// PollInterval is the wait between polls. Default 1 minute.
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+
+	// InitialLookback bounds how far back the first poll reaches for
+	// historical events. Default 1 hour.
+	InitialLookback time.Duration `json:"initial_lookback" yaml:"initial_lookback"`
+
+	// Limit is the number of records requested per API call. Cloudflare caps
+	// this at 1000 server-side regardless of a higher value. Default 1000.
+	Limit int `json:"limit" yaml:"limit"`
+
+	// MaxPages caps how many paginated calls are made within a single poll,
+	// bounding the work done when a poll's window contains more than Limit
+	// records. Default 100.
+	MaxPages int `json:"max_pages" yaml:"max_pages"`
+
+	// DedupeTTL is how long a request's ray_id is remembered to suppress
+	// re-shipping it across overlapping polls. Default 24 hours.
+	DedupeTTL time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
+
+	// Retry tuning for transient API failures.
+	RetryBaseDelay   time.Duration `json:"retry_base_delay" yaml:"retry_base_delay"`
+	MaxRetryDelay    time.Duration `json:"max_retry_delay" yaml:"max_retry_delay"`
+	MaxRetryAttempts int           `json:"max_retry_attempts" yaml:"max_retry_attempts"`
+
+	// Deduper, when set, replaces the built-in in-memory deduper. It is not
+	// settable through a config file; it exists as a seam for tests and for
+	// embedders that want to supply a shared deduper.
+	Deduper utils.Deduper `json:"-" yaml:"-"`
+}
+
+func (c *CloudflareAccessConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+
+	c.APIToken = strings.TrimSpace(c.APIToken)
+	if c.APIToken == "" {
+		return errors.New("missing api_token")
+	}
+	c.AccountID = strings.TrimSpace(c.AccountID)
+	if c.AccountID == "" {
+		return errors.New("missing account_id")
+	}
+
+	c.BaseURL = strings.TrimSpace(c.BaseURL)
+	if c.BaseURL == "" {
+		c.BaseURL = defaultBaseURL
+	}
+	c.BaseURL = strings.TrimRight(c.BaseURL, "/")
+
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
+	if c.InitialLookback <= 0 {
+		c.InitialLookback = defaultInitialLookback
+	}
+	if c.Limit <= 0 {
+		c.Limit = defaultLimit
+	}
+	if c.Limit > maxLimit {
+		c.Limit = maxLimit
+	}
+	if c.MaxPages <= 0 {
+		c.MaxPages = defaultMaxPages
+	}
+	if c.DedupeTTL <= 0 {
+		c.DedupeTTL = defaultDedupeTTL
+	}
+	if c.RetryBaseDelay <= 0 {
+		c.RetryBaseDelay = defaultRetryBaseDelay
+	}
+	if c.MaxRetryDelay <= 0 {
+		c.MaxRetryDelay = defaultMaxRetryDelay
+	}
+	if c.MaxRetryAttempts <= 0 {
+		c.MaxRetryAttempts = defaultMaxRetryAttempts
+	}
+	return nil
+}
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
+// CloudflareAccessAdapter polls the Cloudflare Access per-request audit log
+// endpoint and ships records to LimaCharlie.
+type CloudflareAccessAdapter struct {
+	conf        CloudflareAccessConfig
+	uspClient   uspSink
+	client      *CloudflareAccessClient
+	deduper     utils.Deduper
+	ownsDeduper bool
+
+	// watermark is the start of the next poll's query window. Only the single
+	// poll goroutine reads or writes it, so no lock is needed.
+	watermark time.Time
+
+	chStopped chan struct{}
+	wgSenders sync.WaitGroup
+	doStop    *utils.Event
+
+	closeOnce sync.Once
+	closeErr  error
+
+	ctx context.Context
+}
+
+// NewCloudflareAccessAdapter creates a Cloudflare Access adapter wired to
+// LimaCharlie.
+func NewCloudflareAccessAdapter(ctx context.Context, conf CloudflareAccessConfig) (*CloudflareAccessAdapter, chan struct{}, error) {
+	return newCloudflareAccessAdapter(ctx, conf, nil)
+}
+
+// newCloudflareAccessAdapter is the implementation behind
+// NewCloudflareAccessAdapter. When sink is non-nil it is used in place of a
+// real LimaCharlie client -- the seam tests use to capture shipped events.
+func newCloudflareAccessAdapter(ctx context.Context, conf CloudflareAccessConfig, sink uspSink) (*CloudflareAccessAdapter, chan struct{}, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	a := &CloudflareAccessAdapter{
+		conf:      conf,
+		ctx:       ctx,
+		doStop:    utils.NewEvent(),
+		watermark: time.Now().UTC().Add(-conf.InitialLookback),
+	}
+
+	// Every poll re-walks its window from the last watermark, and overlapping
+	// windows can re-fetch the boundary record; a deduper is required to ship
+	// each record exactly once. A deduper may be supplied via the config;
+	// otherwise an in-memory one is created (and owned/closed by the adapter).
+	a.deduper = conf.Deduper
+	if a.deduper == nil {
+		window := dedupeBucketWindow
+		if window > conf.DedupeTTL {
+			window = conf.DedupeTTL
+		}
+		deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cloudflare_access: deduper: %v", err)
+		}
+		a.deduper = deduper
+		a.ownsDeduper = true
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			if a.ownsDeduper {
+				a.deduper.Close()
+			}
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
+	}
+
+	a.client = NewCloudflareAccessClient(conf.BaseURL, conf.AccountID, conf.APIToken)
+	a.chStopped = make(chan struct{})
+
+	a.wgSenders.Add(1)
+	go a.runPoll()
+
+	go func() {
+		a.wgSenders.Wait()
+		close(a.chStopped)
+	}()
+
+	return a, a.chStopped, nil
+}
+
+// Close stops the adapter. It is idempotent: repeated calls are no-ops and
+// return the result of the first call.
+func (a *CloudflareAccessAdapter) Close() error {
+	a.closeOnce.Do(func() {
+		a.conf.ClientOptions.DebugLog("cloudflare_access: closing")
+		a.doStop.Set()
+		a.wgSenders.Wait()
+		err1 := a.uspClient.Drain(1 * time.Minute)
+		_, err2 := a.uspClient.Close()
+		a.client.Close()
+		if a.ownsDeduper {
+			a.deduper.Close()
+		}
+		if err1 != nil {
+			a.closeErr = err1
+		} else {
+			a.closeErr = err2
+		}
+	})
+	return a.closeErr
+}
+
+// runPoll polls forever, until the adapter is asked to stop.
+func (a *CloudflareAccessAdapter) runPoll() {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog("cloudflare_access: polling stopped")
+
+	isFirstRun := true
+	for isFirstRun || !a.doStop.WaitFor(a.conf.PollInterval) {
+		isFirstRun = false
+		a.poll()
+	}
+}
+
+// poll fetches every record in [watermark, now) once, advancing the watermark
+// as it goes so a later poll resumes exactly where this one left off (or, if
+// the API errors out mid-window, where the last successful page ended).
+//
+// Every page within the window is fetched -- the deduper, not an early exit,
+// is what keeps a record from being shipped more than once across polls whose
+// windows abut or overlap.
+func (a *CloudflareAccessAdapter) poll() {
+	until := time.Now().UTC()
+	since := a.watermark
+	if !since.Before(until) {
+		return
+	}
+
+	nSeen, nShipped := 0, 0
+
+	for page := 0; ; page++ {
+		if a.doStop.IsSet() {
+			return
+		}
+		if page >= a.conf.MaxPages {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"cloudflare_access: hit max_pages=%d before catching up to %s; remaining records "+
+					"in this window are collected on a later poll -- raise max_pages if this persists",
+				a.conf.MaxPages, until.Format(time.RFC3339)))
+			return
+		}
+
+		items, ok := a.fetchPage(since, until)
+		if !ok {
+			// The error has already been reported; abandon this poll (the
+			// watermark stays at the last successful point) and try again on
+			// the next interval.
+			return
+		}
+		if len(items) == 0 {
+			break
+		}
+
+		for _, item := range items {
+			nSeen++
+			if a.deduper.CheckAndAdd(dedupeKey(item)) {
+				continue
+			}
+			if !a.ship(item) {
+				return
+			}
+			nShipped++
+		}
+
+		last := items[len(items)-1]
+		lastTS, ok2 := recordTime(last)
+		if !ok2 {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"cloudflare_access: could not parse %q on the last record of a page; stopping this poll early", timestampField))
+			break
+		}
+
+		// A full page whose last record's timestamp did not advance past the
+		// start of this fetch means more records than fit in one response
+		// share the same instant. Bail out of this poll rather than
+		// re-fetching the identical page until max_pages is hit; the deduper
+		// has already suppressed re-shipping what was seen.
+		if len(items) >= a.conf.Limit && !lastTS.After(since) {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"cloudflare_access: %d records share timestamp %s (>= limit=%d); some may not be "+
+					"collected this poll", len(items), lastTS.Format(time.RFC3339), a.conf.Limit))
+			break
+		}
+
+		since = lastTS
+		a.watermark = since
+
+		if len(items) < a.conf.Limit {
+			// A short page means the window is exhausted.
+			break
+		}
+		// A full page: more records may remain between `since` and `until`.
+	}
+
+	a.watermark = until
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"cloudflare_access: poll complete (seen=%d shipped=%d)", nSeen, nShipped))
+}
+
+// fetchPage requests one page of the access_requests window, retrying
+// transient failures with exponential backoff. The bool result is false when
+// the poll should be abandoned (any source-side error, or the adapter is
+// stopping).
+//
+// Source-side errors (anything the Cloudflare API itself returns: 4xx/5xx,
+// auth failures, network blips, malformed responses) are reported via
+// OnWarning and NEVER stop the adapter. The cloud-sensor host treats any
+// adapter OnError as fatal to the instance -- it tears the adapter down and
+// relaunches it, and after enough failures disables it entirely. Restarting
+// cannot fix a problem on Cloudflare's side, so we log, skip this poll, and
+// let the next interval try again; a recovered token then heals on its own.
+// Only a failure delivering to LimaCharlie (see ship) is fatal, since a
+// relaunch there reconnects the backend.
+func (a *CloudflareAccessAdapter) fetchPage(since, until time.Time) ([]utils.Dict, bool) {
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"cloudflare_access: querying base_url=%s account_id=%s since=%s until=%s limit=%d direction=asc",
+		a.conf.BaseURL, a.conf.AccountID, since.UTC().Format(time.RFC3339), until.UTC().Format(time.RFC3339), a.conf.Limit))
+
+	var raw []json.RawMessage
+	var err error
+	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
+		if a.doStop.IsSet() {
+			return nil, false
+		}
+
+		raw, err = a.client.FetchAccessRequests(a.ctx, since, until, a.conf.Limit)
+		if err == nil {
+			break
+		}
+
+		if !isTransientError(err) {
+			msg := fmt.Sprintf("cloudflare_access: request failed (skipping this poll): %v", err)
+			var httpErr *HTTPError
+			if errors.As(err, &httpErr) &&
+				(httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
+				msg = fmt.Sprintf(
+					"cloudflare_access: HTTP %d, token rejected. Verify the API token is scoped to "+
+						"Account -> Access: Audit Logs Read for account %q.", httpErr.StatusCode, a.conf.AccountID)
+			}
+			a.conf.ClientOptions.OnWarning(msg)
+			return nil, false
+		}
+
+		if attempt+1 >= a.conf.MaxRetryAttempts {
+			break
+		}
+		delay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
+		if delay > a.conf.MaxRetryDelay {
+			delay = a.conf.MaxRetryDelay
+		}
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"cloudflare_access: transient error (attempt %d/%d), retrying in %v: %v",
+			attempt+1, a.conf.MaxRetryAttempts, delay, err))
+		if a.doStop.WaitFor(delay) {
+			return nil, false
+		}
+	}
+	if err != nil {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"cloudflare_access: failed after %d attempts (skipping this poll): %v", a.conf.MaxRetryAttempts, err))
+		return nil, false
+	}
+
+	items := make([]utils.Dict, 0, len(raw))
+	nDropped := 0
+	for _, r := range raw {
+		m, err := utils.UnmarshalCleanJSON(string(r))
+		if err != nil || len(m) == 0 {
+			nDropped++
+			continue
+		}
+		items = append(items, utils.Dict(m))
+	}
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"cloudflare_access: response had %d raw record(s), %d parsed, %d dropped", len(raw), len(items), nDropped))
+	return items, true
+}
+
+// ship forwards a single record to LimaCharlie. It returns false if the
+// adapter should stop (an unrecoverable shipping error).
+func (a *CloudflareAccessAdapter) ship(item utils.Dict) bool {
+	msg := &protocol.DataMessage{
+		JsonPayload: item,
+		EventType:   eventTypeAccessRequests,
+		TimestampMs: eventTime(item),
+	}
+	if err := a.uspClient.Ship(msg, shipTimeout); err != nil {
+		if err == uspclient.ErrorBufferFull {
+			a.conf.ClientOptions.OnWarning("cloudflare_access: stream falling behind")
+			err = a.uspClient.Ship(msg, 1*time.Hour)
+		}
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("cloudflare_access: Ship(): %v", err))
+			a.doStop.Set()
+			return false
+		}
+	}
+	return true
+}
+
+// eventTime extracts a record's event time, falling back to now when
+// created_at is absent or unparseable.
+func eventTime(item utils.Dict) uint64 {
+	if t, ok := recordTime(item); ok {
+		return uint64(t.UnixMilli())
+	}
+	return uint64(time.Now().UnixMilli())
+}
+
+// recordTime parses a record's created_at field.
+func recordTime(item utils.Dict) (time.Time, bool) {
+	raw := item.FindOneString(timestampField)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	return parseTimestamp(raw)
+}
+
+// dedupeKey returns a stable deduplication key for a record.
+func dedupeKey(item utils.Dict) string {
+	if id := item.FindOneString(idField); id != "" {
+		return id
+	}
+	// ray_id is expected on every record; a content hash keeps deduplication
+	// working even for an anomalous record that lacks one.
+	if b, err := json.Marshal(item); err == nil {
+		sum := sha256.Sum256(b)
+		return "sha256:" + hex.EncodeToString(sum[:])
+	}
+	return ""
+}
+
+func parseTimestamp(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range timestampLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}

--- a/cloudflare_access/client_test.go
+++ b/cloudflare_access/client_test.go
@@ -1,0 +1,107 @@
+package usp_cloudflare_access
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testContext returns a context bounded generously enough for the mock-backed
+// end-to-end tests, and its cancel func.
+func testContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 15*time.Second)
+}
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+func validConfig(t *testing.T) CloudflareAccessConfig {
+	return CloudflareAccessConfig{
+		ClientOptions: testClientOptions(t),
+		APIToken:      "test-token",
+		AccountID:     "acct-123",
+	}
+}
+
+func TestValidateRequiresAPIToken(t *testing.T) {
+	conf := validConfig(t)
+	conf.APIToken = ""
+	require.Error(t, conf.Validate())
+}
+
+func TestValidateRequiresAccountID(t *testing.T) {
+	conf := validConfig(t)
+	conf.AccountID = ""
+	require.Error(t, conf.Validate())
+}
+
+func TestValidateFillsDefaults(t *testing.T) {
+	conf := validConfig(t)
+	require.NoError(t, conf.Validate())
+
+	assert.Equal(t, defaultBaseURL, conf.BaseURL)
+	assert.Equal(t, defaultPollInterval, conf.PollInterval)
+	assert.Equal(t, defaultInitialLookback, conf.InitialLookback)
+	assert.Equal(t, defaultLimit, conf.Limit)
+	assert.Equal(t, defaultMaxPages, conf.MaxPages)
+	assert.Equal(t, defaultDedupeTTL, conf.DedupeTTL)
+	assert.Equal(t, defaultRetryBaseDelay, conf.RetryBaseDelay)
+	assert.Equal(t, defaultMaxRetryDelay, conf.MaxRetryDelay)
+	assert.Equal(t, defaultMaxRetryAttempts, conf.MaxRetryAttempts)
+}
+
+func TestValidateClampsLimitToMax(t *testing.T) {
+	conf := validConfig(t)
+	conf.Limit = 5000
+	require.NoError(t, conf.Validate())
+	assert.Equal(t, maxLimit, conf.Limit)
+}
+
+func TestValidateTrimsBaseURL(t *testing.T) {
+	conf := validConfig(t)
+	conf.BaseURL = "https://example.test/client/v4/"
+	require.NoError(t, conf.Validate())
+	assert.Equal(t, "https://example.test/client/v4", conf.BaseURL)
+}
+
+func TestParseTimestampAcceptsDocumentedFormat(t *testing.T) {
+	ts, ok := parseTimestamp("2026-07-02T15:03:00Z")
+	require.True(t, ok)
+	assert.Equal(t, 2026, ts.Year())
+	assert.Equal(t, time.July, ts.Month())
+}
+
+func TestParseTimestampRejectsGarbage(t *testing.T) {
+	_, ok := parseTimestamp("not-a-timestamp")
+	assert.False(t, ok)
+}
+
+func TestDedupeKeyPrefersRayID(t *testing.T) {
+	item := map[string]interface{}{"ray_id": "a1cbcd95da9aa9e9", "user_email": "user@example.com"}
+	assert.Equal(t, "a1cbcd95da9aa9e9", dedupeKey(item))
+}
+
+func TestDedupeKeyFallsBackToContentHash(t *testing.T) {
+	item := map[string]interface{}{"user_email": "user@example.com"}
+	key := dedupeKey(item)
+	assert.NotEmpty(t, key)
+	assert.NotEqual(t, "a1cbcd95da9aa9e9", key)
+}

--- a/cloudflare_access/mock_test.go
+++ b/cloudflare_access/mock_test.go
@@ -1,0 +1,422 @@
+package usp_cloudflare_access
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file exercises the adapter end-to-end against a mock Cloudflare Access
+// API, capturing the exact messages it ships so their content -- event type,
+// timestamp and verbatim payload -- can be asserted.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// --- mock Cloudflare Access API ----------------------------------------------
+
+// mockCloudflareAccess is an in-memory stand-in for the Cloudflare Access
+// per-request audit log endpoint. It honours the real contract: a GET to
+// /accounts/{account_id}/access/logs/access_requests carrying a bearer token,
+// filtered by since/until/limit and returning the standard
+// {"success","errors","messages","result"} envelope.
+type mockCloudflareAccess struct {
+	mu        sync.Mutex
+	token     string
+	accountID string
+	records   []utils.Dict // all records, any order
+	requests  int32
+}
+
+func newMockCloudflareAccess(token, accountID string) *mockCloudflareAccess {
+	return &mockCloudflareAccess{token: token, accountID: accountID}
+}
+
+func (m *mockCloudflareAccess) setRecords(records []utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.records = records
+}
+
+func (m *mockCloudflareAccess) appendRecord(record utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.records = append(m.records, record)
+}
+
+func (m *mockCloudflareAccess) requestCount() int {
+	return int(atomic.LoadInt32(&m.requests))
+}
+
+func (m *mockCloudflareAccess) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&m.requests, 1)
+
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		wantPath := "/accounts/" + m.accountID + "/access/logs/access_requests"
+		if r.URL.Path != wantPath {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer "+m.token {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": false,
+				"errors":  []map[string]interface{}{{"code": 9109, "message": "Invalid access token"}},
+			})
+			return
+		}
+
+		q := r.URL.Query()
+		since, err := time.Parse(time.RFC3339, q.Get("since"))
+		if !assert.NoError(t, err, "since must be RFC3339") {
+			http.Error(w, "bad since", http.StatusBadRequest)
+			return
+		}
+		until, err := time.Parse(time.RFC3339, q.Get("until"))
+		if !assert.NoError(t, err, "until must be RFC3339") {
+			http.Error(w, "bad until", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, "asc", q.Get("direction"), "adapter must always request ascending order")
+		limit, err := strconv.Atoi(q.Get("limit"))
+		if !assert.NoError(t, err, "limit must be an int") {
+			http.Error(w, "bad limit", http.StatusBadRequest)
+			return
+		}
+
+		m.mu.Lock()
+		var matched []utils.Dict
+		for _, rec := range m.records {
+			ts, ok := recordTime(rec)
+			if !ok {
+				continue
+			}
+			if !ts.Before(since) && ts.Before(until) {
+				matched = append(matched, rec)
+			}
+		}
+		m.mu.Unlock()
+
+		sort.Slice(matched, func(i, j int) bool {
+			ti, _ := recordTime(matched[i])
+			tj, _ := recordTime(matched[j])
+			return ti.Before(tj)
+		})
+		if len(matched) > limit {
+			matched = matched[:limit]
+		}
+		if matched == nil {
+			matched = []utils.Dict{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success":  true,
+			"errors":   []interface{}{},
+			"messages": []interface{}{},
+			"result":   matched,
+		})
+	}
+}
+
+// --- realistic record fixtures ----------------------------------------------
+
+// realisticAccessRequest returns a record shaped like a real Cloudflare Access
+// per-request audit log entry, per the documented response schema.
+func realisticAccessRequest(rayID, createdAt string) utils.Dict {
+	return utils.Dict{
+		"created_at": createdAt,
+		"user_email": "user@example.com",
+		"user_id":    "b4bf51f2-c72b-50b1-a179-20b76a49b18b",
+		"ip_address": "203.0.113.10",
+		"country":    "US",
+		"app_domain": "kibana.example.com",
+		"app_name":   "CFZT_App_kibana_example_com",
+		"app_uid":    "968a35b8-def0-45de-9d2f-f65d514fa76c",
+		"app_type":   "self_hosted",
+		"action":     "login",
+		"allowed":    true,
+		"connection": "azureAD",
+		"ray_id":     rayID,
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestMockEndToEnd drives the adapter against the mock API and asserts the
+// exact events shipped: event type, timestamp parsed from created_at, and the
+// payload preserved verbatim.
+func TestMockEndToEnd(t *testing.T) {
+	const token = "cf-api-token-xyz"
+	const accountID = "acct-1"
+
+	now := time.Now().UTC()
+	want := []utils.Dict{
+		realisticAccessRequest("ray-1001", now.Add(-3*time.Minute).Format(time.RFC3339)),
+		realisticAccessRequest("ray-1002", now.Add(-2*time.Minute).Format(time.RFC3339)),
+		realisticAccessRequest("ray-1003", now.Add(-1*time.Minute).Format(time.RFC3339)),
+	}
+
+	mock := newMockCloudflareAccess(token, accountID)
+	mock.setRecords(want)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := testContext()
+	defer cancel()
+
+	conf := CloudflareAccessConfig{
+		ClientOptions:   testClientOptions(t),
+		APIToken:        token,
+		AccountID:       accountID,
+		BaseURL:         server.URL,
+		PollInterval:    40 * time.Millisecond,
+		InitialLookback: 1 * time.Hour,
+	}
+	adapter, _, err := newCloudflareAccessAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "expected all 3 access requests to ship")
+
+	// Re-polling must not re-ship: the count stays at 3.
+	require.Never(t, func() bool { return sink.count() != 3 },
+		300*time.Millisecond, 30*time.Millisecond, "records were re-shipped on a later poll")
+
+	byID := map[string]*protocol.DataMessage{}
+	for _, msg := range sink.snapshot() {
+		assert.Equal(t, eventTypeAccessRequests, msg.EventType)
+		require.NotNil(t, msg.JsonPayload)
+		id, _ := msg.JsonPayload["ray_id"].(string)
+		require.NotEmpty(t, id)
+		byID[id] = msg
+	}
+	require.Len(t, byID, 3)
+
+	for _, src := range want {
+		id := src["ray_id"].(string)
+		msg := byID[id]
+		require.NotNil(t, msg, "record %s was not shipped", id)
+
+		ts, perr := time.Parse(time.RFC3339, src["created_at"].(string))
+		require.NoError(t, perr)
+		assert.Equal(t, uint64(ts.UnixMilli()), msg.TimestampMs,
+			"event time should come from the record's created_at")
+
+		assert.JSONEq(t, mustJSON(t, src), mustJSON(t, msg.JsonPayload),
+			"shipped payload must match the original Cloudflare record verbatim")
+	}
+}
+
+// TestMockNewRequestShippedOnce verifies a request that appears mid-run is
+// shipped exactly once, and already-shipped requests are never re-sent.
+func TestMockNewRequestShippedOnce(t *testing.T) {
+	const token = "tok"
+	const accountID = "acct-1"
+
+	now := time.Now().UTC()
+	mock := newMockCloudflareAccess(token, accountID)
+	mock.setRecords([]utils.Dict{
+		realisticAccessRequest("a", now.Add(-2*time.Minute).Format(time.RFC3339)),
+		realisticAccessRequest("b", now.Add(-1*time.Minute).Format(time.RFC3339)),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := testContext()
+	defer cancel()
+
+	conf := CloudflareAccessConfig{
+		ClientOptions:   testClientOptions(t),
+		APIToken:        token,
+		AccountID:       accountID,
+		BaseURL:         server.URL,
+		PollInterval:    30 * time.Millisecond,
+		InitialLookback: 1 * time.Hour,
+	}
+	adapter, _, err := newCloudflareAccessAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == 2 },
+		5*time.Second, 20*time.Millisecond)
+
+	// A new request appears.
+	mock.appendRecord(realisticAccessRequest("c", time.Now().UTC().Format(time.RFC3339)))
+
+	require.Eventually(t, func() bool { return sink.count() == 3 },
+		5*time.Second, 20*time.Millisecond, "the new request should ship")
+	require.Never(t, func() bool { return sink.count() > 3 },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	shippedPerID := map[string]int{}
+	for _, msg := range sink.snapshot() {
+		shippedPerID[msg.JsonPayload["ray_id"].(string)]++
+	}
+	assert.Equal(t, map[string]int{"a": 1, "b": 1, "c": 1}, shippedPerID,
+		"every request must ship exactly once")
+}
+
+// TestMockPaginationFullDataset verifies a window containing more records
+// than the per-request limit is walked completely, in multiple paginated
+// calls, with every record shipped exactly once.
+func TestMockPaginationFullDataset(t *testing.T) {
+	const token = "tok"
+	const accountID = "acct-1"
+	const total = 25
+
+	base := time.Now().UTC().Add(-1 * time.Hour)
+	records := make([]utils.Dict, total)
+	for i := 0; i < total; i++ {
+		records[i] = realisticAccessRequest(
+			fmt.Sprintf("ray-%03d", i),
+			base.Add(time.Duration(i)*time.Second).Format(time.RFC3339))
+	}
+
+	mock := newMockCloudflareAccess(token, accountID)
+	mock.setRecords(records)
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := testContext()
+	defer cancel()
+
+	conf := CloudflareAccessConfig{
+		ClientOptions:   testClientOptions(t),
+		APIToken:        token,
+		AccountID:       accountID,
+		BaseURL:         server.URL,
+		Limit:           5, // 25 records => at least 5 paginated calls per poll
+		PollInterval:    50 * time.Millisecond,
+		InitialLookback: 2 * time.Hour,
+	}
+	adapter, _, err := newCloudflareAccessAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	require.Eventually(t, func() bool { return sink.count() == total },
+		10*time.Second, 25*time.Millisecond, "all paginated records should ship")
+	require.Never(t, func() bool { return sink.count() != total },
+		300*time.Millisecond, 30*time.Millisecond)
+
+	ids := map[string]bool{}
+	for _, msg := range sink.snapshot() {
+		ids[msg.JsonPayload["ray_id"].(string)] = true
+	}
+	assert.Len(t, ids, total, "every distinct record should be shipped once")
+	assert.GreaterOrEqual(t, mock.requestCount(), total/5,
+		"the adapter should have walked the window in multiple paginated calls")
+}
+
+// TestMockRejectsBadToken verifies the adapter stops, and ships nothing, when
+// the mock API rejects the supplied token.
+func TestMockRejectsBadToken(t *testing.T) {
+	const accountID = "acct-1"
+	mock := newMockCloudflareAccess("correct-token", accountID)
+	mock.setRecords([]utils.Dict{
+		realisticAccessRequest("a", time.Now().UTC().Format(time.RFC3339)),
+	})
+
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	sink := &captureSink{}
+	ctx, cancel := testContext()
+	defer cancel()
+
+	var warnings, fatalErrors atomic.Int32
+	opts := testClientOptions(t)
+	opts.OnWarning = func(msg string) { warnings.Add(1); t.Logf("WRN: %s", msg) }
+	opts.OnError = func(err error) { fatalErrors.Add(1); t.Logf("ERR: %v", err) }
+
+	conf := CloudflareAccessConfig{
+		ClientOptions:   opts,
+		APIToken:        "wrong-token",
+		AccountID:       accountID,
+		BaseURL:         server.URL,
+		PollInterval:    50 * time.Millisecond,
+		InitialLookback: 1 * time.Hour,
+	}
+	adapter, chStopped, err := newCloudflareAccessAdapter(ctx, conf, sink)
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	// A rejected token is a source-side problem: the adapter warns and keeps
+	// running (retrying each poll) rather than stopping. Stopping would make
+	// the cloud-sensor host tear it down, relaunch and eventually disable it --
+	// a restart cannot fix a bad token, and an operator fixing the token should
+	// see the adapter recover on its own.
+	require.Eventually(t, func() bool { return warnings.Load() > 0 },
+		3*time.Second, 20*time.Millisecond, "expected a warning when the token is rejected")
+
+	select {
+	case <-chStopped:
+		t.Fatal("adapter must not stop when the API rejects the token")
+	case <-time.After(300 * time.Millisecond):
+	}
+	assert.False(t, adapter.doStop.IsSet(), "doStop must not be set on a rejected token")
+	assert.Equal(t, int32(0), fatalErrors.Load(), "a rejected token must warn, not fatally error")
+	assert.Equal(t, 0, sink.count(), "nothing should ship when authentication fails")
+	assert.GreaterOrEqual(t, mock.requestCount(), 1, "the adapter should have called the API")
+}

--- a/containers/conf/all.go
+++ b/containers/conf/all.go
@@ -8,6 +8,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/bitwarden"
 	"github.com/refractionPOINT/usp-adapters/box"
 	"github.com/refractionPOINT/usp-adapters/cato"
+	"github.com/refractionPOINT/usp-adapters/cloudflare_access"
 	"github.com/refractionPOINT/usp-adapters/cylance"
 	"github.com/refractionPOINT/usp-adapters/defender"
 	"github.com/refractionPOINT/usp-adapters/duo"
@@ -62,6 +63,7 @@ type GeneralConfigs struct {
 	EntraID           usp_entraid.EntraIDConfig                       `json:"entraid" yaml:"entraid"`
 	Defender          usp_defender.DefenderConfig                     `json:"defender" yaml:"defender"`
 	Cato              usp_cato.CatoConfig                             `json:"cato" yaml:"cato"`
+	CloudflareAccess  usp_cloudflare_access.CloudflareAccessConfig    `json:"cloudflare_access" yaml:"cloudflare_access"`
 	Cylance           usp_cylance.CylanceConfig                       `json:"cylance" yaml:"cylance"`
 	Okta              usp_okta.OktaConfig                             `json:"okta" yaml:"okta"`
 	Office365         usp_o365.Office365Config                        `json:"office365" yaml:"office365"`

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -22,6 +22,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/bitwarden"
 	"github.com/refractionPOINT/usp-adapters/box"
 	"github.com/refractionPOINT/usp-adapters/cato"
+	"github.com/refractionPOINT/usp-adapters/cloudflare_access"
 	"github.com/refractionPOINT/usp-adapters/cylance"
 	"github.com/refractionPOINT/usp-adapters/defender"
 	"github.com/refractionPOINT/usp-adapters/duo"
@@ -375,6 +376,11 @@ func runAdapter(ctx context.Context, method string, configs Configuration, showC
 		configs.Cato.ClientOptions.Architecture = "usp_adapter"
 		configToShow = configs.Cato
 		client, chRunning, err = usp_cato.NewCatoAdapter(ctx, configs.Cato)
+	} else if method == "cloudflare_access" {
+		configs.CloudflareAccess.ClientOptions = applyLogging(configs.CloudflareAccess.ClientOptions)
+		configs.CloudflareAccess.ClientOptions.Architecture = "usp_adapter"
+		configToShow = configs.CloudflareAccess
+		client, chRunning, err = usp_cloudflare_access.NewCloudflareAccessAdapter(ctx, configs.CloudflareAccess)
 	} else if method == "cylance" {
 		configs.Cylance.ClientOptions = applyLogging(configs.Cylance.ClientOptions)
 		configs.Cylance.ClientOptions.Architecture = "usp_adapter"


### PR DESCRIPTION
Add Cloudflare Access adapter (per-request audit logs)

Polls the Access Requests API (since/until/limit, no cursor) and walks forward through a window when it holds more records than fit in one response, deduping on ray_id. Registered in containers/conf/all.go and containers/general/tool.go; includes a mock-backed test suite and README.

Also documents that YAML config files must express duration fields (poll_interval, initial_lookback, etc.) as Go duration strings (e.g. "6h"), not raw nanosecond integers -- gopkg.in/yaml.v3 refuses to decode a bare int into time.Duration when loading from a file (CLI key=value args go through a different, integer-friendly path). Found via live debugging where a login was missed because initial_lookback didn't reach far enough back due to this exact issue.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


