### PR TITLE
Add WithSecure adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ be added purely through configuration. See [threatlocker/README.md](./threatlock
 ./general threatlocker client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=threatlocker api_key=$THREATLOCKER_API_TOKEN instance=g
 ```
 
+### WithSecure
+
+Pulls telemetry from the WithSecure Elements cloud (formerly F-Secure): the EPP
+security event stream, Broad Context Detections (correlated EDR incidents) with
+their underlying detections, and optionally the administrative audit trail. Each
+stream is polled incrementally on a timestamp cursor. See
+[withsecure/README.md](./withsecure/README.md).
+
+```
+./general withsecure client_options.identity.installation_key=e9a3bcdf-efa2-47ae-b6df-579a02f3a54d client_options.identity.oid=8cbe27f4-bfa1-4afb-ba19-138cd51389cd client_options.platform=json client_options.sensor_seed_key=withsecure client_id=$WS_CLIENT_ID client_secret=$WS_CLIENT_SECRET
+```
+
 ### Gmail
 
 Collects incoming email as telemetry from one or many Gmail mailboxes via the

--- a/containers/conf/all.go
+++ b/containers/conf/all.go
@@ -44,6 +44,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/threatlocker"
 	"github.com/refractionPOINT/usp-adapters/trendmicro"
 	"github.com/refractionPOINT/usp-adapters/wel"
+	"github.com/refractionPOINT/usp-adapters/withsecure"
 	"github.com/refractionPOINT/usp-adapters/wiz"
 	"github.com/refractionPOINT/usp-adapters/zendesk"
 )
@@ -94,5 +95,6 @@ type GeneralConfigs struct {
 	ServiceNow        usp_servicenow.ServiceNowConfig                 `json:"servicenow" yaml:"servicenow"`
 	ThreatLocker      usp_threatlocker.ThreatLockerConfig             `json:"threatlocker" yaml:"threatlocker"`
 	TrendMicro        usp_trendmicro.TrendMicroConfig                 `json:"trendmicro" yaml:"trendmicro"`
+	WithSecure        usp_withsecure.WithSecureConfig                 `json:"withsecure" yaml:"withsecure"`
 	Wiz               usp_wiz.WizConfig                               `json:"wiz" yaml:"wiz"`
 }

--- a/containers/general/tool.go
+++ b/containers/general/tool.go
@@ -58,6 +58,7 @@ import (
 	"github.com/refractionPOINT/usp-adapters/threatlocker"
 	"github.com/refractionPOINT/usp-adapters/trendmicro"
 	"github.com/refractionPOINT/usp-adapters/wel"
+	"github.com/refractionPOINT/usp-adapters/withsecure"
 	"github.com/refractionPOINT/usp-adapters/wiz"
 	"github.com/refractionPOINT/usp-adapters/zendesk"
 
@@ -510,6 +511,11 @@ func runAdapter(ctx context.Context, method string, configs Configuration, showC
 		configs.ThreatLocker.ClientOptions.Architecture = "usp_adapter"
 		configToShow = configs.ThreatLocker
 		client, chRunning, err = usp_threatlocker.NewThreatLockerAdapter(ctx, configs.ThreatLocker)
+	} else if method == "withsecure" {
+		configs.WithSecure.ClientOptions = applyLogging(configs.WithSecure.ClientOptions)
+		configs.WithSecure.ClientOptions.Architecture = "usp_adapter"
+		configToShow = configs.WithSecure
+		client, chRunning, err = usp_withsecure.NewWithSecureAdapter(ctx, configs.WithSecure)
 	} else {
 		return nil, nil, errors.New(logError("unknown adapter_type: %s", method))
 	}

--- a/withsecure/README.md
+++ b/withsecure/README.md
@@ -1,0 +1,226 @@
+# WithSecure Adapter
+
+Pulls telemetry from the [WithSecure™ Elements](https://www.withsecure.com/)
+cloud (formerly F-Secure) into LimaCharlie via the
+[Elements API](https://connect.withsecure.com/api-reference/elements). Events are
+forwarded in their original WithSecure JSON form — the adapter does not reshape
+payloads.
+
+## What it collects
+
+Four streams, each shipped under its own event type:
+
+| Event type | Elements endpoint | What it carries |
+|---|---|---|
+| `security_event` | `POST /security-events/v1/security-events` | The EPP protection-engine event stream — malware scanning, DeepGuard, firewall, browsing and connection control, device control, DataGuard, tamper protection, AMSI, application control, collaboration protection, and more. |
+| `incident` | `GET /incidents/v1/incidents` | **Broad Context Detections** — WithSecure's correlated EDR incidents, each grouping related activity across one or more hosts. |
+| `detection` | `GET /incidents/v1/detections` | The individual detections that make up a BCD, with the process evidence that triggered them (path, name, hash, command line, PID, user, privileges). |
+| `audit_log` | `GET /audit-logs/v1/audit-logs` | The Elements administrative audit trail — who changed what. |
+
+`security_event`, `incident` and `detection` are collected by default.
+`audit_log` is **off by default**: it is administrative activity rather than
+security telemetry, and noisy for most deployments.
+
+## Authentication
+
+Create an API client in the Elements Security Center under **Management →
+Organization Settings → API clients**. Read-only access is sufficient — this
+adapter never writes.
+
+> ⚠️ The client secret is displayed **only once**, at creation. Save it before
+> closing the dialog.
+
+Authentication is OAuth2 client credentials against
+`POST /as/token.oauth2`. The adapter mints a token (~30 minute lifetime), caches
+it, and renews it transparently; a `401` mid-poll re-mints once before failing.
+
+A bad credential **stops the adapter** rather than looping: no amount of
+retrying fixes it, and silently collecting nothing is worse than failing
+visibly. Any other API-side failure (5xx, 429, network blip) only skips that
+poll.
+
+## Configuration
+
+| Key | Required | Default | Description |
+|---|---|---|---|
+| `client_id` | yes | | Elements API client ID. |
+| `client_secret` | yes | | Elements API client secret. |
+| `organization_id` | no | credential's own org | Elements organization UUID to collect. Set this when using a partner (MSSP) credential that manages several organizations. |
+| `base_url` | no | `https://api.connect.withsecure.com` | API root override (e.g. the staging host). |
+| `collect_security_events` | no | `true` | Collect the EPP security event stream. |
+| `collect_incidents` | no | `true` | Collect Broad Context Detections. |
+| `collect_detections` | no | `true` | Collect the detections under each BCD. Requires `collect_incidents`. |
+| `collect_audit_logs` | no | `false` | Collect the administrative audit trail. |
+| `engines` | no | all | Only these security-event engines (e.g. `deepGuard`, `firewall`, `fileScanning`). |
+| `engine_groups` | no | all | Only these engine groups: `epp`, `edr`, `ecp` (collaboration protection), `xm` (exposure management). |
+| `severities` | no | all | Only these severities: `critical`, `warning`, `info`. |
+| `include_archived_incidents` | no | `false` | Also collect archived BCDs. Leaving this off is also faster, per the API docs. |
+| `lookback` | no | `1h` | How far back the first poll of each stream reaches. Capped at 30 days for `audit_log`. |
+| `poll_interval` | no | `1m` | Wait between polls of each stream. |
+| `page_size` | no | endpoint max | Records per page. Clamped per endpoint (security events 200, audit logs 200, incidents 50, detections 100). |
+| `max_pages` | no | `100` | Pages walked per poll. The cursor only advances over what was read, so a capped poll resumes where it left off. |
+| `dedupe_ttl` | no | `24h` | How long a record id is remembered to suppress re-shipping. |
+| `retry_base_delay` | no | `5s` | Backoff base for transient failures. |
+| `max_retry_delay` | no | `30s` | Backoff ceiling. |
+| `max_retry_attempts` | no | `3` | Attempts before skipping a poll. |
+| `user_agent` | no | `LimaCharlie-usp-adapter-withsecure/1.0` | The Elements API rejects requests without a `User-Agent`. |
+
+## How it works
+
+**Incremental polling on a timestamp cursor.** Each stream tracks the newest
+timestamp it has seen and asks only for records after it —
+`persistenceTimestampStart` for security events, `updatedTimestampStart` for
+incidents, `serverTimestampStart` for audit logs — always with
+`exclusiveStart=true`. Without that flag the API returns records *greater than
+or equal to* the bound, so the boundary record would be re-read on every poll.
+Results are requested in ascending order so the cursor advances naturally as
+pages are consumed.
+
+After the first poll the cursor is always a timestamp string the API itself
+emitted, so its format cannot drift from what the endpoint accepts.
+
+**Anchor pagination.** Responses are `{"items": [...], "nextAnchor": "..."}`;
+the adapter follows the opaque anchor until it is absent. `max_pages` bounds one
+poll's work — hitting the cap is not data loss, since the cursor only advances
+over records actually read.
+
+**Incidents are living objects.** A Broad Context Detection accretes detections
+over its lifetime, so the incident stream filters on `updatedTimestamp`, not
+`createdTimestamp` — the flow WithSecure's own cookbook prescribes. Each
+*version* of an incident ships once (the dedupe key includes its
+`updatedTimestamp`), so you see a BCD evolve from `new` to `closed`. Detections
+dedupe on their stable `detectionId`, so re-visiting an updated incident only
+ships the detections that are genuinely new.
+
+Detections are fetched **per incident** — the API has no organization-wide
+detections endpoint — which is why `collect_detections` requires
+`collect_incidents`.
+
+**Deduplication.** Consecutive polls deliberately overlap and updated incidents
+are re-visited, so an in-memory deduper (`dedupe_ttl`, default 24 h) guarantees
+each record ships exactly once. A record missing its id field falls back to a
+content hash.
+
+## Rate limits
+
+The Elements API allows 10,000 requests/minute per source IP in general, but
+only **300/minute for the endpoints this adapter uses** (security events,
+incidents, audit logs). A `429` carries `Retry-After` and is treated as
+transient. If you collect many organizations from one host, raise
+`poll_interval` or narrow the streams rather than tightening the loop.
+
+## Sample event
+
+A `security_event`:
+
+```json
+{
+  "id": "07a286cc-99ba-3538-8997-557076ff95ab_0",
+  "action": "blocked",
+  "engine": "deepGuard",
+  "severity": "warning",
+  "serverTimestamp": "2026-07-30T09:31:01.092Z",
+  "persistenceTimestamp": "2026-07-30T09:31:03.292Z",
+  "clientTimestamp": "2026-07-30T09:31:01.000Z",
+  "eventTransactionId": "0000-187cf62797634fef",
+  "acknowledged": false,
+  "message": "DeepGuard blocked a harmful application",
+  "description": "DeepGuard event",
+  "organization": { "id": "…", "name": "example-org" },
+  "device": { "id": "…", "name": "DESKTOP-3D64DAK", "labels": ["finance"] },
+  "target": { "id": "…", "name": "DESKTOP-3D64DAK" },
+  "userName": "EXAMPLE\\jdoe",
+  "details": {
+    "path": "C:\\Users\\jdoe\\AppData\\Local\\Temp\\evil.exe",
+    "alertType": "deepguard.harmful.blocked",
+    "hostIpAddress": "10.1.2.3/24"
+  }
+}
+```
+
+A `detection` under a BCD:
+
+```json
+{
+  "detectionId": "cc04e914-dbea-4785-83cc-60492f03b97d",
+  "incidentId": "2c902c73-e2a6-40fd-9532-257ee102e1c1",
+  "deviceId": "3a8f06e1-c3e8-4933-b617-e23597111644",
+  "name": "suspiciousPowershellCommand",
+  "detectionClass": "PROCESS",
+  "severity": "medium",
+  "riskLevel": "medium",
+  "exePath": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  "exeHash": "c8f21ef51fa2f2033a9ca7c0cc0412c25065e2ba",
+  "cmdl": "powershell -enc SQBFAFgA",
+  "pid": 1234,
+  "username": "EXAMPLE\\jdoe",
+  "createdTimestamp": "2026-07-30T09:30:51.097Z"
+}
+```
+
+The event time (`TimestampMs`) comes from the record itself:
+`persistenceTimestamp` for security events, `updatedTimestamp` for incidents,
+`createdTimestamp` for detections, `serverTimestamp` for audit logs.
+
+## Running it
+
+CLI:
+
+```
+./general withsecure \
+  client_options.identity.oid=$OID \
+  client_options.identity.installation_key=$INSTALLATION_KEY \
+  client_options.platform=json \
+  client_options.sensor_seed_key=withsecure \
+  client_id=$WS_CLIENT_ID \
+  client_secret=$WS_CLIENT_SECRET
+```
+
+YAML:
+
+```yaml
+withsecure:
+  client_options:
+    identity:
+      oid: 8cbe27f4-bfa1-4afb-ba19-138cd51389cd
+      installation_key: e9a3bcdf-efa2-47ae-b6df-579a02f3a54d
+    platform: json
+    sensor_seed_key: withsecure
+  client_id: "your-elements-api-client-id"
+  client_secret: "your-elements-api-client-secret"
+  organization_id: "00000000-0000-0000-0000-000000000000"
+  collect_audit_logs: true
+  severities:
+    - critical
+    - warning
+  poll_interval: 1m
+  lookback: 24h
+```
+
+## Notes
+
+- **One organization per adapter instance.** A partner credential can see many
+  organizations, but each instance collects one `organization_id`. Run one
+  instance per organization (each with its own `sensor_seed_key`) to keep them
+  on separate sensors.
+- Security-event queries **must** carry a time bound; the adapter always sends
+  one, so `lookback` is what decides how much history the first poll pulls.
+- Audit-log queries cannot span more than 30 days, so `lookback` is capped for
+  that stream.
+- The `security-events` query is a `POST` with a form-encoded body, not JSON.
+  Array filters (`engines`, `severities`) are sent as repeated keys.
+- A `403` mentioning a scope means the API client lacks the entitlement for that
+  endpoint (for example, a tenant without the EDR subscription has no BCDs) —
+  it is a licensing/permission problem, not an adapter bug.
+
+## Testing
+
+```
+go test ./withsecure/...
+```
+
+The suite runs end-to-end against a mock Elements API that reproduces the real
+contract: Basic-auth-only token requests whose body carries nothing beyond
+`grant_type`/`scope`, the mandatory `User-Agent`, anchor pagination over the
+`{items, nextAnchor}` envelope, `exclusiveStart` cursor semantics, and the flat
+`{message, code, transactionId}` error object. No credentials are needed.

--- a/withsecure/api.go
+++ b/withsecure/api.go
@@ -1,0 +1,377 @@
+package usp_withsecure
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HTTPError represents a non-2xx response from the Elements API. It carries the
+// status code so callers can classify the error (retry vs. give up) without
+// having to parse error strings.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	body := e.Body
+	if len(body) > 512 {
+		body = body[:512] + "..."
+	}
+	return fmt.Sprintf("unexpected status code %d for %q: %s", e.StatusCode, e.URL, body)
+}
+
+// isTransientError reports whether an error is worth retrying.
+//
+// Transient (retry):
+//   - HTTP 5xx server errors
+//   - HTTP 429 Too Many Requests — the Elements API rate-limits the EDR
+//     endpoints (devices, incidents, security events, audit logs) at 300
+//     requests/minute per source IP, well below its 10,000/minute general
+//     limit, so a busy tenant can legitimately meet a 429.
+//   - network errors (timeouts, connection refused, DNS failures, ...)
+//
+// Permanent (do not retry):
+//   - HTTP 4xx other than 429 (bad request, auth failure, not found, ...)
+//   - context cancellation (intentional shutdown)
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 500 && httpErr.StatusCode <= 599 {
+			return true
+		}
+		if httpErr.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+		return false
+	}
+
+	// Context cancellation is an intentional shutdown, not a transient blip.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Anything that failed before we got a response (DNS, dial, timeout, ...)
+	// is reported by Do() and wrapped with this prefix; treat it as transient.
+	if strings.Contains(err.Error(), "failed to execute request") {
+		return true
+	}
+
+	return false
+}
+
+// isAuthError reports whether an error is an authentication failure, which the
+// adapter treats as fatal (a poll retry cannot fix a bad credential).
+func isAuthError(err error) bool {
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode == http.StatusUnauthorized
+	}
+	var tokErr *tokenError
+	return errors.As(err, &tokErr) && tokErr.fatal
+}
+
+// WithSecureClient is a thin wrapper around the WithSecure Elements API.
+//
+// Everything the adapter needs is a GET or a form-encoded POST against
+// https://api.connect.withsecure.com, authenticated with a cached OAuth2
+// client-credentials bearer token.
+type WithSecureClient struct {
+	baseURL    string
+	userAgent  string
+	httpClient *http.Client
+	tokens     *tokenSource
+}
+
+// NewWithSecureClient builds a client. baseURL is the API root, e.g.
+// "https://api.connect.withsecure.com".
+func NewWithSecureClient(baseURL, clientID, clientSecret, userAgent string) *WithSecureClient {
+	base := strings.TrimRight(baseURL, "/")
+	httpClient := &http.Client{
+		Timeout: 60 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 10 * time.Second,
+			}).Dial,
+		},
+	}
+	return &WithSecureClient{
+		baseURL:    base,
+		userAgent:  userAgent,
+		httpClient: httpClient,
+		tokens: &tokenSource{
+			tokenURL:     base + tokenPath,
+			clientID:     clientID,
+			clientSecret: clientSecret,
+			userAgent:    userAgent,
+			httpClient:   httpClient,
+		},
+	}
+}
+
+// Get issues a GET with query parameters and returns the raw response body.
+func (c *WithSecureClient) Get(ctx context.Context, path string, query url.Values) ([]byte, error) {
+	reqURL := c.baseURL + "/" + strings.TrimPrefix(path, "/")
+	if len(query) > 0 {
+		reqURL += "?" + query.Encode()
+	}
+	return c.do(ctx, http.MethodGet, reqURL, nil)
+}
+
+// PostForm issues a POST with an application/x-www-form-urlencoded body. The
+// security-events and missing-updates queries are POSTs that take form bodies
+// rather than JSON — an easy detail to get wrong.
+func (c *WithSecureClient) PostForm(ctx context.Context, path string, form url.Values) ([]byte, error) {
+	reqURL := c.baseURL + "/" + strings.TrimPrefix(path, "/")
+	return c.do(ctx, http.MethodPost, reqURL, form)
+}
+
+// do performs one authenticated request. A 401 is retried once with a freshly
+// minted token: the Elements token lives only ~30 minutes, so a 401 mid-poll is
+// far more likely to be an expiry race than a revoked credential.
+func (c *WithSecureClient) do(ctx context.Context, method, reqURL string, form url.Values) ([]byte, error) {
+	body, err := c.doOnce(ctx, method, reqURL, form)
+	if err == nil {
+		return body, nil
+	}
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized {
+		c.tokens.invalidate()
+		return c.doOnce(ctx, method, reqURL, form)
+	}
+	return nil, err
+}
+
+func (c *WithSecureClient) doOnce(ctx context.Context, method, reqURL string, form url.Values) ([]byte, error) {
+	token, err := c.tokens.token(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload io.Reader
+	if form != nil {
+		payload = strings.NewReader(form.Encode())
+	}
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request %q: %v", reqURL, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	// The Elements API rejects any request without a User-Agent outright.
+	req.Header.Set("User-Agent", c.userAgent)
+	if form != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request %q: %v", reqURL, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response %q: %v", reqURL, err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &HTTPError{
+			StatusCode: resp.StatusCode,
+			URL:        stripQuery(reqURL),
+			Body:       string(respBody),
+		}
+	}
+	return respBody, nil
+}
+
+// Close releases idle connections held by the underlying transport.
+func (c *WithSecureClient) Close() {
+	c.httpClient.CloseIdleConnections()
+}
+
+// stripQuery removes the query string from a URL for error messages, which are
+// logged: the query carries organization and device identifiers.
+func stripQuery(raw string) string {
+	if i := strings.IndexByte(raw, '?'); i >= 0 {
+		return raw[:i]
+	}
+	return raw
+}
+
+// OAuth2 client credentials
+// ============================================================================
+
+const (
+	tokenPath = "/as/token.oauth2"
+
+	// scopeRead is all this adapter needs — it only ever reads.
+	scopeRead = "connect.api.read"
+
+	// tokenExpiryBuffer renews a token this long before it actually expires so
+	// an in-flight request never races the expiry boundary.
+	tokenExpiryBuffer = 60 * time.Second
+
+	// defaultTokenTTL is assumed when the token endpoint omits expires_in. The
+	// documented lifetime is 1797 seconds.
+	defaultTokenTTL = 25 * time.Minute
+)
+
+// tokenError is a failure from the token endpoint.
+type tokenError struct {
+	statusCode  int
+	code        string
+	description string
+	// fatal marks a credential problem (as opposed to a transient outage) that
+	// no amount of retrying will fix.
+	fatal bool
+}
+
+func (e *tokenError) Error() string {
+	if e.description != "" {
+		return fmt.Sprintf("withsecure oauth token error %d %s: %s", e.statusCode, e.code, e.description)
+	}
+	return fmt.Sprintf("withsecure oauth token error %d %s", e.statusCode, e.code)
+}
+
+// tokenSource acquires and caches the client-credentials bearer token.
+type tokenSource struct {
+	tokenURL     string
+	clientID     string
+	clientSecret string
+	userAgent    string
+	httpClient   *http.Client
+
+	mu        sync.Mutex
+	value     string
+	expiresAt time.Time
+}
+
+func (ts *tokenSource) invalidate() {
+	ts.mu.Lock()
+	ts.value = ""
+	ts.expiresAt = time.Time{}
+	ts.mu.Unlock()
+}
+
+func (ts *tokenSource) token(ctx context.Context) (string, error) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	if ts.value != "" && time.Until(ts.expiresAt) > tokenExpiryBuffer {
+		return ts.value, nil
+	}
+	tok, ttl, err := ts.fetch(ctx)
+	if err != nil {
+		return "", err
+	}
+	ts.value = tok
+	ts.expiresAt = time.Now().Add(ttl)
+	return tok, nil
+}
+
+// fetch performs the client-credentials exchange.
+//
+// The credentials go in an HTTP Basic header and ONLY grant_type/scope may
+// appear in the form body: the API documents that "the request will fail if
+// parameters other than those allowed are sent in the payload", so the usual
+// client_id/client_secret-in-the-body form that most OAuth servers tolerate is
+// rejected here.
+func (ts *tokenSource) fetch(ctx context.Context) (string, time.Duration, error) {
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("scope", scopeRead)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to create token request: %v", err)
+	}
+	req.SetBasicAuth(ts.clientID, ts.clientSecret)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", ts.userAgent)
+
+	resp, err := ts.httpClient.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to execute request %q: %v", ts.tokenURL, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to read token response: %v", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", 0, parseTokenError(resp.StatusCode, respBody)
+	}
+
+	var tr struct {
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(respBody, &tr); err != nil {
+		return "", 0, fmt.Errorf("failed to decode token response: %v", err)
+	}
+	if tr.AccessToken == "" {
+		return "", 0, &tokenError{
+			statusCode:  resp.StatusCode,
+			code:        "no_access_token",
+			description: "token endpoint returned no access_token",
+			fatal:       true,
+		}
+	}
+	ttl := time.Duration(tr.ExpiresIn) * time.Second
+	if ttl <= 0 {
+		ttl = defaultTokenTTL
+	}
+	return tr.AccessToken, ttl, nil
+}
+
+// parseTokenError decodes the OAuth error envelope, falling back to the
+// Elements {"message","code"} envelope the gateway sometimes returns instead.
+func parseTokenError(status int, body []byte) *tokenError {
+	te := &tokenError{statusCode: status}
+
+	var oauthEnv struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &oauthEnv); err == nil && oauthEnv.Error != "" {
+		te.code = oauthEnv.Error
+		te.description = oauthEnv.ErrorDescription
+		switch oauthEnv.Error {
+		case "invalid_client", "unauthorized_client", "invalid_grant", "invalid_scope":
+			te.fatal = true
+		}
+		return te
+	}
+
+	var apiEnv struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &apiEnv); err == nil && apiEnv.Message != "" {
+		te.code = "token_request_failed"
+		te.description = apiEnv.Message
+	} else {
+		te.code = "token_request_failed"
+		te.description = string(body)
+	}
+	// A 4xx from the token endpoint is a credential problem; a 5xx is not.
+	te.fatal = status >= 400 && status < 500
+	return te
+}

--- a/withsecure/client.go
+++ b/withsecure/client.go
@@ -1,0 +1,929 @@
+// Package usp_withsecure implements a USP adapter for the WithSecure™ Elements
+// API (https://api.connect.withsecure.com), the cloud behind WithSecure
+// Elements Endpoint Protection and Endpoint Detection & Response (formerly
+// F-Secure).
+//
+// It collects four streams, each shipped verbatim under its own event type:
+//
+//   - security_event — the EPP protection-engine event stream (malware
+//     scanning, DeepGuard, firewall, browsing/connection control, device
+//     control, DataGuard, tamper protection, AMSI, collaboration protection, …)
+//   - incident       — Broad Context Detections, WithSecure's correlated EDR
+//     incidents, re-shipped each time an incident evolves
+//   - detection      — the individual detections that make up a BCD, with the
+//     process evidence that triggered them
+//   - audit_log      — the Elements administrative audit trail
+//
+// Every stream is polled incrementally on a timestamp cursor with
+// exclusiveStart, so an evolving data set is picked up without re-reading it;
+// a deduper absorbs the overlap that remains.
+package usp_withsecure
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+)
+
+const (
+	// defaultBaseURL is the production Elements API host.
+	defaultBaseURL = "https://api.connect.withsecure.com"
+
+	// defaultUserAgent identifies this integration. The Elements API rejects
+	// any request without a User-Agent, so this is never empty.
+	defaultUserAgent = "LimaCharlie-usp-adapter-withsecure/1.0"
+
+	// API paths.
+	pathSecurityEvents = "security-events/v1/security-events"
+	pathIncidents      = "incidents/v1/incidents"
+	pathDetections     = "incidents/v1/detections"
+	pathAuditLogs      = "audit-logs/v1/audit-logs"
+
+	// Feed names, which become the EventType of each shipped record.
+	feedSecurityEvents = "security_event"
+	feedIncidents      = "incident"
+	feedDetections     = "detection"
+	feedAuditLogs      = "audit_log"
+
+	defaultPollInterval = 1 * time.Minute
+	defaultLookback     = 1 * time.Hour
+	defaultDedupeTTL    = 24 * time.Hour
+	dedupeBucketWindow  = 1 * time.Hour
+	defaultMaxPages     = 100
+
+	defaultMaxRetryAttempts = 3
+	defaultRetryBaseDelay   = 5 * time.Second
+	defaultMaxRetryDelay    = 30 * time.Second
+
+	shipTimeout = 10 * time.Second
+
+	// Per-endpoint page-size ceilings, from the API specification. Requesting
+	// more is rejected, so the config is clamped rather than passed through.
+	maxSecurityEventPageSize = 200
+	maxAuditLogPageSize      = 200
+	maxIncidentPageSize      = 50
+	maxDetectionPageSize     = 100
+
+	// maxAuditLogWindow is the API's hard limit on an audit-log query range.
+	// A first poll with a longer lookback would be rejected outright.
+	maxAuditLogWindow = 30 * 24 * time.Hour
+
+	// maxDetectionsPerIncident bounds how many detections are pulled for one
+	// incident in a single poll, so a pathological incident cannot stall the
+	// feed.
+	maxDetectionsPerIncident = 1000
+
+	// cursorLayout is how the adapter renders its *initial* cursor. Every
+	// later cursor is the timestamp string the API itself returned, so the
+	// format always round-trips.
+	cursorLayout = "2006-01-02T15:04:05.000Z"
+)
+
+// timestampLayouts are the formats accepted for a record's timestamp field.
+// The Elements API emits RFC 3339 with millisecond precision and a Z suffix,
+// but the tolerant list guards against per-endpoint variation.
+var timestampLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05.999999999",
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+}
+
+// WithSecureConfig is the adapter configuration.
+type WithSecureConfig struct {
+	ClientOptions uspclient.ClientOptions `json:"client_options" yaml:"client_options"`
+
+	// ClientID / ClientSecret are an Elements API client credential, created in
+	// the Elements Security Center under Management > Organization Settings >
+	// API clients. Read-only access is sufficient for this adapter.
+	ClientID     string `json:"client_id" yaml:"client_id"`
+	ClientSecret string `json:"client_secret" yaml:"client_secret"`
+
+	// OrganizationID scopes every query to one Elements organization. Optional:
+	// when empty the API uses the credential's own organization. A partner
+	// (MSSP) credential should set it to collect a specific sub-organization —
+	// run the extension's list_organizations, or the /organizations endpoint,
+	// to find the UUID.
+	OrganizationID string `json:"organization_id" yaml:"organization_id"`
+
+	// BaseURL overrides the API root. Defaults to
+	// https://api.connect.withsecure.com.
+	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// CollectSecurityEvents / CollectIncidents / CollectDetections /
+	// CollectAuditLogs select which streams are collected. A nil (absent) value
+	// means enabled for the first three, so the zero-config default collects
+	// security events, incidents and their detections. Audit logs default to
+	// OFF: they are administrative activity rather than security telemetry and
+	// are noisy for most deployments.
+	CollectSecurityEvents *bool `json:"collect_security_events" yaml:"collect_security_events"`
+	CollectIncidents      *bool `json:"collect_incidents" yaml:"collect_incidents"`
+	CollectDetections     *bool `json:"collect_detections" yaml:"collect_detections"`
+	CollectAuditLogs      *bool `json:"collect_audit_logs" yaml:"collect_audit_logs"`
+
+	// Engines / EngineGroups / Severities filter the security event stream.
+	// Empty means no filter (every engine, every severity). engine_group
+	// accepts epp, edr, ecp (collaboration protection) and xm (exposure
+	// management).
+	Engines      []string `json:"engines" yaml:"engines"`
+	EngineGroups []string `json:"engine_groups" yaml:"engine_groups"`
+	Severities   []string `json:"severities" yaml:"severities"`
+
+	// IncludeArchivedIncidents collects archived Broad Context Detections too.
+	// Off by default: the API documents that filtering them out is also faster.
+	IncludeArchivedIncidents bool `json:"include_archived_incidents" yaml:"include_archived_incidents"`
+
+	// Lookback is how far back the first poll of each stream reaches. Default
+	// 1 hour. The audit-log stream is capped at the API's 30-day query limit.
+	Lookback time.Duration `json:"lookback" yaml:"lookback"`
+
+	// PollInterval is the wait between polls of a stream. Default 1 minute.
+	// Note the API rate-limits these endpoints to 300 requests/minute per
+	// source IP.
+	PollInterval time.Duration `json:"poll_interval" yaml:"poll_interval"`
+
+	// PageSize is the number of records requested per page. Clamped to each
+	// endpoint's own ceiling (security events 200, audit logs 200, incidents
+	// 50, detections 100).
+	PageSize int `json:"page_size" yaml:"page_size"`
+
+	// MaxPages caps how many pages are walked per poll, bounding the work of a
+	// first poll against a long lookback. Default 100.
+	MaxPages int `json:"max_pages" yaml:"max_pages"`
+
+	// DedupeTTL is how long a record's identifier is remembered to suppress
+	// re-shipping it. Default 24 hours.
+	DedupeTTL time.Duration `json:"dedupe_ttl" yaml:"dedupe_ttl"`
+
+	// Retry tuning for transient API failures.
+	RetryBaseDelay   time.Duration `json:"retry_base_delay" yaml:"retry_base_delay"`
+	MaxRetryDelay    time.Duration `json:"max_retry_delay" yaml:"max_retry_delay"`
+	MaxRetryAttempts int           `json:"max_retry_attempts" yaml:"max_retry_attempts"`
+
+	// UserAgent overrides the mandatory User-Agent header.
+	UserAgent string `json:"user_agent" yaml:"user_agent"`
+
+	// Deduper, when set, replaces the built-in in-memory deduper. It is not
+	// settable through a config file; it exists as a seam for tests and for
+	// embedders that want to supply a shared deduper.
+	Deduper utils.Deduper `json:"-" yaml:"-"`
+}
+
+// enabled reports whether a stream should run. def is the value used when the
+// toggle is absent from the config.
+func enabled(v *bool, def bool) bool {
+	if v == nil {
+		return def
+	}
+	return *v
+}
+
+func (c *WithSecureConfig) Validate() error {
+	if err := c.ClientOptions.Validate(); err != nil {
+		return fmt.Errorf("client_options: %v", err)
+	}
+	c.ClientID = strings.TrimSpace(c.ClientID)
+	c.ClientSecret = strings.TrimSpace(c.ClientSecret)
+	if c.ClientID == "" {
+		return errors.New("missing client_id")
+	}
+	if c.ClientSecret == "" {
+		return errors.New("missing client_secret")
+	}
+
+	c.BaseURL = strings.TrimRight(strings.TrimSpace(c.BaseURL), "/")
+	if c.BaseURL == "" {
+		c.BaseURL = defaultBaseURL
+	}
+	c.OrganizationID = strings.TrimSpace(c.OrganizationID)
+	if c.UserAgent == "" {
+		c.UserAgent = defaultUserAgent
+	}
+
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
+	if c.Lookback <= 0 {
+		c.Lookback = defaultLookback
+	}
+	if c.DedupeTTL <= 0 {
+		c.DedupeTTL = defaultDedupeTTL
+	}
+	if c.PageSize <= 0 {
+		c.PageSize = maxSecurityEventPageSize
+	}
+	if c.MaxPages <= 0 {
+		c.MaxPages = defaultMaxPages
+	}
+	if c.RetryBaseDelay <= 0 {
+		c.RetryBaseDelay = defaultRetryBaseDelay
+	}
+	if c.MaxRetryDelay <= 0 {
+		c.MaxRetryDelay = defaultMaxRetryDelay
+	}
+	if c.MaxRetryAttempts <= 0 {
+		c.MaxRetryAttempts = defaultMaxRetryAttempts
+	}
+
+	// Detections hang off the incident stream: they are fetched per incident,
+	// because the API has no organization-wide detections endpoint.
+	if enabled(c.CollectDetections, true) && !enabled(c.CollectIncidents, true) {
+		return errors.New("collect_detections requires collect_incidents: detections are fetched per incident")
+	}
+	if !c.anyFeedEnabled() {
+		return errors.New("every stream is disabled; enable at least one of collect_security_events/collect_incidents/collect_audit_logs")
+	}
+	return nil
+}
+
+func (c *WithSecureConfig) anyFeedEnabled() bool {
+	return enabled(c.CollectSecurityEvents, true) ||
+		enabled(c.CollectIncidents, true) ||
+		enabled(c.CollectAuditLogs, false)
+}
+
+// uspSink is the subset of *uspclient.Client the adapter depends on. Expressing
+// it as an interface lets tests substitute an in-memory sink for the real
+// LimaCharlie client; *uspclient.Client satisfies it unchanged.
+type uspSink interface {
+	Ship(message *protocol.DataMessage, timeout time.Duration) error
+	Drain(timeout time.Duration) error
+	Close() ([]*protocol.DataMessage, error)
+}
+
+// WithSecureAdapter polls the WithSecure Elements API and ships its records to
+// LimaCharlie.
+type WithSecureAdapter struct {
+	conf        WithSecureConfig
+	uspClient   uspSink
+	client      *WithSecureClient
+	deduper     utils.Deduper
+	ownsDeduper bool
+
+	chStopped chan struct{}
+	wgSenders sync.WaitGroup
+	doStop    *utils.Event
+
+	closeOnce sync.Once
+	closeErr  error
+
+	ctx context.Context
+}
+
+// NewWithSecureAdapter creates a WithSecure adapter wired to LimaCharlie.
+func NewWithSecureAdapter(ctx context.Context, conf WithSecureConfig) (*WithSecureAdapter, chan struct{}, error) {
+	return newWithSecureAdapter(ctx, conf, nil)
+}
+
+// newWithSecureAdapter is the implementation behind NewWithSecureAdapter. When
+// sink is non-nil it is used in place of a real LimaCharlie client -- the seam
+// tests use to capture shipped events.
+func newWithSecureAdapter(ctx context.Context, conf WithSecureConfig, sink uspSink) (*WithSecureAdapter, chan struct{}, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	a := &WithSecureAdapter{
+		conf:   conf,
+		ctx:    ctx,
+		doStop: utils.NewEvent(),
+	}
+
+	// Consecutive polls deliberately overlap (see pollWindow), and an incident's
+	// detections are re-listed whenever the incident changes, so a deduper is
+	// required to ship each record exactly once.
+	a.deduper = conf.Deduper
+	if a.deduper == nil {
+		window := dedupeBucketWindow
+		if window > conf.DedupeTTL {
+			window = conf.DedupeTTL
+		}
+		deduper, err := utils.NewLocalDeduper(window, conf.DedupeTTL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("withsecure: deduper: %v", err)
+		}
+		a.deduper = deduper
+		a.ownsDeduper = true
+	}
+
+	if sink != nil {
+		a.uspClient = sink
+	} else {
+		uspClient, err := uspclient.NewClient(ctx, conf.ClientOptions)
+		if err != nil {
+			if a.ownsDeduper {
+				a.deduper.Close()
+			}
+			return nil, nil, err
+		}
+		a.uspClient = uspClient
+	}
+
+	a.client = NewWithSecureClient(conf.BaseURL, conf.ClientID, conf.ClientSecret, conf.UserAgent)
+	a.chStopped = make(chan struct{})
+
+	now := time.Now().UTC()
+	if enabled(conf.CollectSecurityEvents, true) {
+		a.startFeed(feedSecurityEvents, now, conf.Lookback)
+	}
+	if enabled(conf.CollectIncidents, true) {
+		a.startFeed(feedIncidents, now, conf.Lookback)
+	}
+	if enabled(conf.CollectAuditLogs, false) {
+		// The API rejects an audit-log query spanning more than 30 days.
+		lookback := conf.Lookback
+		if lookback > maxAuditLogWindow {
+			lookback = maxAuditLogWindow
+		}
+		a.startFeed(feedAuditLogs, now, lookback)
+	}
+
+	go func() {
+		a.wgSenders.Wait()
+		close(a.chStopped)
+	}()
+
+	return a, a.chStopped, nil
+}
+
+// startFeed launches one stream's polling goroutine with its initial cursor.
+func (a *WithSecureAdapter) startFeed(name string, now time.Time, lookback time.Duration) {
+	f := &feedState{name: name, cursor: now.Add(-lookback).Format(cursorLayout)}
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf("withsecure: starting feed %q from %s", name, f.cursor))
+	a.wgSenders.Add(1)
+	go a.runFeed(f)
+}
+
+// Close stops the adapter. It is idempotent: repeated calls are no-ops and
+// return the result of the first call.
+func (a *WithSecureAdapter) Close() error {
+	a.closeOnce.Do(func() {
+		a.conf.ClientOptions.DebugLog("withsecure: closing")
+		a.doStop.Set()
+		a.wgSenders.Wait()
+		err1 := a.uspClient.Drain(1 * time.Minute)
+		_, err2 := a.uspClient.Close()
+		a.client.Close()
+		if a.ownsDeduper {
+			a.deduper.Close()
+		}
+		if err1 != nil {
+			a.closeErr = err1
+		} else {
+			a.closeErr = err2
+		}
+	})
+	return a.closeErr
+}
+
+// feedState is one stream's polling cursor.
+//
+// The cursor is a timestamp string, and after the first poll it is always a
+// value the API itself emitted rather than one this adapter formatted — so the
+// format cannot drift from what the endpoint accepts.
+type feedState struct {
+	name   string
+	cursor string
+}
+
+// runFeed polls a single stream until the adapter is asked to stop.
+func (a *WithSecureAdapter) runFeed(f *feedState) {
+	defer a.wgSenders.Done()
+	defer a.conf.ClientOptions.DebugLog(fmt.Sprintf("withsecure: feed %q stopped", f.name))
+
+	isFirstRun := true
+	for isFirstRun || !a.doStop.WaitFor(a.conf.PollInterval) {
+		isFirstRun = false
+		switch f.name {
+		case feedSecurityEvents:
+			a.pollSecurityEvents(f)
+		case feedIncidents:
+			a.pollIncidents(f)
+		case feedAuditLogs:
+			a.pollAuditLogs(f)
+		}
+	}
+}
+
+// Security events
+// ============================================================================
+
+// pollSecurityEvents walks the EPP security event stream forward from the
+// cursor.
+//
+// The query is a POST with a form-encoded body (not JSON, and not a GET), and
+// the API rejects it outright if no time bound is given. exclusiveStart is what
+// keeps the boundary event from being re-read on every poll: without it the API
+// returns records with a persistenceTimestamp *greater than or equal to* the
+// bound.
+func (a *WithSecureAdapter) pollSecurityEvents(f *feedState) {
+	anchor := ""
+	newest := f.cursor
+	nSeen, nShipped := 0, 0
+
+	for page := 1; !a.doStop.IsSet(); page++ {
+		if page > a.conf.MaxPages {
+			a.warnMaxPages(f.name)
+			break
+		}
+
+		form := url.Values{}
+		a.setOrganization(form)
+		form.Set("persistenceTimestampStart", f.cursor)
+		form.Set("exclusiveStart", "true")
+		// Ascending order makes the last record of the last page the newest,
+		// so the cursor advances naturally as pages are consumed.
+		form.Set("order", "asc")
+		form.Set("limit", strconv.Itoa(clamp(a.conf.PageSize, maxSecurityEventPageSize)))
+		addAll(form, "engine", a.conf.Engines)
+		addAll(form, "engineGroup", a.conf.EngineGroups)
+		addAll(form, "severity", a.conf.Severities)
+		if anchor != "" {
+			form.Set("anchor", anchor)
+		}
+
+		items, next, ok := a.fetchPage(f.name, func(ctx context.Context) ([]byte, error) {
+			return a.client.PostForm(ctx, pathSecurityEvents, form)
+		})
+		if !ok {
+			return
+		}
+		if len(items) == 0 {
+			break
+		}
+
+		for _, item := range items {
+			nSeen++
+			if ts := item.FindOneString("persistenceTimestamp"); ts != "" && ts > newest {
+				newest = ts
+			}
+			key := feedSecurityEvents + "|" + recordID(item, "id")
+			if a.deduper.CheckAndAdd(key) {
+				continue
+			}
+			if !a.ship(feedSecurityEvents, item, a.eventTime(item, "persistenceTimestamp", "serverTimestamp", "clientTimestamp")) {
+				return
+			}
+			nShipped++
+		}
+
+		if next == "" {
+			break
+		}
+		anchor = next
+	}
+
+	f.cursor = newest
+	a.debugPoll(f, nSeen, nShipped)
+}
+
+// Incidents (Broad Context Detections) and their detections
+// ============================================================================
+
+// pollIncidents walks Broad Context Detections forward from the cursor on
+// updatedTimestamp, and — when detections are enabled — pulls the detections of
+// each incident it sees.
+//
+// Filtering on updatedTimestamp rather than createdTimestamp is deliberate and
+// is the flow WithSecure's own cookbook prescribes: a BCD is a living object
+// that accretes detections over its lifetime, so an incident first seen an hour
+// ago can gain new evidence now. Re-visiting it on update is how that evidence
+// is collected; the incident's own dedupe key includes its updatedTimestamp so
+// each *version* ships once, while detections dedupe on their stable id.
+func (a *WithSecureAdapter) pollIncidents(f *feedState) {
+	anchor := ""
+	newest := f.cursor
+	nSeen, nShipped := 0, 0
+	collectDetections := enabled(a.conf.CollectDetections, true)
+
+	for page := 1; !a.doStop.IsSet(); page++ {
+		if page > a.conf.MaxPages {
+			a.warnMaxPages(f.name)
+			break
+		}
+
+		q := url.Values{}
+		a.setOrganization(q)
+		q.Set("updatedTimestampStart", f.cursor)
+		q.Set("exclusiveStart", "true")
+		q.Set("order", "asc")
+		q.Set("limit", strconv.Itoa(clamp(a.conf.PageSize, maxIncidentPageSize)))
+		if !a.conf.IncludeArchivedIncidents {
+			q.Set("archived", "false")
+		}
+		if anchor != "" {
+			q.Set("anchor", anchor)
+		}
+
+		items, next, ok := a.fetchPage(f.name, func(ctx context.Context) ([]byte, error) {
+			return a.client.Get(ctx, pathIncidents, q)
+		})
+		if !ok {
+			return
+		}
+		if len(items) == 0 {
+			break
+		}
+
+		for _, item := range items {
+			nSeen++
+			updated := item.FindOneString("updatedTimestamp")
+			if updated != "" && updated > newest {
+				newest = updated
+			}
+
+			// Key on the incident *version*: a BCD whose status, risk or
+			// detection set changed is new information worth shipping again,
+			// but re-reading an unchanged one must not duplicate it.
+			key := feedIncidents + "|" + recordID(item, "incidentId") + "|" + updated
+			if !a.deduper.CheckAndAdd(key) {
+				if !a.ship(feedIncidents, item, a.eventTime(item, "updatedTimestamp", "createdTimestamp")) {
+					return
+				}
+				nShipped++
+			}
+
+			if collectDetections {
+				shipped, ok := a.pollDetections(item.FindOneString("incidentId"))
+				if !ok {
+					return
+				}
+				nShipped += shipped
+			}
+		}
+
+		if next == "" {
+			break
+		}
+		anchor = next
+	}
+
+	f.cursor = newest
+	a.debugPoll(f, nSeen, nShipped)
+}
+
+// pollDetections ships the detections of one incident. The bool result is false
+// when the whole poll should be abandoned (a shipping failure); a source-side
+// failure to read one incident's detections only skips that incident.
+func (a *WithSecureAdapter) pollDetections(incidentID string) (int, bool) {
+	if incidentID == "" {
+		return 0, true
+	}
+
+	anchor := ""
+	nShipped := 0
+	nSeen := 0
+
+	for page := 1; !a.doStop.IsSet(); page++ {
+		if page > a.conf.MaxPages || nSeen >= maxDetectionsPerIncident {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"withsecure: incident %s has more detections than one poll collects "+
+					"(seen=%d); raise max_pages if this repeats", incidentID, nSeen))
+			break
+		}
+
+		q := url.Values{}
+		a.setOrganization(q)
+		q.Set("incidentId", incidentID)
+		q.Set("limit", strconv.Itoa(clamp(a.conf.PageSize, maxDetectionPageSize)))
+		if anchor != "" {
+			q.Set("anchor", anchor)
+		}
+
+		items, next, ok := a.fetchPage(feedDetections, func(ctx context.Context) ([]byte, error) {
+			return a.client.Get(ctx, pathDetections, q)
+		})
+		if !ok {
+			// Already reported. Skip this incident's detections and carry on
+			// with the rest of the incident page.
+			return nShipped, true
+		}
+		if len(items) == 0 {
+			break
+		}
+
+		for _, item := range items {
+			nSeen++
+			key := feedDetections + "|" + recordID(item, "detectionId")
+			if a.deduper.CheckAndAdd(key) {
+				continue
+			}
+			if !a.ship(feedDetections, item, a.eventTime(item, "createdTimestamp", "initialReceivedTimestamp")) {
+				return nShipped, false
+			}
+			nShipped++
+		}
+
+		if next == "" {
+			break
+		}
+		anchor = next
+	}
+	return nShipped, true
+}
+
+// Audit logs
+// ============================================================================
+
+// pollAuditLogs walks the Elements administrative audit trail forward from the
+// cursor. The API caps a query at a 30-day range, which the initial lookback
+// already respects.
+func (a *WithSecureAdapter) pollAuditLogs(f *feedState) {
+	anchor := ""
+	newest := f.cursor
+	nSeen, nShipped := 0, 0
+
+	for page := 1; !a.doStop.IsSet(); page++ {
+		if page > a.conf.MaxPages {
+			a.warnMaxPages(f.name)
+			break
+		}
+
+		q := url.Values{}
+		a.setOrganization(q)
+		q.Set("serverTimestampStart", f.cursor)
+		q.Set("exclusiveStart", "true")
+		q.Set("order", "asc")
+		q.Set("limit", strconv.Itoa(clamp(a.conf.PageSize, maxAuditLogPageSize)))
+		if anchor != "" {
+			q.Set("anchor", anchor)
+		}
+
+		items, next, ok := a.fetchPage(f.name, func(ctx context.Context) ([]byte, error) {
+			return a.client.Get(ctx, pathAuditLogs, q)
+		})
+		if !ok {
+			return
+		}
+		if len(items) == 0 {
+			break
+		}
+
+		for _, item := range items {
+			nSeen++
+			if ts := item.FindOneString("serverTimestamp"); ts != "" && ts > newest {
+				newest = ts
+			}
+			key := feedAuditLogs + "|" + recordID(item, "id")
+			if a.deduper.CheckAndAdd(key) {
+				continue
+			}
+			if !a.ship(feedAuditLogs, item, a.eventTime(item, "serverTimestamp")) {
+				return
+			}
+			nShipped++
+		}
+
+		if next == "" {
+			break
+		}
+		anchor = next
+	}
+
+	f.cursor = newest
+	a.debugPoll(f, nSeen, nShipped)
+}
+
+// Transport
+// ============================================================================
+
+// fetchPage issues one request, retrying transient failures with exponential
+// backoff, and parses the {items, nextAnchor} envelope. The bool result is
+// false when this poll should be abandoned.
+//
+// Source-side errors (4xx/5xx from the Elements API, network blips, malformed
+// responses) are reported via OnWarning and do NOT stop the adapter: the
+// cloud-sensor host treats an adapter OnError as fatal to the instance, tearing
+// it down and relaunching it, and disabling it after enough failures. A restart
+// cannot fix a problem on WithSecure's side and would take the healthy streams
+// down with the broken one. So we log, skip this poll, and try again next
+// interval.
+//
+// The two exceptions are an authentication failure — no amount of retrying
+// fixes a bad credential, and silently collecting nothing is worse than
+// stopping visibly — and a failure delivering to LimaCharlie (see ship), where
+// a relaunch does reconnect the backend.
+func (a *WithSecureAdapter) fetchPage(feedName string, do func(context.Context) ([]byte, error)) ([]utils.Dict, string, bool) {
+	var raw []byte
+	var err error
+
+	for attempt := 0; attempt < a.conf.MaxRetryAttempts; attempt++ {
+		if a.doStop.IsSet() {
+			return nil, "", false
+		}
+
+		raw, err = do(a.ctx)
+		if err == nil {
+			break
+		}
+
+		if isAuthError(err) {
+			a.conf.ClientOptions.OnError(fmt.Errorf(
+				"withsecure: authentication failed (check client_id/client_secret and that the "+
+					"API client still exists): %v", err))
+			a.doStop.Set()
+			return nil, "", false
+		}
+
+		if !isTransientError(err) {
+			a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+				"withsecure: feed %q request failed (skipping this poll): %v", feedName, err))
+			return nil, "", false
+		}
+
+		if attempt+1 >= a.conf.MaxRetryAttempts {
+			break
+		}
+		delay := a.conf.RetryBaseDelay * time.Duration(1<<attempt)
+		if delay > a.conf.MaxRetryDelay {
+			delay = a.conf.MaxRetryDelay
+		}
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"withsecure: feed %q transient error (attempt %d/%d), retrying in %v: %v",
+			feedName, attempt+1, a.conf.MaxRetryAttempts, delay, err))
+		if a.doStop.WaitFor(delay) {
+			return nil, "", false
+		}
+	}
+	if err != nil {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"withsecure: feed %q failed after %d attempts (skipping this poll): %v",
+			feedName, a.conf.MaxRetryAttempts, err))
+		return nil, "", false
+	}
+
+	items, next, err := extractPage(raw)
+	if err != nil {
+		a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+			"withsecure: feed %q response parse error (skipping this poll): %v", feedName, err))
+		return nil, "", false
+	}
+	return items, next, true
+}
+
+// ship forwards a single record to LimaCharlie. It returns false if the adapter
+// should stop (an unrecoverable shipping error).
+func (a *WithSecureAdapter) ship(eventType string, item utils.Dict, timestampMs uint64) bool {
+	msg := &protocol.DataMessage{
+		JsonPayload: item,
+		EventType:   eventType,
+		TimestampMs: timestampMs,
+	}
+	if err := a.uspClient.Ship(msg, shipTimeout); err != nil {
+		if err == uspclient.ErrorBufferFull {
+			a.conf.ClientOptions.OnWarning("withsecure: stream falling behind")
+			err = a.uspClient.Ship(msg, 1*time.Hour)
+		}
+		if err != nil {
+			a.conf.ClientOptions.OnError(fmt.Errorf("withsecure: Ship(): %v", err))
+			a.doStop.Set()
+			return false
+		}
+	}
+	return true
+}
+
+// Helpers
+// ============================================================================
+
+// setOrganization applies the configured organization scope. When empty the API
+// falls back to the credential's own organization.
+func (a *WithSecureAdapter) setOrganization(v url.Values) {
+	if a.conf.OrganizationID != "" {
+		v.Set("organizationId", a.conf.OrganizationID)
+	}
+}
+
+func (a *WithSecureAdapter) warnMaxPages(feedName string) {
+	a.conf.ClientOptions.OnWarning(fmt.Sprintf(
+		"withsecure: feed %q hit max_pages=%d; the remaining records are collected on the "+
+			"next poll (the cursor only advances over what was read)", feedName, a.conf.MaxPages))
+}
+
+func (a *WithSecureAdapter) debugPoll(f *feedState, nSeen, nShipped int) {
+	a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+		"withsecure: feed %q poll complete (seen=%d shipped=%d cursor=%s)",
+		f.name, nSeen, nShipped, f.cursor))
+}
+
+// eventTime extracts the record's event time from the first of the candidate
+// fields that is present and parseable, falling back to now.
+func (a *WithSecureAdapter) eventTime(item utils.Dict, fields ...string) uint64 {
+	for _, field := range fields {
+		raw := item.FindOneString(field)
+		if raw == "" {
+			continue
+		}
+		if t, ok := parseTimestamp(raw); ok {
+			return uint64(t.UnixMilli())
+		}
+		a.conf.ClientOptions.DebugLog(fmt.Sprintf(
+			"withsecure: unparseable timestamp %q at field %q", raw, field))
+	}
+	return uint64(time.Now().UnixMilli())
+}
+
+// recordID resolves a record's stable identifier, falling back to a content
+// hash so deduplication still works for a record missing its id field.
+func recordID(item utils.Dict, idField string) string {
+	if id := fieldAsString(item, idField); id != "" {
+		return id
+	}
+	if b, err := json.Marshal(item); err == nil {
+		sum := sha256.Sum256(b)
+		return "sha256:" + hex.EncodeToString(sum[:])
+	}
+	return ""
+}
+
+// fieldAsString reads a field as a string, accepting numeric values too.
+func fieldAsString(item utils.Dict, path string) string {
+	if s := item.FindOneString(path); s != "" {
+		return s
+	}
+	// FindInt returns every match at the path; a non-empty result means the
+	// field is present -- including a legitimate value of 0, which FindOneInt
+	// cannot distinguish from "absent".
+	if ints := item.FindInt(path); len(ints) > 0 {
+		return strconv.FormatUint(ints[0], 10)
+	}
+	return ""
+}
+
+// extractPage parses the Elements collection envelope: {"items": [...],
+// "nextAnchor": "..."}. nextAnchor is absent on the last page.
+func extractPage(raw []byte) ([]utils.Dict, string, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil, "", nil
+	}
+	var env struct {
+		Items      []json.RawMessage `json:"items"`
+		NextAnchor string            `json:"nextAnchor"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &env); err != nil {
+		return nil, "", fmt.Errorf("invalid JSON response: %v", err)
+	}
+	return rawMessagesToDicts(env.Items), env.NextAnchor, nil
+}
+
+// rawMessagesToDicts decodes each record with utils.UnmarshalCleanJSON, which
+// preserves integer precision (no float coercion) so payloads round-trip
+// faithfully. A record that is not a non-empty JSON object is skipped rather
+// than failing the whole page -- one anomalous element should not block every
+// other record.
+func rawMessagesToDicts(raw []json.RawMessage) []utils.Dict {
+	items := make([]utils.Dict, 0, len(raw))
+	for _, r := range raw {
+		m, err := utils.UnmarshalCleanJSON(string(r))
+		if err != nil || len(m) == 0 {
+			continue
+		}
+		items = append(items, utils.Dict(m))
+	}
+	return items
+}
+
+func parseTimestamp(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range timestampLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+// addAll appends each value as a repeated parameter, which is how the Elements
+// API models array-valued filters.
+func addAll(v url.Values, key string, vals []string) {
+	for _, val := range vals {
+		if val = strings.TrimSpace(val); val != "" {
+			v.Add(key, val)
+		}
+	}
+}
+
+// clamp bounds a page size by the endpoint's own ceiling.
+func clamp(size, max int) int {
+	if size <= 0 || size > max {
+		return max
+	}
+	return size
+}

--- a/withsecure/client_test.go
+++ b/withsecure/client_test.go
@@ -1,0 +1,901 @@
+package usp_withsecure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testClientOptions returns ClientOptions wired for a sink (no real LimaCharlie
+// connection) with the logging callbacks pointed at the test log.
+func testClientOptions(t *testing.T) uspclient.ClientOptions {
+	t.Helper()
+	return uspclient.ClientOptions{
+		Identity: uspclient.Identity{
+			Oid:             "11111111-1111-1111-1111-111111111111",
+			InstallationKey: "test-installation-key",
+		},
+		Platform:     "json",
+		TestSinkMode: true,
+		DebugLog:     func(msg string) { t.Logf("DBG: %s", msg) },
+		OnWarning:    func(msg string) { t.Logf("WRN: %s", msg) },
+		OnError:      func(err error) { t.Logf("ERR: %v", err) },
+	}
+}
+
+// testConfig returns a config pointed at the mock, collecting only the streams
+// a test asks for. Polling is fast so tests finish quickly.
+func testConfig(t *testing.T, baseURL string, feeds ...string) WithSecureConfig {
+	t.Helper()
+	off := false
+	conf := WithSecureConfig{
+		ClientOptions: testClientOptions(t),
+		ClientID:      "test-client-id",
+		ClientSecret:  "test-client-secret",
+		BaseURL:       baseURL,
+		PollInterval:  50 * time.Millisecond,
+		Lookback:      1 * time.Hour,
+		// Everything off, then switch on what the test wants.
+		CollectSecurityEvents: &off,
+		CollectIncidents:      &off,
+		CollectDetections:     &off,
+		CollectAuditLogs:      &off,
+	}
+	on := true
+	for _, f := range feeds {
+		switch f {
+		case feedSecurityEvents:
+			conf.CollectSecurityEvents = &on
+		case feedIncidents:
+			conf.CollectIncidents = &on
+		case feedDetections:
+			conf.CollectDetections = &on
+		case feedAuditLogs:
+			conf.CollectAuditLogs = &on
+		default:
+			t.Fatalf("unknown feed %q", f)
+		}
+	}
+	return conf
+}
+
+// startAdapter runs the adapter against a capture sink and returns both.
+func startAdapter(t *testing.T, conf WithSecureConfig) (*WithSecureAdapter, *captureSink) {
+	t.Helper()
+	sink := &captureSink{}
+	a, _, err := newWithSecureAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+	return a, sink
+}
+
+// waitForCount waits until the sink has at least n messages.
+func waitForCount(t *testing.T, sink *captureSink, n int) {
+	t.Helper()
+	require.Eventually(t, func() bool { return sink.count() >= n }, 5*time.Second, 10*time.Millisecond,
+		"expected at least %d shipped messages, got %d", n, sink.count())
+}
+
+// countingDeduper wraps a Deduper and records, per key, how many times the key
+// was reported as new (CheckAndAdd returned false). The adapter ships a record
+// exactly when its key is new, so a count above 1 means a record was shipped
+// more than once -- a dedup failure.
+type countingDeduper struct {
+	inner utils.Deduper
+	mu    sync.Mutex
+	new   map[string]int
+}
+
+func newCountingDeduper(t *testing.T) *countingDeduper {
+	t.Helper()
+	inner, err := utils.NewLocalDeduper(1*time.Hour, 24*time.Hour)
+	require.NoError(t, err)
+	return &countingDeduper{inner: inner, new: map[string]int{}}
+}
+
+func (d *countingDeduper) CheckAndAdd(key string) bool {
+	seen := d.inner.CheckAndAdd(key)
+	if !seen {
+		d.mu.Lock()
+		d.new[key]++
+		d.mu.Unlock()
+	}
+	return seen
+}
+
+func (d *countingDeduper) Close() { d.inner.Close() }
+
+func (d *countingDeduper) maxNewCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	max := 0
+	for _, n := range d.new {
+		if n > max {
+			max = n
+		}
+	}
+	return max
+}
+
+// Config validation
+// ============================================================================
+
+func TestValidate(t *testing.T) {
+	base := func() WithSecureConfig {
+		return WithSecureConfig{
+			ClientOptions: testClientOptions(t),
+			ClientID:      "id",
+			ClientSecret:  "secret",
+		}
+	}
+
+	t.Run("defaults are filled", func(t *testing.T) {
+		c := base()
+		require.NoError(t, c.Validate())
+		assert.Equal(t, defaultBaseURL, c.BaseURL)
+		assert.Equal(t, defaultPollInterval, c.PollInterval)
+		assert.Equal(t, defaultLookback, c.Lookback)
+		assert.Equal(t, defaultDedupeTTL, c.DedupeTTL)
+		assert.Equal(t, defaultMaxPages, c.MaxPages)
+		assert.Equal(t, defaultUserAgent, c.UserAgent)
+		assert.Equal(t, defaultMaxRetryAttempts, c.MaxRetryAttempts)
+	})
+
+	t.Run("credentials required", func(t *testing.T) {
+		c := base()
+		c.ClientID = ""
+		assert.ErrorContains(t, c.Validate(), "client_id")
+
+		c = base()
+		c.ClientSecret = "  "
+		assert.ErrorContains(t, c.Validate(), "client_secret")
+	})
+
+	t.Run("base url is normalized", func(t *testing.T) {
+		c := base()
+		c.BaseURL = "https://api.connect-stg.fsapi.com/"
+		require.NoError(t, c.Validate())
+		assert.Equal(t, "https://api.connect-stg.fsapi.com", c.BaseURL)
+	})
+
+	// Detections are fetched per incident -- there is no organization-wide
+	// detections endpoint -- so the combination is rejected rather than
+	// silently collecting nothing.
+	t.Run("detections require incidents", func(t *testing.T) {
+		c := base()
+		off := false
+		c.CollectIncidents = &off
+		assert.ErrorContains(t, c.Validate(), "collect_detections requires collect_incidents")
+	})
+
+	t.Run("at least one stream", func(t *testing.T) {
+		c := base()
+		off := false
+		c.CollectSecurityEvents = &off
+		c.CollectIncidents = &off
+		c.CollectDetections = &off
+		c.CollectAuditLogs = &off
+		assert.ErrorContains(t, c.Validate(), "every stream is disabled")
+	})
+
+	// Audit logs default OFF; the other streams default ON.
+	t.Run("stream defaults", func(t *testing.T) {
+		c := base()
+		require.NoError(t, c.Validate())
+		assert.True(t, enabled(c.CollectSecurityEvents, true))
+		assert.True(t, enabled(c.CollectIncidents, true))
+		assert.True(t, enabled(c.CollectDetections, true))
+		assert.False(t, enabled(c.CollectAuditLogs, false))
+	})
+}
+
+// Authentication
+// ============================================================================
+
+// The token endpoint takes the credentials in an HTTP Basic header and only
+// grant_type/scope in the body; the documented behavior is to reject a payload
+// carrying anything else, so the mock enforces it and this test pins it.
+func TestAuth_TokenRequestShape(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	m.addSecurityEvents(realisticSecurityEvent("evt-1", time.Now().Add(-time.Minute)))
+
+	_, sink := startAdapter(t, testConfig(t, srv.URL, feedSecurityEvents))
+	waitForCount(t, sink, 1)
+
+	assert.Equal(t, 1, m.tokenRequestCount(), "the token should be minted once and cached")
+	reqs := m.requestsFor(pathSecurityEvents)
+	require.NotEmpty(t, reqs)
+	assert.Equal(t, "Bearer ws-token-1", reqs[0].Auth)
+	assert.Equal(t, defaultUserAgent, reqs[0].UserAgent,
+		"the API rejects requests without a User-Agent")
+}
+
+// A bad credential stops the adapter: retrying cannot fix it, and silently
+// collecting nothing would be worse than failing visibly.
+func TestAuth_BadCredentialsStopAdapter(t *testing.T) {
+	m := newMockElements()
+	m.rejectAuth = true
+	srv := m.start(t)
+	m.addSecurityEvents(realisticSecurityEvent("evt-1", time.Now().Add(-time.Minute)))
+
+	conf := testConfig(t, srv.URL, feedSecurityEvents)
+	sink := &captureSink{}
+	a, chRunning, err := newWithSecureAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+
+	select {
+	case <-chRunning:
+	case <-time.After(5 * time.Second):
+		t.Fatal("adapter did not stop on an authentication failure")
+	}
+	assert.Zero(t, sink.count(), "nothing should ship when authentication fails")
+}
+
+// A 401 mid-poll is far more likely to be an expiry race than a revoked
+// credential, so the request is replayed once with a freshly minted token.
+func TestAuth_RefreshesTokenOn401(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	m.addSecurityEvents(realisticSecurityEvent("evt-1", time.Now().Add(-time.Minute)))
+
+	_, sink := startAdapter(t, testConfig(t, srv.URL, feedSecurityEvents))
+	waitForCount(t, sink, 1)
+
+	// Force the next data request to 401.
+	m.setFailNext(401)
+	m.addSecurityEvents(realisticSecurityEvent("evt-2", time.Now()))
+
+	waitForCount(t, sink, 2)
+	assert.GreaterOrEqual(t, m.tokenRequestCount(), 2, "a 401 should mint a fresh token")
+}
+
+// Security events
+// ============================================================================
+
+func TestSecurityEvents_ShipVerbatim(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	ts := time.Now().Add(-5 * time.Minute).Truncate(time.Millisecond)
+	want := realisticSecurityEvent("evt-1", ts)
+	m.addSecurityEvents(want)
+
+	_, sink := startAdapter(t, testConfig(t, srv.URL, feedSecurityEvents))
+	waitForCount(t, sink, 1)
+
+	msgs := sink.snapshot()
+	require.Len(t, msgs, 1)
+	assert.Equal(t, feedSecurityEvents, msgs[0].EventType)
+	assert.Equal(t, uint64(ts.UTC().UnixMilli()), msgs[0].TimestampMs,
+		"the event time should come from persistenceTimestamp, not the wall clock")
+
+	got := utils.Dict(msgs[0].JsonPayload)
+	assertVerbatim(t, want, got)
+
+	// Large integers must survive the round-trip without float coercion.
+	details, ok := got["details"].(map[string]interface{})
+	require.True(t, ok)
+	assert.EqualValues(t, uint64(9007199254740993), toUint64(t, details["fileSize"]),
+		"a large integer lost precision")
+}
+
+// The query must carry a time bound (the API rejects an unbounded one) and
+// exclusiveStart (without it the boundary event is re-read on every poll).
+func TestSecurityEvents_QueryShape(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	m.addSecurityEvents(realisticSecurityEvent("evt-1", time.Now().Add(-time.Minute)))
+
+	conf := testConfig(t, srv.URL, feedSecurityEvents)
+	conf.OrganizationID = "org-uuid"
+	conf.Engines = []string{"deepGuard", "firewall"}
+	conf.Severities = []string{"critical", "warning"}
+	_, sink := startAdapter(t, conf)
+	waitForCount(t, sink, 1)
+
+	reqs := m.requestsFor(pathSecurityEvents)
+	require.NotEmpty(t, reqs)
+	r := reqs[0]
+
+	// A form-encoded POST, not a GET or a JSON body.
+	assert.Equal(t, "POST", r.Method)
+	require.NotNil(t, r.Form, "security events must be queried with a form-encoded body")
+
+	p := r.params()
+	assert.NotEmpty(t, p.Get("persistenceTimestampStart"), "the API rejects a query with no time bound")
+	assert.Equal(t, "true", p.Get("exclusiveStart"))
+	assert.Equal(t, "asc", p.Get("order"))
+	assert.Equal(t, "org-uuid", p.Get("organizationId"))
+	assert.ElementsMatch(t, []string{"deepGuard", "firewall"}, p["engine"],
+		"array filters are sent as repeated keys")
+	assert.ElementsMatch(t, []string{"critical", "warning"}, p["severity"])
+}
+
+// Re-polling an unchanged data set must not re-ship anything.
+func TestSecurityEvents_RepollDoesNotDuplicate(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	for i := 0; i < 3; i++ {
+		m.addSecurityEvents(realisticSecurityEvent(
+			fmt.Sprintf("evt-%c", 'a'+i), time.Now().Add(-time.Duration(10-i)*time.Minute)))
+	}
+
+	dedup := newCountingDeduper(t)
+	conf := testConfig(t, srv.URL, feedSecurityEvents)
+	conf.Deduper = dedup
+	_, sink := startAdapter(t, conf)
+	waitForCount(t, sink, 3)
+
+	// Let several more polls run over the same data.
+	time.Sleep(400 * time.Millisecond)
+
+	assert.Equal(t, 3, sink.count(), "a re-poll re-shipped events")
+	assert.Equal(t, 1, dedup.maxNewCount(), "an event was treated as new more than once")
+	assert.Greater(t, m.requestCount(), 3, "the test did not actually re-poll")
+}
+
+// An event appearing mid-run ships exactly once.
+func TestSecurityEvents_NewEventShipsOnce(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	m.addSecurityEvents(realisticSecurityEvent("evt-1", time.Now().Add(-10*time.Minute)))
+
+	dedup := newCountingDeduper(t)
+	conf := testConfig(t, srv.URL, feedSecurityEvents)
+	conf.Deduper = dedup
+	_, sink := startAdapter(t, conf)
+	waitForCount(t, sink, 1)
+
+	m.addSecurityEvents(realisticSecurityEvent("evt-2", time.Now()))
+	waitForCount(t, sink, 2)
+	time.Sleep(300 * time.Millisecond)
+
+	assert.Equal(t, 2, sink.count())
+	assert.Equal(t, 1, dedup.maxNewCount())
+	ids := []string{}
+	for _, d := range sink.byEventType(feedSecurityEvents) {
+		ids = append(ids, d.FindOneString("id"))
+	}
+	assert.ElementsMatch(t, []string{"evt-1", "evt-2"}, ids)
+}
+
+// A multi-page result set is walked to the end, each record shipped once.
+func TestSecurityEvents_MultiPage(t *testing.T) {
+	m := newMockElements()
+	m.pageSize = 3 // force pagination regardless of the requested limit
+	srv := m.start(t)
+
+	base := time.Now().Add(-time.Hour).Add(time.Minute)
+	const total = 10
+	for i := 0; i < total; i++ {
+		m.addSecurityEvents(realisticSecurityEvent(
+			fmt.Sprintf("evt-%02d", i), base.Add(time.Duration(i)*time.Second)))
+	}
+
+	dedup := newCountingDeduper(t)
+	conf := testConfig(t, srv.URL, feedSecurityEvents)
+	conf.Deduper = dedup
+	_, sink := startAdapter(t, conf)
+	waitForCount(t, sink, total)
+	time.Sleep(300 * time.Millisecond)
+
+	assert.Equal(t, total, sink.count(), "a paginated result set was not fully consumed")
+	assert.Equal(t, 1, dedup.maxNewCount())
+
+	// The anchor must have been used: more than one page request per poll.
+	var anchored int
+	for _, r := range m.requestsFor(pathSecurityEvents) {
+		if r.params().Get("anchor") != "" {
+			anchored++
+		}
+	}
+	assert.Greater(t, anchored, 0, "the nextAnchor cursor was never followed")
+}
+
+// The page size is clamped to each endpoint's documented ceiling; requesting
+// more is rejected by the real API.
+func TestPageSizeIsClamped(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	m.addSecurityEvents(realisticSecurityEvent("evt-1", time.Now().Add(-time.Minute)))
+	inc := realisticIncident("inc-1", time.Now().Add(-time.Hour), time.Now().Add(-time.Minute))
+	m.addIncidents(inc)
+
+	conf := testConfig(t, srv.URL, feedSecurityEvents, feedIncidents)
+	conf.PageSize = 10000
+	_, sink := startAdapter(t, conf)
+	waitForCount(t, sink, 2)
+
+	evReqs := m.requestsFor(pathSecurityEvents)
+	require.NotEmpty(t, evReqs)
+	assert.Equal(t, strconv.Itoa(maxSecurityEventPageSize), evReqs[0].params().Get("limit"))
+
+	incReqs := m.requestsFor(pathIncidents)
+	require.NotEmpty(t, incReqs)
+	assert.Equal(t, strconv.Itoa(maxIncidentPageSize), incReqs[0].params().Get("limit"),
+		"the incidents endpoint caps at a lower page size than security events")
+}
+
+// Incidents and detections
+// ============================================================================
+
+func TestIncidents_ShipWithDetections(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+
+	created := time.Now().Add(-30 * time.Minute).Truncate(time.Millisecond)
+	updated := time.Now().Add(-5 * time.Minute).Truncate(time.Millisecond)
+	inc := realisticIncident("inc-1", created, updated)
+	det := realisticDetection("det-1", "inc-1", created)
+	m.addIncidents(inc)
+	m.setDetections("inc-1", det)
+
+	_, sink := startAdapter(t, testConfig(t, srv.URL, feedIncidents, feedDetections))
+	waitForCount(t, sink, 2)
+
+	incidents := sink.byEventType(feedIncidents)
+	require.Len(t, incidents, 1)
+	assertVerbatim(t, inc, incidents[0])
+
+	detections := sink.byEventType(feedDetections)
+	require.Len(t, detections, 1)
+	assertVerbatim(t, det, detections[0])
+
+	// Event times come from the records, not the wall clock.
+	for _, msg := range sink.snapshot() {
+		switch msg.EventType {
+		case feedIncidents:
+			assert.Equal(t, uint64(updated.UTC().UnixMilli()), msg.TimestampMs)
+		case feedDetections:
+			assert.Equal(t, uint64(created.UTC().UnixMilli()), msg.TimestampMs)
+		}
+	}
+}
+
+// A BCD is a living object: when it evolves, the new version is shipped again
+// (it is new information), but an unchanged one is not.
+func TestIncidents_ReshippedOnlyWhenUpdated(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+
+	created := time.Now().Add(-30 * time.Minute)
+	updated := time.Now().Add(-10 * time.Minute)
+	m.addIncidents(realisticIncident("inc-1", created, updated))
+
+	dedup := newCountingDeduper(t)
+	conf := testConfig(t, srv.URL, feedIncidents)
+	conf.Deduper = dedup
+	_, sink := startAdapter(t, conf)
+	waitForCount(t, sink, 1)
+
+	// Several polls over the unchanged incident must not duplicate it.
+	time.Sleep(300 * time.Millisecond)
+	require.Equal(t, 1, sink.count(), "an unchanged incident was re-shipped")
+
+	// Now the incident evolves: new status, new updatedTimestamp.
+	evolved := realisticIncident("inc-1", created, time.Now())
+	evolved["status"] = "inProgress"
+	evolved["riskLevel"] = "high"
+	m.updateIncident("inc-1", evolved)
+
+	waitForCount(t, sink, 2)
+	time.Sleep(200 * time.Millisecond)
+
+	incidents := sink.byEventType(feedIncidents)
+	require.Len(t, incidents, 2, "the updated incident version should ship")
+	assert.Equal(t, "new", incidents[0].FindOneString("status"))
+	assert.Equal(t, "inProgress", incidents[1].FindOneString("status"))
+	assert.Equal(t, 1, dedup.maxNewCount())
+}
+
+// A detection is stable, so re-visiting an incident that changed must not
+// re-ship the detections already collected -- only the new one.
+func TestDetections_NotDuplicatedWhenIncidentUpdates(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+
+	created := time.Now().Add(-30 * time.Minute)
+	m.addIncidents(realisticIncident("inc-1", created, time.Now().Add(-10*time.Minute)))
+	m.setDetections("inc-1", realisticDetection("det-1", "inc-1", created))
+
+	dedup := newCountingDeduper(t)
+	conf := testConfig(t, srv.URL, feedIncidents, feedDetections)
+	conf.Deduper = dedup
+	_, sink := startAdapter(t, conf)
+	waitForCount(t, sink, 2)
+
+	// The incident gains a second detection and is re-stamped.
+	m.setDetections("inc-1",
+		realisticDetection("det-1", "inc-1", created),
+		realisticDetection("det-2", "inc-1", time.Now()))
+	evolved := realisticIncident("inc-1", created, time.Now())
+	m.updateIncident("inc-1", evolved)
+
+	waitForCount(t, sink, 4) // 2 incident versions + 2 detections
+	time.Sleep(300 * time.Millisecond)
+
+	detections := sink.byEventType(feedDetections)
+	ids := []string{}
+	for _, d := range detections {
+		ids = append(ids, d.FindOneString("detectionId"))
+	}
+	assert.ElementsMatch(t, []string{"det-1", "det-2"}, ids,
+		"the already-collected detection was shipped again")
+	assert.Equal(t, 1, dedup.maxNewCount())
+}
+
+// Archived BCDs are filtered out by default (the API documents that skipping
+// them is also faster).
+func TestIncidents_ArchivedFilteredByDefault(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+
+	created := time.Now().Add(-30 * time.Minute)
+	live := realisticIncident("inc-live", created, time.Now().Add(-time.Minute))
+	archived := realisticIncident("inc-archived", created, time.Now().Add(-time.Minute))
+	archived["archived"] = true
+	m.addIncidents(live, archived)
+
+	_, sink := startAdapter(t, testConfig(t, srv.URL, feedIncidents))
+	waitForCount(t, sink, 1)
+	time.Sleep(300 * time.Millisecond)
+
+	incidents := sink.byEventType(feedIncidents)
+	require.Len(t, incidents, 1)
+	assert.Equal(t, "inc-live", incidents[0].FindOneString("incidentId"))
+
+	reqs := m.requestsFor(pathIncidents)
+	require.NotEmpty(t, reqs)
+	assert.Equal(t, "false", reqs[0].params().Get("archived"))
+}
+
+func TestIncidents_ArchivedIncludedWhenAsked(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+
+	created := time.Now().Add(-30 * time.Minute)
+	archived := realisticIncident("inc-archived", created, time.Now().Add(-time.Minute))
+	archived["archived"] = true
+	m.addIncidents(archived)
+
+	conf := testConfig(t, srv.URL, feedIncidents)
+	conf.IncludeArchivedIncidents = true
+	_, sink := startAdapter(t, conf)
+	waitForCount(t, sink, 1)
+
+	reqs := m.requestsFor(pathIncidents)
+	require.NotEmpty(t, reqs)
+	assert.Empty(t, reqs[0].params().Get("archived"))
+}
+
+// Detections are fetched per incident, so the incident id must be on the query.
+func TestDetections_QueryShape(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+
+	created := time.Now().Add(-30 * time.Minute)
+	m.addIncidents(realisticIncident("inc-1", created, time.Now().Add(-time.Minute)))
+	m.setDetections("inc-1", realisticDetection("det-1", "inc-1", created))
+
+	_, sink := startAdapter(t, testConfig(t, srv.URL, feedIncidents, feedDetections))
+	waitForCount(t, sink, 2)
+
+	reqs := m.requestsFor(pathDetections)
+	require.NotEmpty(t, reqs)
+	assert.Equal(t, "inc-1", reqs[0].params().Get("incidentId"))
+}
+
+// With detections off, only incidents are collected.
+func TestDetections_DisabledSkipsTheEndpoint(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+
+	created := time.Now().Add(-30 * time.Minute)
+	m.addIncidents(realisticIncident("inc-1", created, time.Now().Add(-time.Minute)))
+	m.setDetections("inc-1", realisticDetection("det-1", "inc-1", created))
+
+	_, sink := startAdapter(t, testConfig(t, srv.URL, feedIncidents))
+	waitForCount(t, sink, 1)
+	time.Sleep(300 * time.Millisecond)
+
+	assert.Empty(t, sink.byEventType(feedDetections))
+	assert.Empty(t, m.requestsFor(pathDetections), "the detections endpoint should not be called")
+}
+
+// Audit logs
+// ============================================================================
+
+func TestAuditLogs_ShipVerbatim(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	ts := time.Now().Add(-2 * time.Minute).Truncate(time.Millisecond)
+	want := realisticAuditLog("audit-1", ts)
+	m.addAuditLogs(want)
+
+	_, sink := startAdapter(t, testConfig(t, srv.URL, feedAuditLogs))
+	waitForCount(t, sink, 1)
+
+	msgs := sink.snapshot()
+	require.Len(t, msgs, 1)
+	assert.Equal(t, feedAuditLogs, msgs[0].EventType)
+	assert.Equal(t, uint64(ts.UTC().UnixMilli()), msgs[0].TimestampMs)
+
+	got := utils.Dict(msgs[0].JsonPayload)
+	assertVerbatim(t, want, got)
+
+	reqs := m.requestsFor(pathAuditLogs)
+	require.NotEmpty(t, reqs)
+	assert.Equal(t, "true", reqs[0].params().Get("exclusiveStart"))
+	assert.NotEmpty(t, reqs[0].params().Get("serverTimestampStart"))
+}
+
+// The API rejects an audit-log query spanning more than 30 days, so a longer
+// lookback must be capped rather than passed through.
+func TestAuditLogs_LookbackCappedAtThirtyDays(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	m.addAuditLogs(realisticAuditLog("audit-1", time.Now().Add(-time.Minute)))
+
+	conf := testConfig(t, srv.URL, feedAuditLogs)
+	conf.Lookback = 365 * 24 * time.Hour
+	_, sink := startAdapter(t, conf)
+	waitForCount(t, sink, 1)
+
+	reqs := m.requestsFor(pathAuditLogs)
+	require.NotEmpty(t, reqs)
+	start, err := time.Parse(cursorLayout, reqs[0].params().Get("serverTimestampStart"))
+	require.NoError(t, err)
+	age := time.Since(start)
+	assert.LessOrEqual(t, age, maxAuditLogWindow+time.Minute,
+		"an audit-log query older than 30 days is rejected by the API")
+}
+
+// Multiple streams
+// ============================================================================
+
+func TestMultipleStreams_TaggedCorrectly(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+
+	created := time.Now().Add(-30 * time.Minute)
+	m.addSecurityEvents(realisticSecurityEvent("evt-1", time.Now().Add(-time.Minute)))
+	m.addIncidents(realisticIncident("inc-1", created, time.Now().Add(-time.Minute)))
+	m.setDetections("inc-1", realisticDetection("det-1", "inc-1", created))
+	m.addAuditLogs(realisticAuditLog("audit-1", time.Now().Add(-time.Minute)))
+
+	_, sink := startAdapter(t, testConfig(t, srv.URL,
+		feedSecurityEvents, feedIncidents, feedDetections, feedAuditLogs))
+	waitForCount(t, sink, 4)
+	time.Sleep(300 * time.Millisecond)
+
+	assert.Len(t, sink.byEventType(feedSecurityEvents), 1)
+	assert.Len(t, sink.byEventType(feedIncidents), 1)
+	assert.Len(t, sink.byEventType(feedDetections), 1)
+	assert.Len(t, sink.byEventType(feedAuditLogs), 1)
+}
+
+// Error handling
+// ============================================================================
+
+// A source-side failure must not stop the adapter: the cloud-sensor host treats
+// an adapter error as fatal to the instance, and restarting cannot fix a
+// problem on WithSecure's side. The poll is skipped and retried.
+func TestSourceErrorDoesNotStopAdapter(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	m.addSecurityEvents(realisticSecurityEvent("evt-1", time.Now().Add(-time.Minute)))
+
+	conf := testConfig(t, srv.URL, feedSecurityEvents)
+	conf.RetryBaseDelay = 10 * time.Millisecond
+	conf.MaxRetryDelay = 20 * time.Millisecond
+	sink := &captureSink{}
+	a, chRunning, err := newWithSecureAdapter(context.Background(), conf, sink)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+
+	// A 500 on the first poll; the adapter should retry and recover.
+	m.setFailNext(500)
+	waitForCount(t, sink, 1)
+
+	select {
+	case <-chRunning:
+		t.Fatal("the adapter stopped on a source-side error")
+	default:
+	}
+}
+
+// A transient failure is retried; a 429 counts as transient because the API
+// rate-limits these endpoints at 300 requests/minute.
+func TestIsTransientError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"500", &HTTPError{StatusCode: 500}, true},
+		{"503", &HTTPError{StatusCode: 503}, true},
+		{"429 rate limit", &HTTPError{StatusCode: 429}, true},
+		{"400", &HTTPError{StatusCode: 400}, false},
+		{"401", &HTTPError{StatusCode: 401}, false},
+		{"403", &HTTPError{StatusCode: 403}, false},
+		{"404", &HTTPError{StatusCode: 404}, false},
+		{"context canceled", context.Canceled, false},
+		{"nil", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isTransientError(tc.err))
+		})
+	}
+}
+
+func TestIsAuthError(t *testing.T) {
+	assert.True(t, isAuthError(&HTTPError{StatusCode: 401}))
+	assert.False(t, isAuthError(&HTTPError{StatusCode: 403}),
+		"a 403 is a scope problem, not a credential problem a restart could fix")
+	assert.False(t, isAuthError(&HTTPError{StatusCode: 500}))
+	assert.True(t, isAuthError(&tokenError{statusCode: 401, code: "invalid_client", fatal: true}))
+	assert.False(t, isAuthError(&tokenError{statusCode: 503, code: "token_request_failed"}))
+}
+
+// Envelope parsing
+// ============================================================================
+
+func TestExtractPage(t *testing.T) {
+	t.Run("items and anchor", func(t *testing.T) {
+		items, next, err := extractPage([]byte(`{"items":[{"id":"a"},{"id":"b"}],"nextAnchor":"cursor-1"}`))
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, "cursor-1", next)
+	})
+
+	t.Run("last page has no anchor", func(t *testing.T) {
+		items, next, err := extractPage([]byte(`{"items":[{"id":"a"}]}`))
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		assert.Empty(t, next)
+	})
+
+	t.Run("empty result set", func(t *testing.T) {
+		items, next, err := extractPage([]byte(`{"items":[]}`))
+		require.NoError(t, err)
+		assert.Empty(t, items)
+		assert.Empty(t, next)
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		items, next, err := extractPage(nil)
+		require.NoError(t, err)
+		assert.Empty(t, items)
+		assert.Empty(t, next)
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		_, _, err := extractPage([]byte(`not json`))
+		assert.Error(t, err)
+	})
+
+	// One anomalous element must not block the rest of the page.
+	t.Run("skips non-object records", func(t *testing.T) {
+		items, _, err := extractPage([]byte(`{"items":[{"id":"a"},null,42,{},{"id":"b"}]}`))
+		require.NoError(t, err)
+		require.Len(t, items, 2)
+		assert.Equal(t, "a", items[0].FindOneString("id"))
+		assert.Equal(t, "b", items[1].FindOneString("id"))
+	})
+}
+
+func TestParseTimestamp(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"2026-07-30T09:31:03.292Z", "2026-07-30T09:31:03.292Z"},
+		{"2026-07-30T09:31:03Z", "2026-07-30T09:31:03Z"},
+		{"2026-07-30T09:31:03", "2026-07-30T09:31:03Z"},
+		{"2026-07-30 09:31:03", "2026-07-30T09:31:03Z"},
+	} {
+		got, ok := parseTimestamp(tc.in)
+		require.True(t, ok, "failed to parse %q", tc.in)
+		assert.Equal(t, tc.want, got.Format(time.RFC3339Nano))
+	}
+
+	_, ok := parseTimestamp("")
+	assert.False(t, ok)
+	_, ok = parseTimestamp("not a timestamp")
+	assert.False(t, ok)
+}
+
+// A record missing its id field still deduplicates, via a content hash.
+func TestRecordID(t *testing.T) {
+	assert.Equal(t, "evt-1", recordID(utils.Dict{"id": "evt-1"}, "id"))
+	// Numeric ids are accepted too.
+	assert.Equal(t, "42", recordID(utils.Dict{"id": 42}, "id"))
+
+	hashed := recordID(utils.Dict{"other": "value"}, "id")
+	assert.True(t, len(hashed) > 7 && hashed[:7] == "sha256:", "expected a content hash, got %q", hashed)
+	assert.Equal(t, hashed, recordID(utils.Dict{"other": "value"}, "id"), "the hash must be stable")
+	assert.NotEqual(t, hashed, recordID(utils.Dict{"other": "different"}, "id"))
+}
+
+func TestClampPageSize(t *testing.T) {
+	assert.Equal(t, 50, clamp(50, 200))
+	assert.Equal(t, 200, clamp(500, 200))
+	assert.Equal(t, 200, clamp(0, 200))
+	assert.Equal(t, 200, clamp(-1, 200))
+	assert.Equal(t, 200, clamp(200, 200))
+}
+
+func TestAddAll(t *testing.T) {
+	v := url.Values{}
+	addAll(v, "engine", []string{"deepGuard", "  ", "firewall", ""})
+	assert.Equal(t, []string{"deepGuard", "firewall"}, v["engine"],
+		"blank values must be dropped rather than sent as empty filters")
+}
+
+// Lifecycle
+// ============================================================================
+
+func TestClose_IsIdempotent(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	m.addSecurityEvents(realisticSecurityEvent("evt-1", time.Now().Add(-time.Minute)))
+
+	sink := &captureSink{}
+	a, _, err := newWithSecureAdapter(context.Background(), testConfig(t, srv.URL, feedSecurityEvents), sink)
+	require.NoError(t, err)
+	waitForCount(t, sink, 1)
+
+	assert.NoError(t, a.Close())
+	assert.NoError(t, a.Close(), "Close must be idempotent")
+}
+
+func TestClose_StopsPolling(t *testing.T) {
+	m := newMockElements()
+	srv := m.start(t)
+	m.addSecurityEvents(realisticSecurityEvent("evt-1", time.Now().Add(-time.Minute)))
+
+	sink := &captureSink{}
+	a, _, err := newWithSecureAdapter(context.Background(), testConfig(t, srv.URL, feedSecurityEvents), sink)
+	require.NoError(t, err)
+	waitForCount(t, sink, 1)
+
+	require.NoError(t, a.Close())
+	before := m.requestCount()
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, before, m.requestCount(), "polling continued after Close")
+}
+
+// Helpers
+// ============================================================================
+
+// toUint64 reads a decoded JSON number that must retain full integer precision.
+func toUint64(t *testing.T, v interface{}) uint64 {
+	t.Helper()
+	switch n := v.(type) {
+	case uint64:
+		return n
+	case int64:
+		return uint64(n)
+	case int:
+		return uint64(n)
+	case float64:
+		return uint64(n)
+	case json.Number:
+		u, err := n.Int64()
+		require.NoError(t, err)
+		return uint64(u)
+	}
+	t.Fatalf("unexpected numeric type %T", v)
+	return 0
+}

--- a/withsecure/mock_test.go
+++ b/withsecure/mock_test.go
@@ -1,0 +1,582 @@
+package usp_withsecure
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/refractionPOINT/go-uspclient/protocol"
+	"github.com/refractionPOINT/usp-adapters/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// This file exercises the adapter end-to-end against a mock WithSecure Elements
+// API, capturing the exact messages it ships so their content -- event type,
+// timestamp and verbatim payload -- can be asserted.
+//
+// The mock is deliberately strict about what the real API is strict about:
+// Basic-auth-only token requests whose body carries nothing beyond
+// grant_type/scope, the mandatory User-Agent header, anchor pagination over the
+// {"items":[...],"nextAnchor":"..."} envelope, exclusiveStart semantics on the
+// timestamp cursor, and the flat {"message","code","transactionId"} error
+// object. A test that passes here would not have failed in production for a
+// reason the mock quietly tolerated.
+
+// --- in-memory USP sink -----------------------------------------------------
+
+// captureSink is an in-memory uspSink that records every shipped message.
+type captureSink struct {
+	mu       sync.Mutex
+	messages []*protocol.DataMessage
+}
+
+func (s *captureSink) Ship(m *protocol.DataMessage, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func (s *captureSink) Drain(time.Duration) error               { return nil }
+func (s *captureSink) Close() ([]*protocol.DataMessage, error) { return nil, nil }
+
+func (s *captureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func (s *captureSink) snapshot() []*protocol.DataMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*protocol.DataMessage, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// byEventType returns the shipped payloads of one event type, in order.
+func (s *captureSink) byEventType(eventType string) []utils.Dict {
+	out := []utils.Dict{}
+	for _, m := range s.snapshot() {
+		if m.EventType != eventType {
+			continue
+		}
+		out = append(out, utils.Dict(m.JsonPayload))
+	}
+	return out
+}
+
+// --- mock WithSecure Elements API -------------------------------------------
+
+// mockElements is an in-memory stand-in for the Elements API.
+type mockElements struct {
+	mu sync.Mutex
+
+	clientID     string
+	clientSecret string
+
+	// Datasets, each sorted ascending by its cursor timestamp field.
+	securityEvents []utils.Dict
+	incidents      []utils.Dict
+	auditLogs      []utils.Dict
+	// detections is keyed by incidentId.
+	detections map[string][]utils.Dict
+
+	// pageSize forces the mock to paginate at this size regardless of the
+	// requested limit, so multi-page walks are easy to provoke.
+	pageSize int
+
+	// tokenSeq makes every minted token distinct, so a test can tell a reused
+	// cached token from a freshly minted one.
+	tokenSeq int
+	// rejectAuth makes the token endpoint reject the credentials.
+	rejectAuth bool
+	// failNextWith makes the next data request fail once with this status.
+	// Accessed atomically: tests set it while the handler goroutines read it.
+	failNextWith int32
+
+	// Request counters and the recorded query of each data request.
+	tokenRequests int
+	requests      []recordedRequest
+}
+
+type recordedRequest struct {
+	Method    string
+	Path      string
+	Query     url.Values
+	Form      url.Values
+	Auth      string
+	UserAgent string
+}
+
+// params returns the request's effective parameters: the query string for a
+// GET, the form body for a POST.
+func (r recordedRequest) params() url.Values {
+	if r.Form != nil {
+		return r.Form
+	}
+	return r.Query
+}
+
+func newMockElements() *mockElements {
+	return &mockElements{
+		clientID:     "test-client-id",
+		clientSecret: "test-client-secret",
+		detections:   map[string][]utils.Dict{},
+		pageSize:     100,
+	}
+}
+
+func (m *mockElements) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(m.handle))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (m *mockElements) handle(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+
+	// The real API rejects any request without a User-Agent, token endpoint
+	// included.
+	if r.Header.Get("User-Agent") == "" {
+		writeAPIError(w, http.StatusBadRequest, "User-Agent header is required.", 400001)
+		return
+	}
+
+	if strings.HasSuffix(r.URL.Path, tokenPath) {
+		m.handleToken(w, r, body)
+		return
+	}
+
+	var form url.Values
+	if r.Method == http.MethodPost {
+		form, _ = url.ParseQuery(string(body))
+	}
+
+	m.mu.Lock()
+	m.requests = append(m.requests, recordedRequest{
+		Method: r.Method, Path: strings.TrimPrefix(r.URL.Path, "/"),
+		Query: r.URL.Query(), Form: form,
+		Auth: r.Header.Get("Authorization"), UserAgent: r.Header.Get("User-Agent"),
+	})
+	m.mu.Unlock()
+
+	if status := atomic.SwapInt32(&m.failNextWith, 0); status != 0 {
+		writeAPIError(w, int(status), "forced failure", 500000)
+		return
+	}
+
+	if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+		writeAPIError(w, http.StatusUnauthorized, "Unauthorized.", 401000)
+		return
+	}
+
+	params := r.URL.Query()
+	if form != nil {
+		params = form
+	}
+
+	switch strings.TrimPrefix(r.URL.Path, "/") {
+	case pathSecurityEvents:
+		m.serveCursorPage(w, params, m.snapshotEvents(), "persistenceTimestamp", "persistenceTimestampStart")
+	case pathIncidents:
+		m.serveIncidents(w, params)
+	case pathAuditLogs:
+		m.serveCursorPage(w, params, m.snapshotAudit(), "serverTimestamp", "serverTimestampStart")
+	case pathDetections:
+		m.serveDetections(w, params)
+	default:
+		writeAPIError(w, http.StatusNotFound, "no mock route for "+r.URL.Path, 404000)
+	}
+}
+
+func (m *mockElements) handleToken(w http.ResponseWriter, r *http.Request, body []byte) {
+	form, _ := url.ParseQuery(string(body))
+	user, pass, hasBasic := r.BasicAuth()
+
+	m.mu.Lock()
+	m.tokenRequests++
+	m.tokenSeq++
+	seq := m.tokenSeq
+	reject := m.rejectAuth
+	wantID, wantSecret := m.clientID, m.clientSecret
+	m.mu.Unlock()
+
+	// The credentials must arrive as HTTP Basic, not in the body.
+	if !hasBasic {
+		writeJSON(w, http.StatusUnauthorized,
+			`{"error":"invalid_client","error_description":"Client authentication failed"}`)
+		return
+	}
+	// The documented rejection: anything beyond grant_type/scope in the payload.
+	for k := range form {
+		if k != "grant_type" && k != "scope" {
+			writeJSON(w, http.StatusBadRequest,
+				`{"error":"invalid_request","error_description":"unexpected parameter `+k+` in payload"}`)
+			return
+		}
+	}
+	if form.Get("grant_type") != "client_credentials" {
+		writeJSON(w, http.StatusBadRequest,
+			`{"error":"unsupported_grant_type","error_description":"bad grant_type"}`)
+		return
+	}
+	if reject || user != wantID || pass != wantSecret {
+		writeJSON(w, http.StatusUnauthorized,
+			`{"error":"invalid_client","error_description":"Client authentication failed"}`)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, fmt.Sprintf(
+		`{"token_type":"Bearer","expires_in":1797,"access_token":"ws-token-%d"}`, seq))
+}
+
+// serveCursorPage implements the shared shape of the timestamp-cursor
+// endpoints: filter by a start bound (exclusive when exclusiveStart=true),
+// order, then page with an anchor.
+func (m *mockElements) serveCursorPage(w http.ResponseWriter, params url.Values, dataset []utils.Dict, tsField, startParam string) {
+	start := params.Get(startParam)
+	exclusive := params.Get("exclusiveStart") == "true"
+
+	filtered := make([]utils.Dict, 0, len(dataset))
+	for _, d := range dataset {
+		ts := d.FindOneString(tsField)
+		if start != "" {
+			if exclusive && ts <= start {
+				continue
+			}
+			if !exclusive && ts < start {
+				continue
+			}
+		}
+		filtered = append(filtered, d)
+	}
+	sortByField(filtered, tsField, params.Get("order") != "desc")
+	m.writePage(w, filtered, params)
+}
+
+func (m *mockElements) serveIncidents(w http.ResponseWriter, params url.Values) {
+	dataset := m.snapshotIncidents()
+	if params.Get("archived") == "false" {
+		kept := make([]utils.Dict, 0, len(dataset))
+		for _, d := range dataset {
+			if archived, _ := d["archived"].(bool); !archived {
+				kept = append(kept, d)
+			}
+		}
+		dataset = kept
+	}
+	m.serveCursorPage(w, params, dataset, "updatedTimestamp", "updatedTimestampStart")
+}
+
+func (m *mockElements) serveDetections(w http.ResponseWriter, params url.Values) {
+	incidentID := params.Get("incidentId")
+	if incidentID == "" {
+		writeAPIError(w, http.StatusBadRequest, "incidentId is required", 400000)
+		return
+	}
+	m.mu.Lock()
+	items := append([]utils.Dict(nil), m.detections[incidentID]...)
+	m.mu.Unlock()
+	m.writePage(w, items, params)
+}
+
+// writePage slices the result set the way the API does: an opaque anchor
+// pointing at the next offset, omitted entirely on the last page.
+func (m *mockElements) writePage(w http.ResponseWriter, items []utils.Dict, params url.Values) {
+	m.mu.Lock()
+	pageSize := m.pageSize
+	m.mu.Unlock()
+
+	if limit, err := strconv.Atoi(params.Get("limit")); err == nil && limit > 0 && limit < pageSize {
+		pageSize = limit
+	}
+
+	offset := 0
+	if a := params.Get("anchor"); a != "" && a != "no-value" {
+		// The anchor is opaque to the client; the mock encodes an offset in it.
+		if n, err := strconv.Atoi(strings.TrimPrefix(a, "offset:")); err == nil {
+			offset = n
+		}
+	}
+	if offset > len(items) {
+		offset = len(items)
+	}
+	end := offset + pageSize
+	if end > len(items) {
+		end = len(items)
+	}
+
+	page := map[string]interface{}{"items": items[offset:end]}
+	if end < len(items) {
+		page["nextAnchor"] = "offset:" + strconv.Itoa(end)
+	}
+	body, err := json.Marshal(page)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error(), 500000)
+		return
+	}
+	writeJSON(w, http.StatusOK, string(body))
+}
+
+func writeJSON(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write([]byte(body)) //nolint:errcheck
+}
+
+// writeAPIError emits the flat Elements error envelope, which carries a numeric
+// code rather than the nested {"error":{...}} shape most vendors use.
+func writeAPIError(w http.ResponseWriter, status int, message string, code int) {
+	writeJSON(w, status, fmt.Sprintf(
+		`{"message":%q,"code":%d,"transactionId":"0000-mock"}`, message, code))
+}
+
+func sortByField(items []utils.Dict, field string, ascending bool) {
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i].FindOneString(field), items[j].FindOneString(field)
+		if ascending {
+			return a < b
+		}
+		return a > b
+	})
+}
+
+// --- dataset helpers --------------------------------------------------------
+
+func (m *mockElements) snapshotEvents() []utils.Dict {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]utils.Dict(nil), m.securityEvents...)
+}
+
+func (m *mockElements) snapshotIncidents() []utils.Dict {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]utils.Dict(nil), m.incidents...)
+}
+
+func (m *mockElements) snapshotAudit() []utils.Dict {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]utils.Dict(nil), m.auditLogs...)
+}
+
+func (m *mockElements) addSecurityEvents(items ...utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.securityEvents = append(m.securityEvents, items...)
+}
+
+func (m *mockElements) addIncidents(items ...utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.incidents = append(m.incidents, items...)
+}
+
+func (m *mockElements) addAuditLogs(items ...utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.auditLogs = append(m.auditLogs, items...)
+}
+
+func (m *mockElements) setDetections(incidentID string, items ...utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.detections[incidentID] = items
+}
+
+// updateIncident replaces an incident, simulating a BCD that evolved.
+func (m *mockElements) updateIncident(incidentID string, updated utils.Dict) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, inc := range m.incidents {
+		if inc.FindOneString("incidentId") == incidentID {
+			m.incidents[i] = updated
+			return
+		}
+	}
+	m.incidents = append(m.incidents, updated)
+}
+
+// setFailNext makes the next data request fail once with the given status.
+func (m *mockElements) setFailNext(status int32) {
+	atomic.StoreInt32(&m.failNextWith, status)
+}
+
+func (m *mockElements) requestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.requests)
+}
+
+func (m *mockElements) recordedRequests() []recordedRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]recordedRequest(nil), m.requests...)
+}
+
+func (m *mockElements) tokenRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tokenRequests
+}
+
+// requestsFor returns the recorded requests against one API path.
+func (m *mockElements) requestsFor(path string) []recordedRequest {
+	out := []recordedRequest{}
+	for _, r := range m.recordedRequests() {
+		if r.Path == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// --- realistic fixtures -----------------------------------------------------
+
+// elementsTime renders a timestamp the way the Elements API does: RFC 3339 UTC
+// with millisecond precision and a Z suffix.
+func elementsTime(ts time.Time) string {
+	return ts.UTC().Format("2006-01-02T15:04:05.000Z")
+}
+
+// realisticSecurityEvent is shaped like a real EPP security event, following the
+// example published in the Elements API specification: nested organization /
+// device / target objects, a free-form details map, and mixed scalar types.
+func realisticSecurityEvent(id string, ts time.Time) utils.Dict {
+	return utils.Dict{
+		"id":                   id,
+		"action":               "blocked",
+		"engine":               "deepGuard",
+		"severity":             "warning",
+		"serverTimestamp":      elementsTime(ts),
+		"persistenceTimestamp": elementsTime(ts),
+		"clientTimestamp":      elementsTime(ts.Add(-2 * time.Second)),
+		"eventTransactionId":   "0000-187cf62797634fef",
+		"acknowledged":         false,
+		"message":              "DeepGuard blocked a harmful application",
+		"description":          "DeepGuard event",
+		"organization": map[string]interface{}{
+			"id":   "222298dc-3785-4d2d-a957-f7399c2cd084",
+			"name": "example-org",
+		},
+		"device": map[string]interface{}{
+			"id":     "71cceb9f-2728-4ac4-8e63-402cbbf76e18",
+			"name":   "DESKTOP-3D64DAK",
+			"labels": []interface{}{"finance"},
+		},
+		"target": map[string]interface{}{
+			"id":   "71cceb9f-2728-4ac4-8e63-402cbbf76e18",
+			"name": "DESKTOP-3D64DAK",
+		},
+		"userName": "EXAMPLE\\jdoe",
+		"details": map[string]interface{}{
+			"path":           "C:\\Users\\jdoe\\AppData\\Local\\Temp\\evil.exe",
+			"alertType":      "deepguard.harmful.blocked",
+			"throttledCount": "0",
+			"profileId":      "12444818",
+			"hostIpAddress":  "10.1.2.3/24",
+			// A large integer, to prove payloads round-trip without float
+			// coercion losing precision.
+			"fileSize": 9007199254740993,
+		},
+	}
+}
+
+// realisticIncident is shaped like a real Broad Context Detection.
+func realisticIncident(id string, created, updated time.Time) utils.Dict {
+	return utils.Dict{
+		"incidentId":               id,
+		"incidentPublicId":         "3599-4F9929A4",
+		"organizationId":           "222298dc-3785-4d2d-a957-f7399c2cd084",
+		"name":                     "Incident on DESKTOP-3D64DAK",
+		"status":                   "new",
+		"severity":                 "high",
+		"riskLevel":                "severe",
+		"riskScore":                74.86341234,
+		"resolution":               "unconfirmed",
+		"archived":                 false,
+		"createdTimestamp":         elementsTime(created),
+		"updatedTimestamp":         elementsTime(updated),
+		"initialReceivedTimestamp": elementsTime(created),
+		"categories":               []interface{}{"CREDENTIAL_THEFT"},
+		"sources":                  []interface{}{"endpoint"},
+	}
+}
+
+// realisticDetection is shaped like a real detection under a BCD.
+func realisticDetection(detectionID, incidentID string, ts time.Time) utils.Dict {
+	return utils.Dict{
+		"detectionId":              detectionID,
+		"incidentId":               incidentID,
+		"deviceId":                 "3a8f06e1-c3e8-4933-b617-e23597111644",
+		"name":                     "suspiciousPowershellCommand",
+		"detectionClass":           "PROCESS",
+		"severity":                 "medium",
+		"riskLevel":                "medium",
+		"exePath":                  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+		"exeName":                  "powershell.exe",
+		"exeHash":                  "c8f21ef51fa2f2033a9ca7c0cc0412c25065e2ba",
+		"cmdl":                     "powershell -enc SQBFAFgA",
+		"pid":                      1234,
+		"username":                 "EXAMPLE\\jdoe",
+		"privileges":               "NormalPrivileges",
+		"createdTimestamp":         elementsTime(ts),
+		"initialReceivedTimestamp": elementsTime(ts),
+		"activityContext": []interface{}{
+			map[string]interface{}{"type": "elevation", "description": "Elevation of privileges"},
+		},
+	}
+}
+
+// realisticAuditLog is shaped like a real Elements audit entry.
+func realisticAuditLog(id string, ts time.Time) utils.Dict {
+	return utils.Dict{
+		"id":              id,
+		"serverTimestamp": elementsTime(ts),
+		"transactionId":   "0000-abcdef123456",
+		"namespace":       "devices",
+		"action":          "isolateFromNetwork",
+		"username":        "admin@example.test",
+		"description":     "Device isolated from network",
+		"organization": map[string]interface{}{
+			"id":      "222298dc-3785-4d2d-a957-f7399c2cd084",
+			"name":    "example-org",
+			"orgPath": "example-org",
+		},
+		"target": map[string]interface{}{
+			"id":   "3a8f06e1-c3e8-4933-b617-e23597111644",
+			"name": "DESKTOP-3D64DAK",
+		},
+	}
+}
+
+// --- assertions -------------------------------------------------------------
+
+// assertVerbatim checks that a shipped payload is byte-for-byte the record the
+// API served. Adapters must not reshape payloads -- LimaCharlie maps fields in
+// the cloud.
+func assertVerbatim(t *testing.T, want, got utils.Dict) {
+	t.Helper()
+	wantJSON, err := json.Marshal(want)
+	if !assert.NoError(t, err) {
+		return
+	}
+	gotJSON, err := json.Marshal(got)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.JSONEq(t, string(wantJSON), string(gotJSON), "payload was not shipped verbatim")
+}


### PR DESCRIPTION
Adds a USP adapter for the [WithSecure™ Elements](https://www.withsecure.com/) cloud (formerly F-Secure), built from the published [Elements API](https://connect.withsecure.com/api-reference/elements) specification and the [Elements cookbook](https://connect.withsecure.com/getting-started/elements-cookbook/).

## What it ingests

Four streams, each shipped verbatim under its own event type:

| Event type | Endpoint | What it carries |
|---|---|---|
| `security_event` | `POST /security-events/v1/security-events` | The EPP protection-engine stream — malware scanning, DeepGuard, firewall, browsing/connection control, device control, DataGuard, tamper protection, AMSI, application control, collaboration protection. |
| `incident` | `GET /incidents/v1/incidents` | Broad Context Detections — WithSecure's correlated EDR incidents. |
| `detection` | `GET /incidents/v1/detections` | The individual detections under a BCD, with the process evidence that triggered them. |
| `audit_log` | `GET /audit-logs/v1/audit-logs` | The administrative audit trail. Off by default (administrative, not security telemetry). |

## Auth

OAuth2 client credentials against an Elements API client (Security Center → Management → Organization Settings → API clients); read-only access is sufficient.

The credentials go in an **HTTP Basic** header and the token body carries only `grant_type`/`scope` — the endpoint documents that it rejects a payload containing anything else, so the usual credentials-in-the-body form fails. Every request also needs a `User-Agent`, without which the API rejects it outright.

A bad credential **stops** the adapter (retrying can't fix it, and silently collecting nothing is worse than failing visibly). Every other API-side failure only skips that poll — the cloud-sensor host treats an adapter error as fatal to the instance, and a restart cannot fix a problem upstream.

## How polling works

Incremental on a timestamp cursor, with `exclusiveStart=true` — without that flag the API returns records *greater than or equal to* the bound, so the boundary record is re-read on every poll. Results are requested ascending so the cursor advances as pages are consumed, and anchor pagination is followed to the end of each result set.

After the first poll the cursor is always a timestamp string the API itself emitted, so its format can't drift from what the endpoint accepts.

**Incidents are living objects.** A BCD accretes detections over its lifetime, so the incident stream filters on `updatedTimestamp` (the flow WithSecure's own cookbook prescribes). Each *version* of an incident ships once — its dedupe key includes the `updatedTimestamp` — so you can watch a BCD evolve from `new` to `closed`, while detections dedupe on their stable `detectionId` so a re-visited incident only yields genuinely new evidence. Detections are fetched per incident because the API has no organization-wide detections endpoint, which is why `collect_detections` requires `collect_incidents`.

Rate limits are handled: these endpoints allow only 300 req/min per IP (vs. 10,000 generally), so a 429 is treated as transient and retried with backoff.

## Testing

`go test ./withsecure/...` — passes, and clean under `-race`.

The suite runs end-to-end against a mock Elements API that reproduces the real contract rather than a permissive stub: Basic-auth-only token requests whose body is rejected if it carries anything beyond `grant_type`/`scope`, the mandatory `User-Agent`, anchor pagination over the `{items, nextAnchor}` envelope, `exclusiveStart` cursor semantics, and the flat `{message, code, transactionId}` error object (numeric code, not the usual nested shape). Fixtures follow the payload examples published in the API specification, including a large integer that would lose precision under float coercion.

Coverage includes: all records ship with verbatim payloads and record-derived timestamps; a re-poll doesn't duplicate; an event appearing mid-run ships once; multi-page sets are fully walked; an updated incident re-ships but an unchanged one doesn't; already-collected detections aren't re-shipped when their incident updates; archived BCDs filtered by default; per-endpoint page-size clamping; bad auth stops the adapter and ships nothing; a source-side 500 doesn't stop it.

## Not live-verified

No tenant credentials were available, so this is validated against the spec-derived mock only. Phase 5b of the adapter guide (diffing the mock against captured real responses) is still outstanding — worth doing when a test tenant exists, particularly to confirm the `nextAnchor` behavior and timestamp formats on a live tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZHzrvvLmWsaSCLrFWMkFu